### PR TITLE
rename docker compose to docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,13 +137,13 @@ cd gpt4free
 4. Build the Docker image:
 
 ```bash
-docker compose build
+docker-compose build
 ```
 
 5. Start the service using Docker Compose:
 
 ```bash
-docker compose up
+docker-compose up
 ```
 
 Your server will now be running at `http://localhost:1337`. You can interact with the API or run your tests as you would normally.
@@ -151,11 +151,11 @@ Your server will now be running at `http://localhost:1337`. You can interact wit
 To stop the Docker containers, simply run:
 
 ```bash
-docker compose down
+docker-compose down
 ```
 
 > [!Note]
-> When using Docker, any changes you make to your local files will be reflected in the Docker container thanks to the volume mapping in the `docker-compose.yml` file. If you add or remove dependencies, however, you'll need to rebuild the Docker image using `docker compose build`.
+> When using Docker, any changes you make to your local files will be reflected in the Docker container thanks to the volume mapping in the `docker-compose.yml` file. If you add or remove dependencies, however, you'll need to rebuild the Docker image using `docker-compose build`.
 
 ## 💡 Usage
 


### PR DESCRIPTION
Docker compose is a separate binary called `docker-compose` and is not a command of `docker` itself.