### PR TITLE
Add DeepAI wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Just API's from some language model sites.
 | `forefront` | Example usage for forefront (gpt-4) | [![Link to File](https://img.shields.io/badge/Link-Go%20to%20File-blue)](gpt4free/forefront/README.md) | ![Active](https://img.shields.io/badge/Active-brightgreen) | ||
 | `quora (poe)` | Example usage for quora | [![Link to File](https://img.shields.io/badge/Link-Go%20to%20File-blue)](gpt4free/quora/README.md) | ![Active](https://img.shields.io/badge/Active-brightgreen) |
 | `you` | Example usage for you | [![Link to File](https://img.shields.io/badge/Link-Go%20to%20File-blue)](gpt4free/you/README.md) | ![Active](https://img.shields.io/badge/Active-brightgreen) |
+| `deepai` | Example usage for DeepAI (gpt-3.5, with chat) | [![Link to File](https://img.shields.io/badge/Link-Go%20to%20File-blue)](gpt4free/deepai/README.md) | ![Active](https://img.shields.io/badge/Active-brightgreen) |
 | **Try it Out** | | | |
 | Google Colab Jupyter Notebook | Example usage for gpt4free | [![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/DanielShemesh/gpt4free-colab/blob/main/gpt4free.ipynb) | - |
 | replit Example (feel free to fork this repl) | Example usage for gpt4free | [![](https://img.shields.io/badge/Open%20in-Replit-1A1E27?logo=replit)](https://replit.com/@gpt4free/gpt4free-webui) | - |
@@ -126,6 +127,8 @@ Just API's from some language model sites.
 | [bard.google.com](https://bard.google.com)       | custom / search                  |
 | [bing.com/chat](https://bing.com/chat)           | GPT-4/3.5                        |
 | [italygpt.it](https://italygpt.it)               | GPT-3.5                          |
+| [deepai.org](https://deepai.org/chat)            | GPT-3.5 / chat support           |
+
 
 ## Best sites <a name="best-sites"></a>
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ docker-compose up --build -d
 
 This program is licensed under the [GNU GPL v3](https://www.gnu.org/licenses/gpl-3.0.txt)
 
-Most code, with the exception of `quora/api.py` (by [ading2210](https://github.com/ading2210)), has been written by me, [xtekky](https://github.com/xtekky).
+Most code, with the exception of `quora/api.py` and `deepai/__init__.py` (by [ading2210](https://github.com/ading2210)), has been written by me, [xtekky](https://github.com/xtekky).
 
 ### Copyright Notice: <a name="copyright"></a>
 

--- a/gpt4free/__init__.py
+++ b/gpt4free/__init__.py
@@ -5,6 +5,7 @@ from gpt4free import quora
 from gpt4free import theb
 from gpt4free import usesless
 from gpt4free import you
+from gpt4free import deepai
 
 
 class Provider(Enum):
@@ -69,3 +70,25 @@ class Completion:
     @staticmethod
     def __deepai_service(prompt: str, **kwargs):
         return ''.join(deepai.Completion.create(prompt=prompt))
+
+class ChatCompletion:
+    """This class is used to execute a chat completion for a specified provider"""
+
+    @staticmethod
+    def create(provider: Provider, messages: list, **kwargs) -> str:
+        """
+        Invokes the given provider with given chat messages and addition arguments and returns the string response
+
+        :param provider: an enum representing the provider to use while invoking
+        :param messages: a list of chat messages, see the OpenAI docs for how to format this (https://platform.openai.com/docs/guides/chat/introduction)
+        :param kwargs:  Additional keyword arguments to pass to the provider while invoking
+        :return: A string representing the response from the provider
+        """
+        if provider == Provider.DeepAI:
+            return ChatCompletion.__deepai_service(messages, **kwargs)
+        else:
+            raise Exception('Provider not exist, Please try again')
+    
+    @staticmethod
+    def __deepai_service(messages: list, **kwargs):
+        return ''.join(deepai.ChatCompletion.create(messages=messages))

--- a/gpt4free/__init__.py
+++ b/gpt4free/__init__.py
@@ -15,6 +15,7 @@ class Provider(Enum):
     ForeFront = 'fore_front'
     Theb = 'theb'
     UseLess = 'useless'
+    DeepAI = 'deepai'
 
 
 class Completion:
@@ -40,6 +41,8 @@ class Completion:
             return Completion.__theb_service(prompt, **kwargs)
         elif provider == Provider.UseLess:
             return Completion.__useless_service(prompt, **kwargs)
+        elif provider == Provider.DeepAI:
+            return Completion.__deepai_service(prompt, **kwargs)
         else:
             raise Exception('Provider not exist, Please try again')
 
@@ -62,4 +65,7 @@ class Completion:
     @staticmethod
     def __theb_service(prompt: str, **kwargs):
         return ''.join(theb.Completion.create(prompt=prompt))
-
+    
+    @staticmethod
+    def __deepai_service(prompt: str, **kwargs):
+        return ''.join(deepai.Completion.create(prompt=prompt))

--- a/gpt4free/deepai/README.md
+++ b/gpt4free/deepai/README.md
@@ -1,0 +1,26 @@
+# DeepAI Wrapper
+Written by [ading2210](https://github.com/ading2210/).
+
+## Examples:
+These functions are generators which yield strings containing the newly generated text.
+
+### Completion:
+```python
+for chunk in deepai.Completion.create("Who are you?"):
+    print(chunk, end="", flush=True)
+print()
+```
+
+### Chat Completion:
+Use the same format for the messages as you would for the [official OpenAI API](https://platform.openai.com/docs/guides/chat/introduction).
+```python
+messages = [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "Who won the world series in 2020?"},
+    {"role": "assistant", "content": "The Los Angeles Dodgers won the World Series in 2020."},
+    {"role": "user", "content": "Where was it played?"}
+]
+for chunk in deepai.ChatCompletion.create(messages):
+    print(chunk, end="", flush=True)
+print()
+```

--- a/gpt4free/deepai/__init__.py
+++ b/gpt4free/deepai/__init__.py
@@ -1,0 +1,46 @@
+import requests
+import json
+import hashlib
+import random
+import string
+from fake_useragent import UserAgent
+
+class ChatCompletion:
+    @classmethod
+    def md5(self, text):
+        return hashlib.md5(text.encode()).hexdigest()[::-1]
+
+    @classmethod
+    def get_api_key(self, user_agent):
+        part1 = str(random.randint(0, 10**11))
+        part2 = self.md5(user_agent+self.md5(user_agent+self.md5(user_agent+part1+"x")))
+        return f"tryit-{part1}-{part2}"
+
+    @classmethod
+    def create(self, messages):
+        user_agent = UserAgent().random
+        api_key = self.get_api_key(user_agent)
+        headers = {
+          "api-key": api_key,
+          "user-agent": user_agent
+        }
+        files = {
+          "chat_style": (None, "chat"),
+          "chatHistory": (None, json.dumps(messages))
+        }
+
+        r = requests.post("https://api.deepai.org/chat_response", headers=headers, files=files, stream=True)
+
+        for chunk in r.iter_content(chunk_size=None):
+            r.raise_for_status()
+            yield chunk.decode()
+
+class Completion:
+    @classmethod
+    def create(self, prompt):
+        return ChatCompletion.create([
+            {
+                "role": "user", 
+                "content": prompt
+            }
+        ])

--- a/testing/deepai_test.py
+++ b/testing/deepai_test.py
@@ -1,0 +1,18 @@
+from gpt4free import deepai
+
+#single completion
+for chunk in deepai.Completion.create("Write a list of possible vacation destinations:"):
+    print(chunk, end="", flush=True)
+print()
+
+#chat completion
+print("==============")
+messages = [ #taken from the openai docs
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "Who won the world series in 2020?"},
+    {"role": "assistant", "content": "The Los Angeles Dodgers won the World Series in 2020."},
+    {"role": "user", "content": "Where was it played?"}
+]
+for chunk in deepai.ChatCompletion.create(messages):
+    print(chunk, end="", flush=True)
+print()


### PR DESCRIPTION
This PR adds a wrapper for [deepai.org](https://deepai.org/chat). It also adds support for chat completions, via `gpt4free.ChatCompletion` or `gpt4free.deepai.ChatCompletion`.

DeepAI seems to provide unlimited `gpt-3.5-turbo` chat completions, which I have reverse engineered to be able to generate API keys for. 

See `/gpt4free/deepai/README.md` for documentation.