### PR TITLE
Implemented the ability to save forefront cookies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,9 +14,6 @@ venv/
 conversations.pkl
 *.pkl
 
-# Ignore accounts created by api's
-accounts.txt
-
 .idea/
 
 **/__pycache__/
@@ -30,3 +27,5 @@ cookie.json
 *.pyc
 
 dist/
+
+gpt4free/forefront/cookie.txt


### PR DESCRIPTION
Added the ability to save cookies in the create function.
Default is disabled.

Refactoring is being done as it has become redundant code.
* split funcion
* delete account.txt(unused)

Similar to the following pull request, but since it was removed, I am suggesting it again.
https://github.com/xtekky/gpt4free/pull/386

Time taken to process `Account.create`

Cookies disabled(default): 9.393363237380981
Cookies enabled: 0.5772099494934082