### PR TITLE
Add back crutch of incorrect responses to ChatBase

### DIFF
--- a/g4f/Provider/ChatBase.py
+++ b/g4f/Provider/ChatBase.py
@@ -12,6 +12,8 @@ class ChatBase(AsyncGeneratorProvider):
     supports_message_history = True
     working = True
     jailbreak = True
+    list_incorrect_responses = ["support@chatbase",
+                                "about Chatbase"]
 
     @classmethod
     async def create_async_generator(
@@ -53,6 +55,9 @@ class ChatBase(AsyncGeneratorProvider):
                 response_data = ""
                 async for stream in response.content.iter_any():
                     response_data += stream.decode()
+                    for incorrect_response in cls.list_incorrect_responses:
+                        if incorrect_response in response_data:
+                            raise RuntimeError("Incorrect response")
                     yield stream.decode()
 
     @classmethod


### PR DESCRIPTION
70% of responses content order to contact support instead of answer. It must not be treated as normal answer and raise ValueError.