### PR TITLE
Add console script

### DIFF
--- a/interference/app.py
+++ b/interference/app.py
@@ -12,6 +12,7 @@ from g4f import ChatCompletion
 app = Flask(__name__)
 CORS(app)
 
+
 @app.route("/chat/completions", methods=["POST"])
 def chat_completions():
     model = request.get_json().get("model", "gpt-3.5-turbo")
@@ -87,5 +88,9 @@ def chat_completions():
     return app.response_class(streaming(), mimetype="text/event-stream")
 
 
-if __name__ == "__main__":
+def main():
     app.run(host="0.0.0.0", port=1337, debug=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,3 @@ js2py
 quickjs
 flask
 flask-cors
-httpx

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ js2py
 quickjs
 flask
 flask-cors
+httpx

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,10 @@ with codecs.open(os.path.join(here, "README.md"), encoding="utf-8") as fh:
 with open("requirements.txt") as f:
     required = f.read().splitlines()
 
-VERSION = '0.0.2.6'
+with open("interference/requirements.txt") as f:
+    api_required = f.read().splitlines()
+
+VERSION = "0.0.2.6"
 DESCRIPTION = (
     "The official gpt4free repository | various collection of powerful language models"
 )
@@ -26,11 +29,16 @@ setup(
     long_description_content_type="text/markdown",
     long_description=long_description,
     packages=find_packages(),
+    data_files=["interference/app.py"],
     install_requires=required,
-    url='https://github.com/xtekky/gpt4free',  # Link to your GitHub repository
+    extras_require={"api": api_required},
+    entry_points={
+        "console_scripts": ["g4f=interference.app:main"],
+    },
+    url="https://github.com/xtekky/gpt4free",  # Link to your GitHub repository
     project_urls={
-        'Source Code': 'https://github.com/xtekky/gpt4free',  # GitHub link
-        'Bug Tracker': 'https://github.com/xtekky/gpt4free/issues',  # Link to issue tracker
+        "Source Code": "https://github.com/xtekky/gpt4free",  # GitHub link
+        "Bug Tracker": "https://github.com/xtekky/gpt4free/issues",  # Link to issue tracker
     },
     keywords=[
         "python",


### PR DESCRIPTION
Added a `console_script` to `setup.py` to allow users to easily run the API server using the command `g4f` after installing the package.

I have also added `extras_require` so that if a user should want to use this console script, they can easily install the needed additional requirements by running `pip install g4f[api]` - It is possible that the name `server` might be preferred over `api`