### PR TITLE
Fix Bing provider Cookie issue

### DIFF
--- a/g4f/Provider/Bing.py
+++ b/g4f/Provider/Bing.py
@@ -439,8 +439,7 @@ async def stream_generate(
     ):
     async with ClientSession(
             timeout=ClientTimeout(total=900),
-            cookies=cookies,
-            headers=Defaults.headers,
+            headers=Defaults.headers if not cookies else {**Defaults.headers, "Cookie": "; ".join(f"{k}={v}" for k, v in cookies.items())},
         ) as session:
         conversation = await create_conversation(session, tone, image, proxy)
         try:


### PR DESCRIPTION
This is a fix for an Issue that causes this error when using Bing Provider.

```
aiohttp.client_exceptions.ContentTypeError: 0, message='Attempt to decode JSON with unexpected mimetype: ', url=URL('https://www.bing.com/turing/conversation/create?bundleVersion=1.1199.4') 
```

Due to the specification of the aiohttp library, double quotes are escaped when cookies are passed as-is as arguments.
Therefore, it is necessary to assign the cookie directly to the Header.

Good
```
  "headers": {
    "Cookie": "SRCHD=AF=NOFORM; PPLState=1; KievRPSSecAuth=; SUID=; SRCHUSR=; SRCHHPGUSR=HV=9999999999", 
  }
```

Bad
```
  "headers": {
    "Cookie": "KievRPSSecAuth=\"\"; PPLState=1; SRCHD=\"AF=NOFORM\"; SRCHHPGUSR=\"HV=9999999999\"; SRCHUSR=\"\"; SUID=\"\"", 
  }
```

This problem does not occur under normal circumstances, perhaps it occurs when a Captcha is present.