### PR TITLE
Bring back the README banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![image](https://github.com/onlpx/gpt4free-v2/assets/98614666/7886223b-c1d1-4260-82aa-da5741f303bb)
+![image](https://user-images.githubusercontent.com/98614666/233799515-1a7cb6a3-b17f-42c4-956d-8d2a0664466f.png)
 
 By using this repository or any code related to it, you agree to the [legal notice](./LEGAL_NOTICE.md). The author is not responsible for any copies, forks, or reuploads made by other users. This is the author's only account and repository. To prevent impersonation or irresponsible actions, you may comply with the GNU GPL license this Repository uses.
 


### PR DESCRIPTION
Whatever the new banner was, the link to it specified in the README died, so I replaced it with the v1 banner. Better that than nothing, right?