### PR TITLE
Chore: move ML related deps to interference dir

### DIFF
--- a/interference/requirements.txt
+++ b/interference/requirements.txt
@@ -1,2 +1,5 @@
 flask_cors
 watchdog~=3.0.0
+transformers
+tensorflow
+torch

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,4 @@ js2py
 flask
 flask-cors
 typing-extensions
-transformers
 PyExecJS
-tensorflow
-torch


### PR DESCRIPTION
## Intention

- Move `transformers` `tensorflow` `torch` from `/requirements.txt` to `/interference/requirements.txt`

## Reason

After search through each `.py` file, I found `transformers` only imported by `interference/app.py`, this file is http server, and its deps should be save in `interference/requirements.txt`. Also, saving these deps in `/requirements.txt` may cause people who only use reverse engineering features installing unnecessary packages(which are extremly large).

## Related Issue

#942 