### PR TITLE
[suggestion] Adding new parameter to check if a provider 'natively' supports mesage history

### DIFF
--- a/g4f/Provider/Bing.py
+++ b/g4f/Provider/Bing.py
@@ -32,6 +32,7 @@ default_cookies = {
 class Bing(AsyncGeneratorProvider):
     url             = "https://bing.com/chat"
     working         = True
+    supports_message_history = True
     supports_gpt_4  = True
         
     @staticmethod

--- a/g4f/Provider/ChatBase.py
+++ b/g4f/Provider/ChatBase.py
@@ -9,6 +9,7 @@ from .base_provider import AsyncGeneratorProvider
 class ChatBase(AsyncGeneratorProvider):
     url                   = "https://www.chatbase.co"
     supports_gpt_35_turbo = True
+    supports_message_history = True
     working               = True
 
     @classmethod

--- a/g4f/Provider/ChatForAi.py
+++ b/g4f/Provider/ChatForAi.py
@@ -11,6 +11,7 @@ from .base_provider import AsyncGeneratorProvider
 class ChatForAi(AsyncGeneratorProvider):
     url                   = "https://chatforai.store"
     working               = True
+    supports_message_history = True
     supports_gpt_35_turbo = True
 
     @classmethod

--- a/g4f/Provider/ChatgptX.py
+++ b/g4f/Provider/ChatgptX.py
@@ -12,6 +12,7 @@ from .helper import format_prompt
 class ChatgptX(AsyncGeneratorProvider):
     url = "https://chatgptx.de"
     supports_gpt_35_turbo = True
+    supports_message_history = True
     working               = True
 
     @classmethod

--- a/g4f/Provider/FakeGpt.py
+++ b/g4f/Provider/FakeGpt.py
@@ -10,6 +10,7 @@ from .helper import format_prompt
 
 class FakeGpt(AsyncGeneratorProvider):
     url                   = "https://chat-shared2.zhile.io"
+    supports_message_history = True
     supports_gpt_35_turbo = True
     working               = True
     _access_token         = None

--- a/g4f/Provider/FreeGpt.py
+++ b/g4f/Provider/FreeGpt.py
@@ -12,6 +12,7 @@ domains = [
 
 class FreeGpt(AsyncGeneratorProvider):
     url                   = "https://freegpts1.aifree.site/"
+    supports_message_history = True
     supports_gpt_35_turbo = True
     working               = True
 

--- a/g4f/Provider/GPTalk.py
+++ b/g4f/Provider/GPTalk.py
@@ -11,6 +11,7 @@ from .helper import format_prompt
 class GPTalk(AsyncGeneratorProvider):
     url = "https://gptalk.net"
     supports_gpt_35_turbo = True
+    supports_message_history = True
     working = True
     _auth = None
 

--- a/g4f/Provider/GptForLove.py
+++ b/g4f/Provider/GptForLove.py
@@ -9,6 +9,7 @@ from .helper import format_prompt
 
 class GptForLove(AsyncGeneratorProvider):
     url = "https://ai18.gptforlove.com"
+    supports_message_history = True
     supports_gpt_35_turbo = True
     working = True
 

--- a/g4f/Provider/You.py
+++ b/g4f/Provider/You.py
@@ -10,6 +10,7 @@ from .base_provider import AsyncGeneratorProvider, format_prompt
 class You(AsyncGeneratorProvider):
     url = "https://you.com"
     working = True
+    supports_message_history = True
     supports_gpt_35_turbo = True
 
 

--- a/g4f/Provider/Yqcloud.py
+++ b/g4f/Provider/Yqcloud.py
@@ -10,6 +10,7 @@ from .base_provider import AsyncGeneratorProvider, format_prompt
 class Yqcloud(AsyncGeneratorProvider):
     url = "https://chat9.yqcloud.top/"
     working = True
+    supports_message_history = True
     supports_gpt_35_turbo = True
 
     @staticmethod

--- a/g4f/Provider/base_provider.py
+++ b/g4f/Provider/base_provider.py
@@ -15,6 +15,7 @@ class BaseProvider(ABC):
     supports_stream: bool = False
     supports_gpt_35_turbo: bool = False
     supports_gpt_4: bool = False
+    supports_message_history: bool = False
 
     @staticmethod
     @abstractmethod


### PR DESCRIPTION
Imo, that would be a great idea to introduce a parameter that allows us to promptly verify whether the provider "natively" supports message history. But I would like to hear thoughts from other contributors about it. I am also considering adding another parameter to indicate whether a provider can perform web searches.