### PR TITLE
Add stage to CI/CD for publishing image to Github Container Registry

### DIFF
--- a/.github/workflows/publish-workflow.yaml
+++ b/.github/workflows/publish-workflow.yaml
@@ -1,0 +1,33 @@
+name: Publish Docker image
+
+on:
+  push:
+    tags:
+      - '**'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Get metadata for Docker
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,8 @@ RUN pip install --upgrade pip && pip install -r requirements.txt
 # This may include all code, assets, and configuration files required to run the application.
 COPY . /app/
 
-# Expose port 1337
-EXPOSE 1337
+# Expose port 80 and 1337
+EXPOSE 80 1337
 
 # Define the default command to run the app using Python's module mode.
-CMD ["python", "-m", "g4f.api.run"]
+ENTRYPOINT ["python", "-m", "g4f.cli"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,18 @@
 version: '3'
 
 services:
-  gpt4free:
+  gpt4free-api: &gpt4free
+    image: gpt4free:latest
     build:
       context: .
       dockerfile: Dockerfile
-    volumes:
-      - .:/app
+      cache_from:
+        - gpt4free:latest
     ports:
       - '1337:1337'
-    environment:
-      - PYTHONUNBUFFERED=1
+    command: api
+  gpt4free-gui:
+    <<: *gpt4free
+    ports:
+      - '8080:80'
+    command: gui


### PR DESCRIPTION
I found of that the **CI/CD workflow** for publishing image to **DockerHub** was removed. Unfortunately, I didn't find why :( (legal purposes?):
```bash
* 08291e8 - Delete ci.yml (10 weeks ago) <xtekky>
* 9b69fc6 - Add docker image ci support (6 months ago) <wengchaoxi>
```
So, I think we can use **Github Container Registry** for these purposes, aren’t we? I have created workflow which publish a new image to **Github registry** every time when a tag has been pushed.

UPD: Also I found of that **Docker compose** launch only **API** service. I have added the **GUI** service to **Docker compose**.