### PR TITLE
Remove forced Streamlit version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ pypasser
 names
 colorama
 curl_cffi
-streamlit==1.21.0
+streamlit
 selenium
 fake-useragent
 twocaptcha


### PR DESCRIPTION
Remove forced Streamlit version. You're breaking other software that uses GPT4Free and Streamlit for their own apps by forcing this.