### PR TITLE
Trim remaining characters

### DIFF
--- a/you/__init__.py
+++ b/you/__init__.py
@@ -64,7 +64,8 @@ class Completion:
         text = response.text.split('}]}\n\nevent: youChatToken\ndata: {"youChatToken": "')[-1]
         text = text.replace('"}\n\nevent: youChatToken\ndata: {"youChatToken": "', '')
         text = text.replace('event: done\ndata: I\'m Mr. Meeseeks. Look at me.\n\n', '')
-        
+        text = text[:-4] # trims '"}', along with the last two remaining newlines
+
         extra = {
             'youChatSerpResults'      : loads(youChatSerpResults),
             #'slots'                   : loads(slots)


### PR DESCRIPTION
The output always contains '"}' along with two newlines at the end. I'm guessing this isn't intentional, so this fixes it.