### PR TITLE
Enabled direct pip install from Git.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,7 @@ requires-python = ">=3.10"
 dynamic = ["dependencies"]
 
 [tool.setuptools.packages.find]
-exclude = ["**/*.txt", "/.v1/*"]
-include = ["g4f"]
+include = ["g4f*"]
 
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
I enabled direct pip install from Git.

Sample:
```
pip install git+https://github.com/MIDORIBIN/gpt4free.git@prepare_pip_install
```

Ultimately, I believe we should make it possible to execute `pip install gpt4free` (or `pip install g4f`). However, I think xtekky should be the one to handle that task.

This pull request is the preparation for that.