### PR TITLE
Fix: Python versions below 3.9 cannot use `g4f`

### DIFF
--- a/g4f/Provider/AItianhu.py
+++ b/g4f/Provider/AItianhu.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 
 import requests

--- a/g4f/Provider/Acytoo.py
+++ b/g4f/Provider/Acytoo.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time
 
 import requests

--- a/g4f/Provider/AiService.py
+++ b/g4f/Provider/AiService.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import requests
 
 from ..typing import Any, CreateResult

--- a/g4f/Provider/Aichat.py
+++ b/g4f/Provider/Aichat.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import requests
 
 from ..typing import Any, CreateResult

--- a/g4f/Provider/Ails.py
+++ b/g4f/Provider/Ails.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import hashlib
 import json
 import time
@@ -8,6 +10,7 @@ import requests
 
 from ..typing import SHA256, Any, CreateResult
 from .base_provider import BaseProvider
+
 
 class Ails(BaseProvider):
     url: str              = "https://ai.ls"

--- a/g4f/Provider/Bard.py
+++ b/g4f/Provider/Bard.py
@@ -1,9 +1,13 @@
+from __future__ import annotations
+
 import json
 import random
 import re
+
 from aiohttp import ClientSession
 
-from .base_provider import AsyncProvider, get_cookies, format_prompt
+from .base_provider import AsyncProvider, format_prompt, get_cookies
+
 
 class Bard(AsyncProvider):
     url = "https://bard.google.com"

--- a/g4f/Provider/Bing.py
+++ b/g4f/Provider/Bing.py
@@ -1,8 +1,16 @@
-import asyncio, aiohttp, json, os, random
+from __future__ import annotations
 
-from aiohttp        import ClientSession
-from ..typing       import Any, AsyncGenerator, CreateResult, Union
+import asyncio
+import json
+import os
+import random
+
+import aiohttp
+from aiohttp import ClientSession
+
+from ..typing import Any, AsyncGenerator, CreateResult, Union
 from .base_provider import AsyncGeneratorProvider, get_cookies
+
 
 class Bing(AsyncGeneratorProvider):
     url             = "https://bing.com/chat"

--- a/g4f/Provider/ChatgptAi.py
+++ b/g4f/Provider/ChatgptAi.py
@@ -1,6 +1,10 @@
-import re, requests
+from __future__ import annotations
 
-from ..typing       import Any, CreateResult
+import re
+
+import requests
+
+from ..typing import Any, CreateResult
 from .base_provider import BaseProvider
 
 

--- a/g4f/Provider/ChatgptLogin.py
+++ b/g4f/Provider/ChatgptLogin.py
@@ -1,6 +1,12 @@
-import base64, os, re, requests
+from __future__ import annotations
 
-from ..typing       import Any, CreateResult
+import base64
+import os
+import re
+
+import requests
+
+from ..typing import Any, CreateResult
 from .base_provider import BaseProvider
 
 

--- a/g4f/Provider/DeepAi.py
+++ b/g4f/Provider/DeepAi.py
@@ -1,6 +1,11 @@
-import json, js2py, requests
+from __future__ import annotations
 
-from ..typing       import Any, CreateResult
+import json
+
+import js2py
+import requests
+
+from ..typing import Any, CreateResult
 from .base_provider import BaseProvider
 
 

--- a/g4f/Provider/DfeHub.py
+++ b/g4f/Provider/DfeHub.py
@@ -1,6 +1,12 @@
-import json, re, time , requests
+from __future__ import annotations
 
-from ..typing       import Any, CreateResult
+import json
+import re
+import time
+
+import requests
+
+from ..typing import Any, CreateResult
 from .base_provider import BaseProvider
 
 

--- a/g4f/Provider/EasyChat.py
+++ b/g4f/Provider/EasyChat.py
@@ -1,6 +1,11 @@
-import json, requests, random
+from __future__ import annotations
 
-from ..typing       import Any, CreateResult
+import json
+import random
+
+import requests
+
+from ..typing import Any, CreateResult
 from .base_provider import BaseProvider
 
 

--- a/g4f/Provider/Equing.py
+++ b/g4f/Provider/Equing.py
@@ -1,6 +1,10 @@
-import requests, json
+from __future__ import annotations
 
-from abc      import ABC, abstractmethod
+import json
+from abc import ABC, abstractmethod
+
+import requests
+
 from ..typing import Any, CreateResult
 
 

--- a/g4f/Provider/FastGpt.py
+++ b/g4f/Provider/FastGpt.py
@@ -1,5 +1,10 @@
-import requests, json, random
+from __future__ import annotations
+
+import json
+import random
 from abc import ABC, abstractmethod
+
+import requests
 
 from ..typing import Any, CreateResult
 

--- a/g4f/Provider/Forefront.py
+++ b/g4f/Provider/Forefront.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 
 import requests

--- a/g4f/Provider/GetGpt.py
+++ b/g4f/Provider/GetGpt.py
@@ -1,7 +1,13 @@
-import os, json, uuid, requests
+from __future__ import annotations
 
-from Crypto.Cipher  import AES
-from ..typing       import Any, CreateResult
+import json
+import os
+import uuid
+
+import requests
+from Crypto.Cipher import AES
+
+from ..typing import Any, CreateResult
 from .base_provider import BaseProvider
 
 

--- a/g4f/Provider/H2o.py
+++ b/g4f/Provider/H2o.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import json
 import uuid
+
 from aiohttp import ClientSession
 
 from ..typing import AsyncGenerator

--- a/g4f/Provider/HuggingChat.py
+++ b/g4f/Provider/HuggingChat.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 import json
+
 from aiohttp import ClientSession
 
 from ..typing import AsyncGenerator
-from .base_provider import AsyncGeneratorProvider, get_cookies, format_prompt
+from .base_provider import AsyncGeneratorProvider, format_prompt, get_cookies
 
 
 class HuggingChat(AsyncGeneratorProvider):

--- a/g4f/Provider/Liaobots.py
+++ b/g4f/Provider/Liaobots.py
@@ -1,5 +1,8 @@
-import uuid
+from __future__ import annotations
+
 import json
+import uuid
+
 from aiohttp import ClientSession
 
 from ..typing import AsyncGenerator

--- a/g4f/Provider/Lockchat.py
+++ b/g4f/Provider/Lockchat.py
@@ -1,6 +1,10 @@
-import json, requests
+from __future__ import annotations
 
-from ..typing       import Any, CreateResult
+import json
+
+import requests
+
+from ..typing import Any, CreateResult
 from .base_provider import BaseProvider
 
 

--- a/g4f/Provider/Opchatgpts.py
+++ b/g4f/Provider/Opchatgpts.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import requests
 
-from ..typing       import Any, CreateResult
+from ..typing import Any, CreateResult
 from .base_provider import BaseProvider
 
 

--- a/g4f/Provider/OpenAssistant.py
+++ b/g4f/Provider/OpenAssistant.py
@@ -1,8 +1,12 @@
+from __future__ import annotations
+
 import json
+
 from aiohttp import ClientSession
 
 from ..typing import Any, AsyncGenerator
-from .base_provider import AsyncGeneratorProvider, get_cookies, format_prompt
+from .base_provider import AsyncGeneratorProvider, format_prompt, get_cookies
+
 
 class OpenAssistant(AsyncGeneratorProvider):
     url = "https://open-assistant.io/chat"

--- a/g4f/Provider/OpenaiChat.py
+++ b/g4f/Provider/OpenaiChat.py
@@ -1,13 +1,17 @@
+from __future__ import annotations
+
 has_module = True
 try:
     from revChatGPT.V1 import AsyncChatbot
 except ImportError:
     has_module = False
 
-from .base_provider import AsyncGeneratorProvider, get_cookies, format_prompt
-from ..typing import AsyncGenerator
-from httpx import AsyncClient
 import json
+
+from httpx import AsyncClient
+
+from ..typing import AsyncGenerator
+from .base_provider import AsyncGeneratorProvider, format_prompt, get_cookies
 
 
 class OpenaiChat(AsyncGeneratorProvider):

--- a/g4f/Provider/Raycast.py
+++ b/g4f/Provider/Raycast.py
@@ -1,6 +1,10 @@
-import json, requests
+from __future__ import annotations
 
-from ..typing       import Any, CreateResult
+import json
+
+import requests
+
+from ..typing import Any, CreateResult
 from .base_provider import BaseProvider
 
 

--- a/g4f/Provider/Theb.py
+++ b/g4f/Provider/Theb.py
@@ -1,6 +1,11 @@
-import json, random, requests
+from __future__ import annotations
 
-from ..typing       import Any, CreateResult
+import json
+import random
+
+import requests
+
+from ..typing import Any, CreateResult
 from .base_provider import BaseProvider
 
 

--- a/g4f/Provider/V50.py
+++ b/g4f/Provider/V50.py
@@ -1,7 +1,12 @@
-import uuid, requests
+from __future__ import annotations
 
-from ..typing       import Any, CreateResult
+import uuid
+
+import requests
+
+from ..typing import Any, CreateResult
 from .base_provider import BaseProvider
+
 
 class V50(BaseProvider):
     url                     = 'https://p5.v50.ltd'

--- a/g4f/Provider/Vercel.py
+++ b/g4f/Provider/Vercel.py
@@ -1,7 +1,13 @@
-import base64, json, uuid, quickjs
+from __future__ import annotations
 
-from curl_cffi      import requests
-from ..typing       import Any, CreateResult, TypedDict
+import base64
+import json
+import uuid
+
+import quickjs
+from curl_cffi import requests
+
+from ..typing import Any, CreateResult, TypedDict
 from .base_provider import BaseProvider
 
 

--- a/g4f/Provider/Wewordle.py
+++ b/g4f/Provider/Wewordle.py
@@ -1,6 +1,13 @@
-import json, random, string, time, requests
+from __future__ import annotations
 
-from ..typing       import Any, CreateResult
+import json
+import random
+import string
+import time
+
+import requests
+
+from ..typing import Any, CreateResult
 from .base_provider import BaseProvider
 
 

--- a/g4f/Provider/Wuguokai.py
+++ b/g4f/Provider/Wuguokai.py
@@ -1,4 +1,9 @@
-import random, requests
+from __future__ import annotations
+
+import random
+
+import requests
+
 from ..typing import Any, CreateResult
 from .base_provider import BaseProvider
 

--- a/g4f/Provider/You.py
+++ b/g4f/Provider/You.py
@@ -1,5 +1,8 @@
-from aiohttp import ClientSession
+from __future__ import annotations
+
 import json
+
+from aiohttp import ClientSession
 
 from ..typing import AsyncGenerator
 from .base_provider import AsyncGeneratorProvider, format_prompt, get_cookies

--- a/g4f/Provider/Yqcloud.py
+++ b/g4f/Provider/Yqcloud.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from aiohttp import ClientSession
 
 from .base_provider import AsyncProvider, format_prompt

--- a/g4f/Provider/__init__.py
+++ b/g4f/Provider/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .Acytoo        import Acytoo
 from .Aichat        import Aichat
 from .Ails          import Ails

--- a/g4f/Provider/base_provider.py
+++ b/g4f/Provider/base_provider.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
+import asyncio
 from abc import ABC, abstractmethod
 
-from ..typing import Any, CreateResult, AsyncGenerator, Union
-
 import browser_cookie3
-import asyncio
+
+from ..typing import Any, AsyncGenerator, CreateResult, Union
 
 
 class BaseProvider(ABC):

--- a/g4f/__init__.py
+++ b/g4f/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from .          import models
 from .Provider  import BaseProvider
 from .typing    import Any, CreateResult, Union

--- a/g4f/models.py
+++ b/g4f/models.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from dataclasses import dataclass
 from .Provider import Bard, BaseProvider, GetGpt, H2o, Liaobots, Vercel, Equing
 


### PR DESCRIPTION
(Reopen #868 )
In versions of Python below 3.9,, the `g4f` cannot use correctly. For example (python3.8):

```python
import g4f

# Set with provider
response = g4f.ChatCompletion.create(
    model="gpt-3.5-turbo",
    provider=g4f.Provider.Wewordle,
    messages=[{"role": "user", "content": "Hello world"}],
)
print(response)
```

**Result before fix:**
```
Traceback (most recent call last):
  File "d:/Junxiang/Python/gpt4free/test.py", line 1, in <module>
    import g4f
  File "d:\Junxiang\Python\gpt4free\g4f\__init__.py", line 1, in <module>
    from .          import models
  File "d:\Junxiang\Python\gpt4free\g4f\models.py", line 2, in <module>
    from .Provider import Bard, BaseProvider, GetGpt, H2o, Liaobots, Vercel, Equing
  File "d:\Junxiang\Python\gpt4free\g4f\Provider\__init__.py", line 1, in <module>
    from .Acytoo        import Acytoo
  File "d:\Junxiang\Python\gpt4free\g4f\Provider\Acytoo.py", line 6, in <module>
    from .base_provider import BaseProvider
  File "d:\Junxiang\Python\gpt4free\g4f\Provider\base_provider.py", line 9, in <module>
  File "d:\Junxiang\Python\gpt4free\g4f\Provider\base_provider.py", line 21, in BaseProvider
    messages: list[dict[str, str]],
TypeError: 'type' object is not subscriptable
```

**Result after fix:**
```
Hi there! How can I assist you today?
```

---

## Descrpition

Use `from __future__ import annotations` avoid `dict` and `list` cause "TypeErro: 'type' object is not subscriptable".

(`dict` and `list` type hint will result in an error in **Python versions below 3.9.**)

Refer to the following Stack Overflow discussions for more information:
1. https://stackoverflow.com/questions/75202610/typeerror-type-object-is-not-subscriptable-python
2. https://stackoverflow.com/questions/59101121/type-hint-for-a-dict-gives-typeerror-type-object-is-not-subscriptable


