### PR TITLE
fix Yqcloud and You prompter using only the last message

### DIFF
--- a/g4f/Provider/Ails.py
+++ b/g4f/Provider/Ails.py
@@ -72,6 +72,8 @@ class Ails(BaseProvider):
             if b"content" in token:
                 completion_chunk = json.loads(token.decode().replace("data: ", ""))
                 token = completion_chunk["choices"][0]["delta"].get("content")
+                if "ai.ls".lower() in token.lower():
+                    raise Exception("Response Error: " + token)
                 if token != None:
                     yield token
 

--- a/g4f/Provider/Ails.py
+++ b/g4f/Provider/Ails.py
@@ -72,7 +72,7 @@ class Ails(BaseProvider):
             if b"content" in token:
                 completion_chunk = json.loads(token.decode().replace("data: ", ""))
                 token = completion_chunk["choices"][0]["delta"].get("content")
-                if "ai.ls".lower() in token.lower():
+                if "ai.ls" in token.lower() or "ai.ci" in token.lower():
                     raise Exception("Response Error: " + token)
                 if token != None:
                     yield token

--- a/g4f/Provider/Yqcloud.py
+++ b/g4f/Provider/Yqcloud.py
@@ -35,7 +35,10 @@ def _create_header():
 
 
 def _create_payload(messages: list[dict[str, str]]):
-    prompt = messages[-1]["content"]
+    prompt = ""
+    for message in messages:
+        prompt += "%s: %s\n" % (message["role"], message["content"])
+    prompt += "assistant:"
     return {
         "prompt": prompt,
         "network": True,


### PR DESCRIPTION
Unicode encoding of special characters in You's response text : {"youChatToken": "\u563f"} 
The "chat" parameter is the history of the conversation, so a "history" parameter is used.