### PR TITLE
added gpt4free python package

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,14 @@ install requirements with:
 pip3 install -r requirements.txt
 ```
 
+OR 
+  
+```python
+pip install gpt4free
+```
+APIs that support this package : you, theb, forefront, usesless
+
+If there was a problem you can report to this [repository](https://github.com/rzashakeri/gpt4free-python-package)
 
 ## To start gpt4free GUI <a name="streamlit-gpt4free-gui"></a>
 


### PR DESCRIPTION
Hi i made a python package for this repository

Repository Link : [gpt4free python package](https://github.com/rzashakeri/gpt4free-python-package)

You Can Install With Command :

`pip install gpt4free`

## Supported Stable Api's
1. you
2. theb
3. forefront
4. usesless
