### PR TITLE
stream check workaround & fix

### DIFF
--- a/g4f/api/__init__.py
+++ b/g4f/api/__init__.py
@@ -78,7 +78,7 @@ class Api:
                 item_data['messages'] = ast.literal_eval(item_data.get('messages'))
 
             model = item_data.get('model')
-            stream = item_data.get('stream')
+            stream = True if item_data.get("stream") == "True" else False
             messages = item_data.get('messages')
 
             try:


### PR DESCRIPTION
fixed the line where it checks if stream is requested. I made the change because before it ignored what the user typed because there was a invalid conversion from the boolean to string where the if stream clause would always be true. Simple workaround :)