### PR TITLE
Updated requirements.txt (added: `random-password-generator`)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ Levenshtein
 retrying
 mailgw_temporary_email
 pycryptodome
+random-password-generator


### PR DESCRIPTION
### **Added**: 
`random-password-generator`

Package `random-password-generator` was used in `gpt4free/usesless/__init__.py`, but it's not written in requirements.txt