### PR TITLE
Fix readme example to run interference API from repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ g4f api
 or
 
 ```sh
-python -m g4f.api
+python -m g4f.api.run
 ```
 
 ```python


### PR DESCRIPTION
Fix readme example to run interference API from repo.

Running `python -m g4f.api` throws the error:
_No module named g4f.api.__main__; 'g4f.api' is a package and cannot be directly executed_

Adding the '.run' at the end of the command solves the problem.
`python -m g4f.api.run`

Below is an example.

![g4f-run](https://github.com/xtekky/gpt4free/assets/13617054/a84fd0dc-51b6-4e20-b812-c28e2ec363fd)
