### PR TITLE
Fix docker build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ then run:
 Build
 
 ```
-docker build -t gpt4free:latest -f Docker/Dockerfile .
+docker build -t gpt4free:latest .
 ```
 
 Run


### PR DESCRIPTION
As the Dockerfile was moved to the root of the project we need to update the path in the README