### PR TITLE
Add GoogleBard to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ js2py
 quickjs
 flask
 flask-cors
+GoogleBard


### PR DESCRIPTION
Adding GoogleBard to requirements resolves errors due to it not being installed.