### PR TITLE
fixed bug: ImportError: cannot import name 'Request' from 'curl_cffi.…

### DIFF
--- a/g4f/requests.py
+++ b/g4f/requests.py
@@ -7,7 +7,7 @@ from aiohttp import StreamReader
 from aiohttp.base_protocol import BaseProtocol
 
 from curl_cffi.requests import AsyncSession as BaseSession
-from curl_cffi.requests.cookies import Request, Response
+from curl_cffi.requests import Request, Response
 
 
 class StreamResponse:


### PR DESCRIPTION
…requests.cookies' (/Users/yanyuming/opt/anaconda3/envs/chatgpt/lib/python3.11/site-packages/curl_cffi/requests/cookies.py)

          
When I run the README example, an error occurs, and I fixed it:

```
Traceback (most recent call last):
  File "/Users/*****/test/g4ftest.py", line 1, in <module>
    import g4f
  File "/Users/opt/anaconda3/envs/chatgpt/lib/python3.11/site-packages/g4f/__init__.py", line 2, in <module>
    from g4f        import models
  File "/Users/opt/anaconda3/envs/chatgpt/lib/python3.11/site-packages/g4f/models.py", line 4, in <module>
    from .Provider   import BaseProvider, RetryProvider
  File "/Users/opt/anaconda3/envs/chatgpt/lib/python3.11/site-packages/g4f/Provider/__init__.py", line 7, in <module>
    from .AItianhuSpace import AItianhuSpace
  File "/Users/opt/anaconda3/envs/chatgpt/lib/python3.11/site-packages/g4f/Provider/AItianhuSpace.py", line 5, in <module>
    from g4f.requests import AsyncSession, StreamRequest
  File "/Users/opt/anaconda3/envs/chatgpt/lib/python3.11/site-packages/g4f/requests.py", line 8, in <module>
    from curl_cffi.requests.cookies import Request
ImportError: cannot import name 'Request' from 'curl_cffi.requests.cookies' (/Users/opt/anaconda3/envs/chatgpt/lib/python3.11/site-packages/curl_cffi/requests/cookies.py)
```
