### PR TITLE
Fix: debug.logging not work in retry provider

### DIFF
--- a/g4f/__init__.py
+++ b/g4f/__init__.py
@@ -48,6 +48,7 @@ def get_model_and_provider(model    : Union[Model, str],
         raise ValueError(f'{provider.__name__} does not support "stream" argument')
 
     if logging:
+        RetryProvider.logging = True
         print(f'Using {provider.__name__} provider')
 
     return model, provider


### PR DESCRIPTION
When using `RetryProvider`, we want to identify the specific `Provider` being used (according to #1094 requirements).

According to the source code, I noticed that `g4f.logging` is likely intended for this purpose, facilitating better debugging for developers (please correct me if I'm wrong).

However, the `logging` attribute in `retry_provider.py` does not change along with `g4f.logging = True`. (always be `False`)

https://github.com/xtekky/gpt4free/blob/cb3677a3e2bc53aba76f02e8d69c03fa9b5ab1c7/g4f/Provider/retry_provider.py#L43-L44

Therefore, in this case, I have defined `logging` as a **class variable** in `RetryProvider`.


### Example

```python
import g4f

g4f.logging = True

print(
    g4f.ChatCompletion.create(
            model='gpt-3.5-turbo',
            messages=[{"role": "user", "content": "hello"}],
    )
)
```

### Results

```
Using RetryProvider provider
Using ChatgptAi provider
Using AItianhuSpace provider
AItianhuSpace: RuntimeError: g4f.provider.AItianhuSpace requires cookies
Using GptGo provider
Hello! How can I assist you today?
```


**Noted**: I'm not sure if this modification is the optimal solution. If there is a better way, I welcome assistance.