### PR TITLE
Install flask async extra

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ certifi
 browser_cookie3
 websockets
 js2py
-flask
+flask[async]
 flask-cors
 typing-extensions
 PyExecJS


### PR DESCRIPTION
PR to ensure `flask` is installed with the `async` extra. This is required when running and using the API server.

Without the dependencies installed by this extra, the following error is thrown when using the API server via `g4f api` for example

```bash
RuntimeError: Install Flask with the 'async' extra in order to use async views.
2023-10-31 19:21:47.992 | ERROR    | logging:callHandlers:1706 - 500 Internal Server Error: The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application.
```