### PR TITLE
requests encoding error

### DIFF
--- a/g4f/Provider/Yqcloud.py
+++ b/g4f/Provider/Yqcloud.py
@@ -22,6 +22,7 @@ class Yqcloud(BaseProvider):
         url = "https://api.aichatos.cloud/api/generateStream"
         response = requests.post(url=url, headers=headers, json=payload)
         response.raise_for_status()
+        response.encoding = 'utf-8'
         yield response.text
 
 

--- a/g4f/Provider/Yqcloud.py
+++ b/g4f/Provider/Yqcloud.py
@@ -22,7 +22,6 @@ class Yqcloud(BaseProvider):
         url = "https://api.aichatos.cloud/api/generateStream"
         response = requests.post(url=url, headers=headers, json=payload)
         response.raise_for_status()
-        response.encoding = 'utf-8'
         yield response.text
 
 


### PR DESCRIPTION
Hello!

A bug with requests encoding prevented a readable response from Yqcloud.
fixed by forced encoding in utf-8.

response before:
½ÑÐ¯ - Ð¼Ð¾Ð´ÐµÐ»Ñ GPT-3.5, ÑÐ¾Ð·Ð´Ð°Ð½Ð½Ð°Ñ ÐºÐ¾Ð¼Ð°Ð½Ð´Ð¾Ð¹ OpenAI. Ð¯ ÑÐ°Ð·ÑÐ°Ð±Ð¾ÑÐ°Ð½, ÑÑÐ¾Ð±Ñ Ð¿ÑÐµÐ´Ð¾ÑÑÐ°Ð²Ð»ÑÑÑ Ð¾ÑÐ²ÐµÑÑ Ð½Ð° ÑÐ°Ð·Ð»Ð¸ÑÐ½ÑÐµ Ð²Ð¾Ð¿ÑÐ¾ÑÑ Ð¸ Ð·Ð°Ð´Ð°ÑÐ¸, Ð¾ÑÐ½Ð¾Ð²Ð°Ð½Ð½ÑÐµ Ð½Ð° Ð±Ð¾Ð»ÑÑÐ¾Ð¼ Ð¾Ð±ÑÐµÐ¼Ðµ ÑÐµÐºÑÑÐ¾Ð²ÑÑ
 Ð´Ð°Ð½Ð½ÑÑ
, Ð´Ð¾ÑÑÑÐ¿Ð½ÑÑ
 Ð² ÐÐµÑÐ½ÐµÑÐµ. ÐÐ¾Ñ ÑÐµÐ»Ñ - Ð¿Ð¾Ð¼Ð¾ÑÑ Ð²Ð°Ð¼ Ñ Ð¸Ð½Ñ
                                                        Ð¾ÑÐ¼Ð°ÑÐ¸ÐµÐ¹ Ð¸ Ð¾ÑÐ²ÐµÑÐ°Ð¼Ð¸ Ð½Ð° Ð²Ð°Ñ Ð·Ð°Ð¿ÑÐ¾Ñ.

response after:
I am a GPT-3.5 AI model developed by OpenAI. I have a wide range of capabilities, such as understanding text, generating speech, answering questions, and even simulating conversations with people. My job is to help and provide information in response to your questions. How can I help?

Have a good day!