### PR TITLE
#935 [Docker] ModuleNotFoundError: No module named 'transformers' and 'PyExecJS'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ js2py
 flask
 flask-cors
 typing-extensions
+transformers
+PyExecJS

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ flask-cors
 typing-extensions
 transformers
 PyExecJS
+tensorflow
+torch


### PR DESCRIPTION
fixing missing modules