### PR TITLE
Rollback to #241 when handling special character 

### DIFF
--- a/gui/streamlit_app.py
+++ b/gui/streamlit_app.py
@@ -38,7 +38,7 @@ st.header('GPT4free GUI')
 question_text_area = st.text_area('🤖 Ask Any Question :', placeholder='Explain quantum computing in 50 words')
 if st.button('🧠 Think'):
     answer = get_answer(question_text_area)
-    escaped = answer.encode('utf-8').decode('utf-8')
+    escaped = answer.encode('utf-8').decode('unicode-escape')
     # Display answer
     st.caption("Answer :")
     st.markdown(escaped)


### PR DESCRIPTION
According to this issue #631, I think rollback back to #241 will solve most of the cases when handling special character like chinese or russian 