### PR TITLE
Adding embedding support to the interference proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,9 +278,12 @@ asyncio.run(run_async())
 ```
 
 ### interference openai-proxy api (use with openai python package)
-#### if you want to use the embedding function, you need to get a huggingface token.
-#### You can get one at https://huggingface.co/settings/tokens make sure your role is set to write.
-#### If you have your token, just use it instead of the OpenAI api-key.
+
+if you want to use the embedding function, you need to get a huggingface token.
+You can get one at https://huggingface.co/settings/tokens make sure your role is set to write.
+If you have your token, just use it instead of the OpenAI api-key.
+
+
 get requirements:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ asyncio.run(run_async())
 
 ### interference openai-proxy api (use with openai python package)
 
-if you want to use the embedding function, you need to get a huggingface token. You can get one at https://huggingface.co/settings/tokens make sure your role is set to write. If you have your token, just use it instead of the OpenAI api-key.
+If you want to use the embedding function, you need to get a huggingface token. You can get one at https://huggingface.co/settings/tokens make sure your role is set to write. If you have your token, just use it instead of the OpenAI api-key.
 
 
 get requirements:

--- a/README.md
+++ b/README.md
@@ -278,7 +278,9 @@ asyncio.run(run_async())
 ```
 
 ### interference openai-proxy api (use with openai python package)
-
+#### if you want to use the embedding function, you need to get a huggingface token.
+#### You can get one at https://huggingface.co/settings/tokens make sure your role is set to write.
+#### If you have your token, just use it instead of the OpenAI api-key.
 get requirements:
 
 ```sh
@@ -294,7 +296,7 @@ python3 -m interference.app
 ```py
 import openai
 
-openai.api_key = ""
+openai.api_key = "Emppty if you dont use embeddings, otherwise your hugginface token"
 openai.api_base = "http://localhost:1337"
 
 

--- a/README.md
+++ b/README.md
@@ -279,9 +279,7 @@ asyncio.run(run_async())
 
 ### interference openai-proxy api (use with openai python package)
 
-if you want to use the embedding function, you need to get a huggingface token.
-You can get one at https://huggingface.co/settings/tokens make sure your role is set to write.
-If you have your token, just use it instead of the OpenAI api-key.
+if you want to use the embedding function, you need to get a huggingface token. You can get one at https://huggingface.co/settings/tokens make sure your role is set to write. If you have your token, just use it instead of the OpenAI api-key.
 
 
 get requirements:

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ python3 -m interference.app
 ```py
 import openai
 
-openai.api_key = "Emppty if you dont use embeddings, otherwise your hugginface token"
+openai.api_key = "Empty if you don't use embeddings, otherwise your hugginface token"
 openai.api_base = "http://localhost:1337"
 
 

--- a/interference/app.py
+++ b/interference/app.py
@@ -6,7 +6,7 @@ from typing import Any
 import requests
 from flask import Flask, request
 from flask_cors import CORS
-
+from transformers import AutoTokenizer
 from g4f import ChatCompletion
 
 app = Flask(__name__)

--- a/interference/app.py
+++ b/interference/app.py
@@ -3,7 +3,7 @@ import random
 import string
 import time
 from typing import Any
-
+import requests
 from flask import Flask, request
 from flask_cors import CORS
 
@@ -87,6 +87,70 @@ def chat_completions():
 
     return app.response_class(streaming(), mimetype="text/event-stream")
 
+
+#Get the embedding from huggingface
+def get_embedding(input_text, token):
+    huggingface_token = token
+    embedding_model = "sentence-transformers/all-mpnet-base-v2"
+    max_token_length = 500
+
+    # Load the tokenizer for the "all-mpnet-base-v2" model
+    tokenizer = AutoTokenizer.from_pretrained(embedding_model)
+    # Tokenize the text and split the tokens into chunks of 500 tokens each
+    tokens = tokenizer.tokenize(input_text)
+    token_chunks = [tokens[i:i + max_token_length] for i in range(0, len(tokens), max_token_length)]
+
+    # Initialize an empty list
+    embeddings = []
+
+    # Create embeddings for each chunk
+    for chunk in token_chunks:
+        # Convert the chunk tokens back to text
+        chunk_text = tokenizer.convert_tokens_to_string(chunk)
+
+        # Use the Hugging Face API to get embeddings for the chunk
+        api_url = f"https://api-inference.huggingface.co/pipeline/feature-extraction/{embedding_model}"
+        headers = {"Authorization": f"Bearer {huggingface_token}"}
+        chunk_text = chunk_text.replace("\n", " ")
+    
+        # Make a POST request to get the chunk's embedding
+        response = requests.post(api_url, headers=headers, json={"inputs": chunk_text, "options": {"wait_for_model": True}})
+    
+        # Parse the response and extract the embedding
+        chunk_embedding = response.json()
+        # Append the embedding to the list
+        embeddings.append(chunk_embedding)
+
+    #averaging all the embeddings
+    #this isn't very effective
+    #someone a better idea?
+    num_embeddings = len(embeddings)
+    average_embedding = [sum(x) / num_embeddings for x in zip(*embeddings)]
+    embedding = average_embedding
+    return embedding
+
+
+@app.route("/embeddings", methods=["POST"])
+def embeddings():
+    input_text_list = request.get_json().get("input")
+    input_text = ' '.join(map(str, input_text_list))
+    token = request.headers.get('Authorization').replace("Bearer ", "")
+    embedding = get_embedding(input_text, token)
+    return {
+  "data": [
+    {
+     "embedding": embedding,
+     "index": 0,
+     "object": "embedding"
+   }
+  ],
+ "model": "text-embedding-ada-002",
+  "object": "list",
+  "usage": {
+    "prompt_tokens": None,
+    "total_tokens": None
+  }
+  }
 
 def main():
     app.run(host="0.0.0.0", port=1337, debug=True)


### PR DESCRIPTION
Adding embedding support to the interference proxy, using the all-mpnet-base-v2 model. 
I know this is already free but it can be handy in situations where you both need chat completions and embeddings.
by the way it's still kind of sketchy