### PR TITLE
repair, add module: Crypto

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ Levenshtein
 retrying
 mailgw_temporary_email
 pycryptodome
+Crypto 


### PR DESCRIPTION
Fixing the error when using forefront: ModuleNotFoundError: No module named 'Crypto'.