### PR TITLE
Fix Chinese garbled characters

### DIFF
--- a/gui/streamlit_app.py
+++ b/gui/streamlit_app.py
@@ -38,7 +38,7 @@ st.header('GPT4free GUI')
 question_text_area = st.text_area('🤖 Ask Any Question :', placeholder='Explain quantum computing in 50 words')
 if st.button('🧠 Think'):
     answer = get_answer(question_text_area)
-    escaped = answer.encode('utf-8').decode('unicode-escape')
+    escaped = answer.encode('utf-8').decode('utf-8')
     # Display answer
     st.caption("Answer :")
     st.markdown(escaped)


### PR DESCRIPTION
When getting a reply in Chinese, it will be garbled. Use utf-8 decoding to solve it.