### PR TITLE
Fix #1353: Remove import of deprecated NoowAi provider

### DIFF
--- a/g4f/Provider/__init__.py
+++ b/g4f/Provider/__init__.py
@@ -39,7 +39,6 @@ from .Koala           import Koala
 from .Liaobots        import Liaobots
 from .Llama2          import Llama2
 from .MyShell         import MyShell
-from .NoowAi          import NoowAi
 from .OnlineGpt       import OnlineGpt
 from .Opchatgpts      import Opchatgpts
 from .PerplexityAi    import PerplexityAi


### PR DESCRIPTION
closes #1353 