### PR TITLE
Adding context preservation to the GUI.

### DIFF
--- a/g4f/gui/client/css/style.css
+++ b/g4f/gui/client/css/style.css
@@ -260,6 +260,32 @@ body {
     z-index: 10000;
 }
 
+.message .assistant{
+    max-width: 48px;
+    max-height: 48px;
+    flex-shrink: 0;
+}
+
+.message .assistant img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 8px;
+    outline: 1px solid var(--blur-border);
+}
+
+.message .assistant:after {
+    content: "63";
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    height: 60%;
+    width: 60%;
+    background: var(--colour-3);
+    filter: blur(10px) opacity(0.5);
+    z-index: 10000;
+}
+
 .message .content {
     display: flex;
     flex-direction: column;
@@ -274,6 +300,13 @@ body {
 }
 
 .message .user i {
+    position: absolute;
+    bottom: -6px;
+    right: -6px;
+    z-index: 1000;
+}
+
+.message .assistant i {
     position: absolute;
     bottom: -6px;
     right: -6px;

--- a/g4f/gui/server/backend.py
+++ b/g4f/gui/server/backend.py
@@ -1,5 +1,4 @@
 import g4f
-import json
 
 from flask      import request
 from .internet  import search
@@ -44,45 +43,26 @@ class Backend_Api:
         }
     
     def _conversation(self):
-        config = None
-        proxy = None
         try:
-            config = json.load(open("config.json","r",encoding="utf-8"))
-            proxy = config["proxy"]
-
-        except Exception:
-            pass
-
-        try:
-            jailbreak       = request.json['jailbreak']
-            internet_access = request.json['meta']['content']['internet_access']
-            conversation    = request.json['meta']['content']['conversation']
-            prompt          = request.json['meta']['content']['parts'][0]
+            #jailbreak       = request.json['jailbreak']
+            #internet_access = request.json['meta']['content']['internet_access']
+            #conversation    = request.json['meta']['content']['conversation']
+            prompt          = request.json['meta']['content']['parts']
             model           = request.json['model']
             provider        = request.json.get('provider').split('g4f.Provider.')[1]
 
-            messages = special_instructions[jailbreak] + conversation + search(internet_access, prompt) + [prompt]
+            messages = prompt
+            print(messages)
 
             def stream():
-                if proxy != None:
-                    yield from g4f.ChatCompletion.create(
-                        model=model,
-                        provider=get_provider(provider),
-                        messages=messages,
-                        stream=True,
-                        proxy=proxy
-                    ) if provider else g4f.ChatCompletion.create(
-                        model=model, messages=messages, stream=True, proxy=proxy
-                    )
-                else:
-                    yield from g4f.ChatCompletion.create(
-                        model=model,
-                        provider=get_provider(provider),
-                        messages=messages,
-                        stream=True,
-                    ) if provider else g4f.ChatCompletion.create(
-                        model=model, messages=messages, stream=True
-                    )
+                yield from g4f.ChatCompletion.create(
+                    model=g4f.models.gpt_35_long,
+                    provider=get_provider(provider),
+                    messages=messages,
+                    stream=True,
+                ) if provider else g4f.ChatCompletion.create(
+                    model=model, messages=messages, stream=True
+                )
 
             return self.app.response_class(stream(), mimetype='text/event-stream')
 


### PR DESCRIPTION
**Part: "chat.v1.js"**

This code is an enhanced version of my previous attempt to add context. This code allows for preserving context when _refreshing the page_, _changing providers_, _changing ChatGPT models_, and _restarting the server_.
In this code, the following additions were made:

1. Separate role for ChatGPT itself to facilitate context understanding;

2. Gathering message history within the current conversation.

After collecting the message history, the obtained data is filtered and packed into an array of objects
`{'role': '...', 'content': '...'}`.
Roles are determined correctly even if multiple messages are sent simultaneously by one of the participants. When composing the list of messages, the introductory message "_Hello! How can I assist you today?_" will be ignored.

**Part: "style.css"**

Here, changes related to adding a new role to differentiate between ChatGPT messages and user messages were made.

**Part: "backend.py"**

In this code, in order to avoid errors and preserve the context correctly, it was necessary to abandon the parameters: 

- `jailbreak`
- `internet_access`
- `conversation`

To be able to send particularly long messages, the value in the variable model was replaced with `g4f.models.gpt_35_long`. Despite the recent change, the ability to choose the neural network model remains functional.
