### PR TITLE
Fix: There is no current event loop in thread.

### DIFF
--- a/g4f/Provider/Providers/Bing.py
+++ b/g4f/Provider/Providers/Bing.py
@@ -304,19 +304,20 @@ async def stream_generate(prompt: str, mode: optionsSets.optionSet = optionsSets
                     await session.close()
 
 
-def run(generator):
-    loop = asyncio.get_event_loop()
-    gen = generator.__aiter__()
+def run(generator):  
+    loop = asyncio.new_event_loop()  
+    asyncio.set_event_loop(loop)  
+    gen = generator.__aiter__()  
+  
+    while True:  
+        try:  
+            next_val = loop.run_until_complete(gen.__anext__())  
+            yield next_val  
+  
+        except StopAsyncIteration:  
+            break  
+    #print('Done')  
 
-    while True:
-        try:
-            next_val = loop.run_until_complete(gen.__anext__())
-            yield next_val
-
-        except StopAsyncIteration:
-            break
-
-    #print('Done')
 
 
 def convert(messages):


### PR DESCRIPTION
The error you are encountering is related to attempting to use the default asyncio event loop within a non-main thread. asyncio expects you to use the default event loop only in the main thread.

To resolve this issue, asyncio.new_event_loop() was used instead of asyncio.get_event_loop() to create a new event loop for the current thread.