### PR TITLE
HuggingChat: Strip leading whitespace from the first token in the stream

### DIFF
--- a/g4f/Provider/needs_auth/HuggingChat.py
+++ b/g4f/Provider/needs_auth/HuggingChat.py
@@ -47,12 +47,17 @@ class HuggingChat(AsyncGeneratorProvider):
                 "web_search": web_search
             }
             async with session.post(f"{cls.url}/conversation/{conversation_id}", json=send, proxy=proxy) as response:
+                first_token = True
                 async for line in response.content:
                     line = json.loads(line[:-1])
                     if "type" not in line:
                         raise RuntimeError(f"Response: {line}")
                     elif line["type"] == "stream":
-                        yield line["token"]
+                        token = line["token"]
+                        if first_token:
+                            token = token.lstrip()
+                            first_token = False
+                        yield token
                     elif line["type"] == "finalAnswer":
                         break
                 


### PR DESCRIPTION
For some reason first token from the stream on HuggingChat always starts with a whitespace. This commit strips the leading whitespace from the first token in the stream to fix this issue.