### PR TITLE
docs(readme): remove duplicate website

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ Just API's from some language model sites.
 | [sqlchat.ai](https://sqlchat.ai)                 | GPT-3.5                          |
 | [bard.google.com](https://bard.google.com)       | custom / search                  |
 | [bing.com/chat](https://bing.com/chat)           | GPT-4/3.5                        |
-| [chat.forefront.ai/](https://chat.forefront.ai/) | GPT-4/3.5                        |
 
 ## Best sites <a name="best-sites"></a>
 


### PR DESCRIPTION
https://chat.forefront.ai is mentioned twice.

https://github.com/xtekky/gpt4free/blob/2ae26bfa7e10bd57f9b0d2e90e4c599c816359a4/README.md?plain=1#L81-L89