### PR TITLE
interference/app.py: remove unused imports

### DIFF
--- a/interference/app.py
+++ b/interference/app.py
@@ -3,8 +3,8 @@ import time
 import json
 import random
 
-from g4f import Model, ChatCompletion, Provider
-from flask import Flask, request, Response
+from g4f import ChatCompletion
+from flask import Flask, request
 from flask_cors import CORS
 
 app = Flask(__name__)


### PR DESCRIPTION
Also `Model` is no longer accessible from g4f, so it causes errors, since it is not used there is no point importing it from `g4f.models`