### PR TITLE
Add httpx requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ js2py
 quickjs
 flask
 flask-cors
+httpx


### PR DESCRIPTION
Add httpx requirement to resolve issue.

```
agixt_1                  |     from g4f import Provider, ChatCompletion
agixt_1                  |   File "/src/g4f/g4f/__init__.py", line 1, in <module>
agixt_1                  |     from .          import models
agixt_1                  |   File "/src/g4f/g4f/models.py", line 2, in <module>
agixt_1                  |     from .Provider import Bard, BaseProvider, GetGpt, H2o, Liaobots, Vercel, Equing
agixt_1                  |   File "/src/g4f/g4f/Provider/__init__.py", line 20, in <module>
agixt_1                  |     from .OpenaiChat    import OpenaiChat
agixt_1                  |   File "/src/g4f/g4f/Provider/OpenaiChat.py", line 9, in <module>
agixt_1                  |     from httpx import AsyncClient
agixt_1                  | ModuleNotFoundError: No module named 'httpx'
```