### PR TITLE
Fix docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,11 +4,9 @@ services:
     gpt4:
       build:
         context: .
-	dockerfile: Dockerfile
-	image: gpt4free:latest
+        dockerfile: Dockerfile
+      image: gpt4free:latest
       container_name: gpt4
       ports: 
         - 8501:8501
       restart: unless-stopped
-      read_only: true
-		


### PR DESCRIPTION
The image/dockerfile lines are incorrectly indented, also the read_only flag prevents the UI from starting due to not being able to write to the /tmp folder.