### PR TITLE
Fix: Python versions below 3.9 cannot use `g4f`

### DIFF
--- a/g4f/Provider/AItianhu.py
+++ b/g4f/Provider/AItianhu.py
@@ -2,7 +2,7 @@ import json
 
 import requests
 
-from ..typing import Any, CreateResult
+from ..typing import Any, CreateResult, Dict, List
 from .base_provider import BaseProvider
 
 
@@ -14,7 +14,7 @@ class AItianhu(BaseProvider):
     @staticmethod
     def create_completion(
         model: str,
-        messages: list[dict[str, str]],
+        messages: List[Dict[str, str]],
         stream: bool, **kwargs: Any) -> CreateResult:
         
         base = ""
@@ -44,7 +44,7 @@ class AItianhu(BaseProvider):
     def params(cls):
         params = [
             ("model", "str"),
-            ("messages", "list[dict[str, str]]"),
+            ("messages", "List[Dict[str, str]]"),
             ("stream", "bool"),
             ("temperature", "float"),
             ("top_p", "int"),

--- a/g4f/Provider/Acytoo.py
+++ b/g4f/Provider/Acytoo.py
@@ -2,7 +2,7 @@ import time
 
 import requests
 
-from ..typing import Any, CreateResult
+from ..typing import Any, CreateResult, Dict, List
 from .base_provider import BaseProvider
 
 
@@ -15,7 +15,7 @@ class Acytoo(BaseProvider):
     def create_completion(
         cls,
         model: str,
-        messages: list[dict[str, str]],
+        messages: List[Dict[str, str]],
         stream: bool, **kwargs: Any) -> CreateResult:
 
         response = requests.post(f'{cls.url}api/completions', 
@@ -34,7 +34,7 @@ def _create_header():
     }
 
 
-def _create_payload(messages: list[dict[str, str]], temperature):
+def _create_payload(messages: List[Dict[str, str]], temperature):
     payload_messages = [
         message | {'createdAt': int(time.time()) * 1000} for message in messages
     ]

--- a/g4f/Provider/AiService.py
+++ b/g4f/Provider/AiService.py
@@ -1,6 +1,6 @@
 import requests
 
-from ..typing import Any, CreateResult
+from ..typing import Any, CreateResult, Dict, List
 from .base_provider import BaseProvider
 
 
@@ -12,7 +12,7 @@ class AiService(BaseProvider):
     @staticmethod
     def create_completion(
         model: str,
-        messages: list[dict[str, str]],
+        messages: List[Dict[str, str]],
         stream: bool,
         **kwargs: Any,
     ) -> CreateResult:

--- a/g4f/Provider/Aichat.py
+++ b/g4f/Provider/Aichat.py
@@ -1,6 +1,6 @@
 import requests
 
-from ..typing import Any, CreateResult
+from ..typing import Any, CreateResult, Dict, List
 from .base_provider import BaseProvider
 
 
@@ -12,7 +12,7 @@ class Aichat(BaseProvider):
     @staticmethod
     def create_completion(
         model: str,
-        messages: list[dict[str, str]],
+        messages: List[Dict[str, str]],
         stream: bool, **kwargs: Any) -> CreateResult:
         
         base = ""

--- a/g4f/Provider/Ails.py
+++ b/g4f/Provider/Ails.py
@@ -6,8 +6,9 @@ from datetime import datetime
 
 import requests
 
-from ..typing import SHA256, Any, CreateResult
+from ..typing import SHA256, Any, CreateResult, Dict, List
 from .base_provider import BaseProvider
+
 
 class Ails(BaseProvider):
     url: str              = "https://ai.ls"
@@ -18,7 +19,7 @@ class Ails(BaseProvider):
     @staticmethod
     def create_completion(
         model: str,
-        messages: list[dict[str, str]],
+        messages: List[Dict[str, str]],
         stream: bool, **kwargs: Any) -> CreateResult:
         
         headers = {
@@ -80,7 +81,7 @@ class Ails(BaseProvider):
     def params(cls):
         params = [
             ("model", "str"),
-            ("messages", "list[dict[str, str]]"),
+            ("messages", "List[Dict[str, str]]"),
             ("stream", "bool"),
             ("temperature", "float"),
         ]
@@ -88,7 +89,7 @@ class Ails(BaseProvider):
         return f"g4f.provider.{cls.__name__} supports: ({param})"
 
 
-def _hash(json_data: dict[str, str]) -> SHA256:
+def _hash(json_data: Dict[str, str]) -> SHA256:
     base_string: str = "%s:%s:%s:%s" % (
         json_data["t"],
         json_data["m"],

--- a/g4f/Provider/Bard.py
+++ b/g4f/Provider/Bard.py
@@ -1,9 +1,12 @@
 import json
 import random
 import re
+
 from aiohttp import ClientSession
 
-from .base_provider import AsyncProvider, get_cookies, format_prompt
+from ..typing import Dict, List
+from .base_provider import AsyncProvider, format_prompt, get_cookies
+
 
 class Bard(AsyncProvider):
     url = "https://bard.google.com"
@@ -14,7 +17,7 @@ class Bard(AsyncProvider):
     async def create_async(
         cls,
         model: str,
-        messages: list[dict[str, str]],
+        messages: List[Dict[str, str]],
         proxy: str = None,
         cookies: dict = None,
         **kwargs
@@ -79,7 +82,7 @@ class Bard(AsyncProvider):
     def params(cls):
         params = [
             ("model", "str"),
-            ("messages", "list[dict[str, str]]"),
+            ("messages", "List[Dict[str, str]]"),
             ("stream", "bool"),
             ("proxy", "str"),
         ]

--- a/g4f/Provider/Bing.py
+++ b/g4f/Provider/Bing.py
@@ -1,8 +1,14 @@
-import asyncio, aiohttp, json, os, random
+import asyncio
+import json
+import os
+import random
 
-from aiohttp        import ClientSession
-from ..typing       import Any, AsyncGenerator, CreateResult, Union
+import aiohttp
+from aiohttp import ClientSession
+
+from ..typing import Any, AsyncGenerator, CreateResult, Dict, List, Union
 from .base_provider import AsyncGeneratorProvider, get_cookies
+
 
 class Bing(AsyncGeneratorProvider):
     url             = "https://bing.com/chat"
@@ -14,7 +20,7 @@ class Bing(AsyncGeneratorProvider):
     @staticmethod
     def create_async_generator(
             model: str,
-            messages: list[dict[str, str]],
+            messages: List[Dict[str, str]],
             cookies: dict = None, **kwargs) -> AsyncGenerator:
         
         if not cookies:
@@ -56,7 +62,7 @@ class Bing(AsyncGeneratorProvider):
         
         return stream_generate(prompt, context, cookies_dict)
 
-def create_context(messages: list[dict[str, str]]):
+def create_context(messages: List[Dict[str, str]]):
     context = ""
 
     for message in messages:

--- a/g4f/Provider/ChatgptAi.py
+++ b/g4f/Provider/ChatgptAi.py
@@ -1,6 +1,8 @@
-import re, requests
+import re
 
-from ..typing       import Any, CreateResult
+import requests
+
+from ..typing import Any, CreateResult, Dict, List
 from .base_provider import BaseProvider
 
 
@@ -12,7 +14,7 @@ class ChatgptAi(BaseProvider):
     @staticmethod
     def create_completion(
         model: str,
-        messages: list[dict[str, str]],
+        messages: List[Dict[str, str]],
         stream: bool, **kwargs: Any) -> CreateResult:
         
         chat = ""

--- a/g4f/Provider/ChatgptLogin.py
+++ b/g4f/Provider/ChatgptLogin.py
@@ -1,6 +1,10 @@
-import base64, os, re, requests
+import base64
+import os
+import re
 
-from ..typing       import Any, CreateResult
+import requests
+
+from ..typing import Any, CreateResult, Dict, List
 from .base_provider import BaseProvider
 
 
@@ -12,7 +16,7 @@ class ChatgptLogin(BaseProvider):
     @staticmethod
     def create_completion(
         model: str,
-        messages: list[dict[str, str]],
+        messages: List[Dict[str, str]],
         stream: bool, **kwargs: Any) -> CreateResult:
         
         headers = {
@@ -65,7 +69,7 @@ class ChatgptLogin(BaseProvider):
     def params(cls):
         params = [
             ("model", "str"),
-            ("messages", "list[dict[str, str]]"),
+            ("messages", "List[Dict[str, str]]"),
             ("stream", "bool"),
             ("temperature", "float"),
         ]
@@ -93,7 +97,7 @@ def _get_nonce() -> str:
     return "" if result is None else result.group(1)
 
 
-def _transform(messages: list[dict[str, str]]) -> list[dict[str, Any]]:
+def _transform(messages: List[Dict[str, str]]) -> List[Dict[str, Any]]:
     return [
         {
             "id"     : os.urandom(6).hex(),

--- a/g4f/Provider/DeepAi.py
+++ b/g4f/Provider/DeepAi.py
@@ -1,6 +1,9 @@
-import json, js2py, requests
+import json
 
-from ..typing       import Any, CreateResult
+import js2py
+import requests
+
+from ..typing import Any, CreateResult, Dict, List
 from .base_provider import BaseProvider
 
 
@@ -13,7 +16,7 @@ class DeepAi(BaseProvider):
     @staticmethod
     def create_completion(
         model: str,
-        messages: list[dict[str, str]],
+        messages: List[Dict[str, str]],
         stream: bool, **kwargs: Any) -> CreateResult:
         
         token_js = """

--- a/g4f/Provider/DfeHub.py
+++ b/g4f/Provider/DfeHub.py
@@ -1,6 +1,10 @@
-import json, re, time , requests
+import json
+import re
+import time
 
-from ..typing       import Any, CreateResult
+import requests
+
+from ..typing import Any, CreateResult, Dict, List
 from .base_provider import BaseProvider
 
 
@@ -12,7 +16,7 @@ class DfeHub(BaseProvider):
     @staticmethod
     def create_completion(
         model: str,
-        messages: list[dict[str, str]],
+        messages: List[Dict[str, str]],
         stream: bool, **kwargs: Any) -> CreateResult:
         
         headers = {
@@ -60,7 +64,7 @@ class DfeHub(BaseProvider):
     def params(cls):
         params = [
             ("model", "str"),
-            ("messages", "list[dict[str, str]]"),
+            ("messages", "List[Dict[str, str]]"),
             ("stream", "bool"),
             ("temperature", "float"),
             ("presence_penalty", "int"),

--- a/g4f/Provider/EasyChat.py
+++ b/g4f/Provider/EasyChat.py
@@ -1,6 +1,9 @@
-import json, requests, random
+import json
+import random
 
-from ..typing       import Any, CreateResult
+import requests
+
+from ..typing import Any, CreateResult, Dict, List
 from .base_provider import BaseProvider
 
 
@@ -13,7 +16,7 @@ class EasyChat(BaseProvider):
     @staticmethod
     def create_completion(
         model: str,
-        messages: list[dict[str, str]],
+        messages: List[Dict[str, str]],
         stream: bool, **kwargs: Any) -> CreateResult:
         
         active_servers = [
@@ -94,7 +97,7 @@ class EasyChat(BaseProvider):
     def params(cls):
         params = [
             ("model", "str"),
-            ("messages", "list[dict[str, str]]"),
+            ("messages", "List[Dict[str, str]]"),
             ("stream", "bool"),
             ("temperature", "float"),
             ("presence_penalty", "int"),

--- a/g4f/Provider/Equing.py
+++ b/g4f/Provider/Equing.py
@@ -1,7 +1,9 @@
-import requests, json
+import json
+from abc import ABC, abstractmethod
 
-from abc      import ABC, abstractmethod
-from ..typing import Any, CreateResult
+import requests
+
+from ..typing import Any, CreateResult, Dict, List
 
 
 class Equing(ABC):
@@ -16,7 +18,7 @@ class Equing(ABC):
     @abstractmethod
     def create_completion(
         model: str,
-        messages: list[dict[str, str]],
+        messages: List[Dict[str, str]],
         stream: bool, **kwargs: Any) -> CreateResult:
 
         headers = {
@@ -70,7 +72,7 @@ class Equing(ABC):
     def params(cls):
         params = [
             ("model", "str"),
-            ("messages", "list[dict[str, str]]"),
+            ("messages", "List[Dict[str, str]]"),
             ("stream", "bool"),
         ]
         param = ", ".join([": ".join(p) for p in params])

--- a/g4f/Provider/FastGpt.py
+++ b/g4f/Provider/FastGpt.py
@@ -1,7 +1,10 @@
-import requests, json, random
+import json
+import random
 from abc import ABC, abstractmethod
 
-from ..typing import Any, CreateResult
+import requests
+
+from ..typing import Any, CreateResult, Dict, List
 
 
 class FastGpt(ABC):
@@ -16,7 +19,7 @@ class FastGpt(ABC):
     @abstractmethod
     def create_completion(
         model: str,
-        messages: list[dict[str, str]],
+        messages: List[Dict[str, str]],
         stream: bool, **kwargs: Any) -> CreateResult:
 
         headers = {
@@ -74,7 +77,7 @@ class FastGpt(ABC):
     def params(cls):
         params = [
             ("model", "str"),
-            ("messages", "list[dict[str, str]]"),
+            ("messages", "List[Dict[str, str]]"),
             ("stream", "bool"),
         ]
         param = ", ".join([": ".join(p) for p in params])

--- a/g4f/Provider/Forefront.py
+++ b/g4f/Provider/Forefront.py
@@ -2,7 +2,7 @@ import json
 
 import requests
 
-from ..typing import Any, CreateResult
+from ..typing import Any, CreateResult, Dict, List
 from .base_provider import BaseProvider
 
 
@@ -14,7 +14,7 @@ class Forefront(BaseProvider):
     @staticmethod
     def create_completion(
         model: str,
-        messages: list[dict[str, str]],
+        messages: List[Dict[str, str]],
         stream: bool, **kwargs: Any) -> CreateResult:
         
         json_data = {

--- a/g4f/Provider/GetGpt.py
+++ b/g4f/Provider/GetGpt.py
@@ -1,7 +1,11 @@
-import os, json, uuid, requests
+import json
+import os
+import uuid
 
-from Crypto.Cipher  import AES
-from ..typing       import Any, CreateResult
+import requests
+from Crypto.Cipher import AES
+
+from ..typing import Any, CreateResult, Dict, List
 from .base_provider import BaseProvider
 
 
@@ -14,7 +18,7 @@ class GetGpt(BaseProvider):
     @staticmethod
     def create_completion(
         model: str,
-        messages: list[dict[str, str]],
+        messages: List[Dict[str, str]],
         stream: bool, **kwargs: Any) -> CreateResult:
         
         headers = {
@@ -51,7 +55,7 @@ class GetGpt(BaseProvider):
     def params(cls):
         params = [
             ('model', 'str'),
-            ('messages', 'list[dict[str, str]]'),
+            ('messages', 'List[Dict[str, str]]'),
             ('stream', 'bool'),
             ('temperature', 'float'),
             ('presence_penalty', 'int'),

--- a/g4f/Provider/H2o.py
+++ b/g4f/Provider/H2o.py
@@ -1,8 +1,9 @@
 import json
 import uuid
+
 from aiohttp import ClientSession
 
-from ..typing import AsyncGenerator
+from ..typing import AsyncGenerator, Dict, List
 from .base_provider import AsyncGeneratorProvider, format_prompt
 
 
@@ -16,7 +17,7 @@ class H2o(AsyncGeneratorProvider):
     async def create_async_generator(
         cls,
         model: str,
-        messages: list[dict[str, str]],
+        messages: List[Dict[str, str]],
         proxy: str = None,
         **kwargs
     ) -> AsyncGenerator:
@@ -86,7 +87,7 @@ class H2o(AsyncGeneratorProvider):
     def params(cls):
         params = [
             ("model", "str"),
-            ("messages", "list[dict[str, str]]"),
+            ("messages", "List[Dict[str, str]]"),
             ("stream", "bool"),
             ("temperature", "float"),
             ("truncate", "int"),

--- a/g4f/Provider/HuggingChat.py
+++ b/g4f/Provider/HuggingChat.py
@@ -1,8 +1,9 @@
 import json
+
 from aiohttp import ClientSession
 
-from ..typing import AsyncGenerator
-from .base_provider import AsyncGeneratorProvider, get_cookies, format_prompt
+from ..typing import AsyncGenerator, Dict, List
+from .base_provider import AsyncGeneratorProvider, format_prompt, get_cookies
 
 
 class HuggingChat(AsyncGeneratorProvider):
@@ -15,7 +16,7 @@ class HuggingChat(AsyncGeneratorProvider):
     async def create_async_generator(
         cls,
         model: str,
-        messages: list[dict[str, str]],
+        messages: List[Dict[str, str]],
         stream: bool = True,
         proxy: str = None,
         cookies: dict = None,
@@ -99,7 +100,7 @@ class HuggingChat(AsyncGeneratorProvider):
     def params(cls):
         params = [
             ("model", "str"),
-            ("messages", "list[dict[str, str]]"),
+            ("messages", "List[Dict[str, str]]"),
             ("stream", "bool"),
             ("proxy", "str"),
         ]

--- a/g4f/Provider/Liaobots.py
+++ b/g4f/Provider/Liaobots.py
@@ -1,8 +1,9 @@
-import uuid
 import json
+import uuid
+
 from aiohttp import ClientSession
 
-from ..typing import AsyncGenerator
+from ..typing import AsyncGenerator, Dict, List
 from .base_provider import AsyncGeneratorProvider
 
 models = {
@@ -37,7 +38,7 @@ class Liaobots(AsyncGeneratorProvider):
     async def create_async_generator(
         cls,
         model: str,
-        messages: list[dict[str, str]],
+        messages: List[Dict[str, str]],
         auth: str = None,
         proxy: str = None,
         **kwargs
@@ -78,7 +79,7 @@ class Liaobots(AsyncGeneratorProvider):
     def params(cls):
         params = [
             ("model", "str"),
-            ("messages", "list[dict[str, str]]"),
+            ("messages", "List[Dict[str, str]]"),
             ("stream", "bool"),
             ("proxy", "str"),
             ("auth", "str"),

--- a/g4f/Provider/Lockchat.py
+++ b/g4f/Provider/Lockchat.py
@@ -1,6 +1,8 @@
-import json, requests
+import json
 
-from ..typing       import Any, CreateResult
+import requests
+
+from ..typing import Any, CreateResult, Dict, List
 from .base_provider import BaseProvider
 
 
@@ -13,7 +15,7 @@ class Lockchat(BaseProvider):
     @staticmethod
     def create_completion(
         model: str,
-        messages: list[dict[str, str]],
+        messages: List[Dict[str, str]],
         stream: bool, **kwargs: Any) -> CreateResult:
 
         temperature = float(kwargs.get("temperature", 0.7))
@@ -52,7 +54,7 @@ class Lockchat(BaseProvider):
     def params(cls):
         params = [
             ("model", "str"),
-            ("messages", "list[dict[str, str]]"),
+            ("messages", "List[Dict[str, str]]"),
             ("stream", "bool"),
             ("temperature", "float"),
         ]

--- a/g4f/Provider/Opchatgpts.py
+++ b/g4f/Provider/Opchatgpts.py
@@ -1,6 +1,6 @@
 import requests
 
-from ..typing       import Any, CreateResult
+from ..typing import Any, CreateResult, Dict, List
 from .base_provider import BaseProvider
 
 
@@ -12,7 +12,7 @@ class Opchatgpts(BaseProvider):
     @staticmethod
     def create_completion(
         model: str,
-        messages: list[dict[str, str]],
+        messages: List[Dict[str, str]],
         stream: bool, **kwargs: Any) -> CreateResult:
         
         temperature   = kwargs.get("temperature", 0.8)
@@ -34,7 +34,7 @@ class Opchatgpts(BaseProvider):
 
 
 def _create_payload(
-    messages: list[dict[str, str]],
+    messages: List[Dict[str, str]],
     temperature: float,
     max_tokens: int, system_prompt: str) -> dict:
     

--- a/g4f/Provider/OpenAssistant.py
+++ b/g4f/Provider/OpenAssistant.py
@@ -1,8 +1,10 @@
 import json
+
 from aiohttp import ClientSession
 
-from ..typing import Any, AsyncGenerator
-from .base_provider import AsyncGeneratorProvider, get_cookies, format_prompt
+from ..typing import Any, AsyncGenerator, Dict, List
+from .base_provider import AsyncGeneratorProvider, format_prompt, get_cookies
+
 
 class OpenAssistant(AsyncGeneratorProvider):
     url = "https://open-assistant.io/chat"
@@ -14,7 +16,7 @@ class OpenAssistant(AsyncGeneratorProvider):
     async def create_async_generator(
         cls,
         model: str,
-        messages: list[dict[str, str]],
+        messages: List[Dict[str, str]],
         proxy: str = None,
         cookies: dict = None,
         **kwargs: Any
@@ -90,7 +92,7 @@ class OpenAssistant(AsyncGeneratorProvider):
     def params(cls):
         params = [
             ("model", "str"),
-            ("messages", "list[dict[str, str]]"),
+            ("messages", "List[Dict[str, str]]"),
             ("stream", "bool"),
             ("proxy", "str"),
         ]

--- a/g4f/Provider/OpenaiChat.py
+++ b/g4f/Provider/OpenaiChat.py
@@ -4,10 +4,12 @@ try:
 except ImportError:
     has_module = False
 
-from .base_provider import AsyncGeneratorProvider, get_cookies, format_prompt
-from ..typing import AsyncGenerator
-from httpx import AsyncClient
 import json
+
+from httpx import AsyncClient
+
+from ..typing import AsyncGenerator, Dict, List
+from .base_provider import AsyncGeneratorProvider, format_prompt, get_cookies
 
 
 class OpenaiChat(AsyncGeneratorProvider):
@@ -23,7 +25,7 @@ class OpenaiChat(AsyncGeneratorProvider):
     async def create_async_generator(
         cls,
         model: str,
-        messages: list[dict[str, str]],
+        messages: List[Dict[str, str]],
         proxy: str = None,
         access_token: str = _access_token,
         cookies: dict = None,
@@ -65,7 +67,7 @@ class OpenaiChat(AsyncGeneratorProvider):
     def params(cls):
         params = [
             ("model", "str"),
-            ("messages", "list[dict[str, str]]"),
+            ("messages", "List[Dict[str, str]]"),
             ("stream", "bool"),
             ("proxy", "str"),
         ]

--- a/g4f/Provider/Raycast.py
+++ b/g4f/Provider/Raycast.py
@@ -1,6 +1,8 @@
-import json, requests
+import json
 
-from ..typing       import Any, CreateResult
+import requests
+
+from ..typing import Any, CreateResult, Dict, List
 from .base_provider import BaseProvider
 
 
@@ -15,7 +17,7 @@ class Raycast(BaseProvider):
     @staticmethod
     def create_completion(
         model: str,
-        messages: list[dict[str, str]],
+        messages: List[Dict[str, str]],
         stream: bool,
         **kwargs: Any,
     ) -> CreateResult:
@@ -57,7 +59,7 @@ class Raycast(BaseProvider):
     def params(cls):
         params = [
             ("model", "str"),
-            ("messages", "list[dict[str, str]]"),
+            ("messages", "List[Dict[str, str]]"),
             ("stream", "bool"),
             ("temperature", "float"),
             ("top_p", "int"),

--- a/g4f/Provider/Theb.py
+++ b/g4f/Provider/Theb.py
@@ -1,6 +1,9 @@
-import json, random, requests
+import json
+import random
 
-from ..typing       import Any, CreateResult
+import requests
+
+from ..typing import Any, CreateResult, Dict, List
 from .base_provider import BaseProvider
 
 
@@ -14,7 +17,7 @@ class Theb(BaseProvider):
     @staticmethod
     def create_completion(
         model: str,
-        messages: list[dict[str, str]],
+        messages: List[Dict[str, str]],
         stream: bool, **kwargs: Any) -> CreateResult:
         
         conversation = ''
@@ -82,8 +85,8 @@ class Theb(BaseProvider):
     def params(cls):
         params = [
             ("model", "str"),
-            ("messages", "list[dict[str, str]]"),
-            ("auth", "list[dict[str, str]]"),
+            ("messages", "List[Dict[str, str]]"),
+            ("auth", "List[Dict[str, str]]"),
             ("stream", "bool"),
             ("temperature", "float"),
             ("presence_penalty", "int"),

--- a/g4f/Provider/V50.py
+++ b/g4f/Provider/V50.py
@@ -1,7 +1,10 @@
-import uuid, requests
+import uuid
 
-from ..typing       import Any, CreateResult
+import requests
+
+from ..typing import Any, CreateResult, Dict, List
 from .base_provider import BaseProvider
+
 
 class V50(BaseProvider):
     url                     = 'https://p5.v50.ltd'
@@ -13,7 +16,7 @@ class V50(BaseProvider):
     @staticmethod
     def create_completion(
         model: str,
-        messages: list[dict[str, str]],
+        messages: List[Dict[str, str]],
         stream: bool, **kwargs: Any) -> CreateResult:
         
         conversation = ''
@@ -55,7 +58,7 @@ class V50(BaseProvider):
     def params(cls):
         params = [
             ("model", "str"),
-            ("messages", "list[dict[str, str]]"),
+            ("messages", "List[Dict[str, str]]"),
             ("stream", "bool"),
             ("temperature", "float"),
             ("top_p", "int"),

--- a/g4f/Provider/Vercel.py
+++ b/g4f/Provider/Vercel.py
@@ -1,7 +1,11 @@
-import base64, json, uuid, quickjs
+import base64
+import json
+import uuid
 
-from curl_cffi      import requests
-from ..typing       import Any, CreateResult, TypedDict
+import quickjs
+from curl_cffi import requests
+
+from ..typing import Any, CreateResult, Dict, List, TypedDict
 from .base_provider import BaseProvider
 
 
@@ -13,7 +17,7 @@ class Vercel(BaseProvider):
     @staticmethod
     def create_completion(
         model: str,
-        messages: list[dict[str, str]],
+        messages: List[Dict[str, str]],
         stream: bool, **kwargs: Any) -> CreateResult:
         
         if model in ["gpt-3.5-turbo", "gpt-4"]:
@@ -21,7 +25,7 @@ class Vercel(BaseProvider):
         yield _chat(model_id=model, messages=messages)
 
 
-def _chat(model_id: str, messages: list[dict[str, str]]) -> str:
+def _chat(model_id: str, messages: List[Dict[str, str]]) -> str:
     session = requests.Session(impersonate="chrome107")
 
     url     = "https://sdk.vercel.ai/api/generate"
@@ -33,7 +37,7 @@ def _chat(model_id: str, messages: list[dict[str, str]]) -> str:
     return response.text
 
 
-def _create_payload(model_id: str, messages: list[dict[str, str]]) -> dict[str, Any]:
+def _create_payload(model_id: str, messages: List[Dict[str, str]]) -> Dict[str, Any]:
     default_params = model_info[model_id]["default_params"]
     return {
         "messages": messages,
@@ -72,10 +76,10 @@ def _get_custom_encoding(session: requests.Session):
 
 class ModelInfo(TypedDict):
     id: str
-    default_params: dict[str, Any]
+    default_params: Dict[str, Any]
 
 
-model_info: dict[str, ModelInfo] = {
+model_info: Dict[str, ModelInfo] = {
     "anthropic:claude-instant-v1": {
         "id": "anthropic:claude-instant-v1",
         "default_params": {

--- a/g4f/Provider/Wewordle.py
+++ b/g4f/Provider/Wewordle.py
@@ -1,6 +1,11 @@
-import json, random, string, time, requests
+import json
+import random
+import string
+import time
 
-from ..typing       import Any, CreateResult
+import requests
+
+from ..typing import Any, CreateResult, Dict, List
 from .base_provider import BaseProvider
 
 
@@ -13,7 +18,7 @@ class Wewordle(BaseProvider):
     def create_completion(
         cls,
         model: str,
-        messages: list[dict[str, str]],
+        messages: List[Dict[str, str]],
         stream: bool, **kwargs: Any) -> CreateResult:
         
         # randomize user id and app id

--- a/g4f/Provider/Wuguokai.py
+++ b/g4f/Provider/Wuguokai.py
@@ -1,5 +1,9 @@
-import random, requests, json
-from ..typing import Any, CreateResult
+import json
+import random
+
+import requests
+
+from ..typing import Any, CreateResult, Dict, List
 from .base_provider import BaseProvider
 
 
@@ -13,7 +17,7 @@ class Wuguokai(BaseProvider):
     @staticmethod
     def create_completion(
         model: str,
-        messages: list[dict[str, str]],
+        messages: List[Dict[str, str]],
         stream: bool,
         **kwargs: Any,
     ) -> CreateResult:
@@ -58,7 +62,7 @@ class Wuguokai(BaseProvider):
     def params(cls):
         params = [
             ("model", "str"),
-            ("messages", "list[dict[str, str]]"),
+            ("messages", "List[Dict[str, str]]"),
             ("stream", "bool")
         ]
         param = ", ".join([": ".join(p) for p in params])

--- a/g4f/Provider/You.py
+++ b/g4f/Provider/You.py
@@ -1,7 +1,8 @@
-from aiohttp import ClientSession
 import json
 
-from ..typing import AsyncGenerator
+from aiohttp import ClientSession
+
+from ..typing import AsyncGenerator, Dict, List
 from .base_provider import AsyncGeneratorProvider, format_prompt, get_cookies
 
 
@@ -14,7 +15,7 @@ class You(AsyncGeneratorProvider):
     @staticmethod
     async def create_async_generator(
         model: str,
-        messages: list[dict[str, str]],
+        messages: List[Dict[str, str]],
         cookies: dict = None,
         **kwargs,
     ) -> AsyncGenerator:

--- a/g4f/Provider/Yqcloud.py
+++ b/g4f/Provider/Yqcloud.py
@@ -1,5 +1,6 @@
 from aiohttp import ClientSession
 
+from ..typing import Dict, List
 from .base_provider import AsyncProvider, format_prompt
 
 
@@ -11,7 +12,7 @@ class Yqcloud(AsyncProvider):
     @staticmethod
     async def create_async(
         model: str,
-        messages: list[dict[str, str]],
+        messages: List[Dict[str, str]],
         proxy: str = None,
         **kwargs,
     ) -> str:
@@ -32,7 +33,7 @@ def _create_header():
     }
 
 
-def _create_payload(messages: list[dict[str, str]]):
+def _create_payload(messages: List[Dict[str, str]]):
     return {
         "prompt": format_prompt(messages),
         "network": True,

--- a/g4f/Provider/base_provider.py
+++ b/g4f/Provider/base_provider.py
@@ -1,9 +1,9 @@
+import asyncio
 from abc import ABC, abstractmethod
 
-from ..typing import Any, CreateResult, AsyncGenerator, Union
-
 import browser_cookie3
-import asyncio
+
+from ..typing import Any, AsyncGenerator, CreateResult, Dict, List, Union
 
 
 class BaseProvider(ABC):
@@ -18,7 +18,7 @@ class BaseProvider(ABC):
     @abstractmethod
     def create_completion(
         model: str,
-        messages: list[dict[str, str]],
+        messages: List[Dict[str, str]],
         stream: bool, **kwargs: Any) -> CreateResult:
         
         raise NotImplementedError()
@@ -28,7 +28,7 @@ class BaseProvider(ABC):
     def params(cls):
         params = [
             ("model", "str"),
-            ("messages", "list[dict[str, str]]"),
+            ("messages", "List[Dict[str, str]]"),
             ("stream", "bool"),
         ]
         param = ", ".join([": ".join(p) for p in params])
@@ -47,7 +47,7 @@ def get_cookies(cookie_domain: str) -> dict:
     return _cookies[cookie_domain]
 
 
-def format_prompt(messages: list[dict[str, str]], add_special_tokens=False):
+def format_prompt(messages: List[Dict[str, str]], add_special_tokens=False):
     if add_special_tokens or len(messages) > 1:
         formatted = "\n".join(
             ["%s: %s" % ((message["role"]).capitalize(), message["content"]) for message in messages]
@@ -63,7 +63,7 @@ class AsyncProvider(BaseProvider):
     def create_completion(
         cls,
         model: str,
-        messages: list[dict[str, str]],
+        messages: List[Dict[str, str]],
         stream: bool = False, **kwargs: Any) -> CreateResult:
         
         yield asyncio.run(cls.create_async(model, messages, **kwargs))
@@ -72,7 +72,7 @@ class AsyncProvider(BaseProvider):
     @abstractmethod
     async def create_async(
         model: str,
-        messages: list[dict[str, str]], **kwargs: Any) -> str:
+        messages: List[Dict[str, str]], **kwargs: Any) -> str:
         raise NotImplementedError()
 
 
@@ -81,7 +81,7 @@ class AsyncGeneratorProvider(AsyncProvider):
     def create_completion(
         cls,
         model: str,
-        messages: list[dict[str, str]],
+        messages: List[Dict[str, str]],
         stream: bool = True,
         **kwargs
     ) -> CreateResult:
@@ -91,7 +91,7 @@ class AsyncGeneratorProvider(AsyncProvider):
     async def create_async(
         cls,
         model: str,
-        messages: list[dict[str, str]],
+        messages: List[Dict[str, str]],
         **kwargs
     ) -> str:
         chunks = [chunk async for chunk in cls.create_async_generator(model, messages, stream=False, **kwargs)]
@@ -102,7 +102,7 @@ class AsyncGeneratorProvider(AsyncProvider):
     @abstractmethod
     def create_async_generator(
             model: str,
-            messages: list[dict[str, str]],
+            messages: List[Dict[str, str]],
             **kwargs
         ) -> AsyncGenerator:
         raise NotImplementedError()

--- a/g4f/__init__.py
+++ b/g4f/__init__.py
@@ -1,6 +1,6 @@
-from .          import models
-from .Provider  import BaseProvider
-from .typing    import Any, CreateResult, Union
+from . import models
+from .Provider import BaseProvider
+from .typing import Any, CreateResult, Dict, List, Union
 
 logging = False
 
@@ -8,8 +8,8 @@ class ChatCompletion:
     @staticmethod
     def create(
         model    : Union[models.Model, str],
-        messages : list[dict[str, str]],
-        provider : Union[type[BaseProvider], None] = None,
+        messages : List[Dict[str, str]],
+        provider : Union[BaseProvider, None] = None,
         stream   : bool                            = False,
         auth     : Union[str, None]                = None, **kwargs: Any) -> Union[CreateResult, str]:
         

--- a/g4f/models.py
+++ b/g4f/models.py
@@ -1,11 +1,14 @@
 from dataclasses import dataclass
-from .Provider import Bard, BaseProvider, GetGpt, H2o, Liaobots, Vercel, Equing
+from typing import Dict
+
+from .Provider import Bard, BaseProvider, Equing, GetGpt, H2o, Liaobots, Vercel
+
 
 @dataclass
 class Model:
     name: str
     base_provider: str
-    best_provider: type[BaseProvider]
+    best_provider: BaseProvider
 
 # Config for HuggingChat, OpenAssistant
 # Works for Liaobots, H2o, OpenaiChat, Yqcloud, You
@@ -161,7 +164,7 @@ llama7b_v2_chat = Model(
 
 
 class ModelUtils:
-    convert: dict[str, Model] = {
+    convert: Dict[str, Model] = {
         # GPT-3.5 / GPT-4
         'gpt-3.5-turbo' : gpt_35_turbo,
         'gpt-4'         : gpt_4,

--- a/g4f/typing.py
+++ b/g4f/typing.py
@@ -1,4 +1,14 @@
-from typing import Any, AsyncGenerator, Generator, NewType, Tuple, TypedDict, Union
+from typing import (
+    Any,
+    AsyncGenerator,
+    Dict,
+    Generator,
+    List,
+    NewType,
+    Tuple,
+    TypedDict,
+    Union,
+)
 
 SHA256 = NewType('sha_256_hash', str)
 CreateResult = Generator[str, None, None]
@@ -6,7 +16,9 @@ CreateResult = Generator[str, None, None]
 __all__ = [
     'Any',
     'AsyncGenerator',
+    'Dict',
     'Generator',
+    'List',
     'Tuple',
     'TypedDict',
     'SHA256',


### PR DESCRIPTION
In versions of Python below 3.9,, the `g4f` cannot use correctly. For example (python3.8):

```python
import g4f

# Set with provider
response = g4f.ChatCompletion.create(
    model="gpt-3.5-turbo",
    provider=g4f.Provider.Wewordle,
    messages=[{"role": "user", "content": "Hello world"}],
)
print(response)
```

**Result before fix:**
```
Traceback (most recent call last):
  File "d:/Junxiang/Python/gpt4free/test.py", line 1, in <module>
    import g4f
  File "d:\Junxiang\Python\gpt4free\g4f\__init__.py", line 1, in <module>
    from .          import models
  File "d:\Junxiang\Python\gpt4free\g4f\models.py", line 2, in <module>
    from .Provider import Bard, BaseProvider, GetGpt, H2o, Liaobots, Vercel, Equing
  File "d:\Junxiang\Python\gpt4free\g4f\Provider\__init__.py", line 1, in <module>
    from .Acytoo        import Acytoo
  File "d:\Junxiang\Python\gpt4free\g4f\Provider\Acytoo.py", line 6, in <module>
    from .base_provider import BaseProvider
  File "d:\Junxiang\Python\gpt4free\g4f\Provider\base_provider.py", line 9, in <module>
  File "d:\Junxiang\Python\gpt4free\g4f\Provider\base_provider.py", line 21, in BaseProvider
    messages: list[dict[str, str]],
TypeError: 'type' object is not subscriptable
```

**Result after fix:**
```
Hi there! How can I assist you today?
```

---

## Descrpition

Use standard **type hints** like `List` and `Dict` instead of `list` and `dict`. The latter will result in an error in **Python versions below 3.9.**

Refer to the following Stack Overflow discussions for more information:
1. https://stackoverflow.com/questions/75202610/typeerror-type-object-is-not-subscriptable-python
2. https://stackoverflow.com/questions/59101121/type-hint-for-a-dict-gives-typeerror-type-object-is-not-subscriptable
