### PR TITLE
Remove height restriction

### DIFF
--- a/g4f/gui/client/css/style.css
+++ b/g4f/gui/client/css/style.css
@@ -660,12 +660,6 @@ ul {
     }
 }
 
-@media screen and (max-height: 640px) and (min-width: 990px) {
-    body {
-        height: 87vh
-    }
-}
-
 .shown {
     display: flex;
 }


### PR DESCRIPTION
Currently has blank black space at the bottom of the screen on 13" devices:
<img width="811" alt="Screenshot 2023-11-08 135405" src="https://github.com/xtekky/gpt4free/assets/105471783/000cf01e-25a4-41bf-a71a-1956561fa80c">
