### PR TITLE
fix(typo): Fix typo in function name

### DIFF
--- a/g4f/debug.py
+++ b/g4f/debug.py
@@ -25,14 +25,14 @@ def get_version() -> str:
         pass
     raise VersionNotFoundError("Version not found")
     
-def get_lastet_version() -> str:
+def get_latest_version() -> str:
     response = get("https://pypi.org/pypi/g4f/json").json()
     return response["info"]["version"]
 
 def check_pypi_version() -> None:
     try:
         version = get_version()
-        latest_version = get_lastet_version()
+        latest_version = get_latest_version()
         if version != latest_version:
             print(f'New pypi version: {latest_version} (current: {version}) | pip install -U g4f')
     except Exception as e:

--- a/g4f/gui/server/backend.py
+++ b/g4f/gui/server/backend.py
@@ -54,7 +54,7 @@ class Backend_Api:
     def version(self):
         return {
             "version": debug.get_version(),
-            "lastet_version": debug.get_lastet_version(),
+            "lastet_version": debug.get_latest_version(),
         }
     
     def _gen_title(self):


### PR DESCRIPTION
This commit fixes a typo in the function name `get_lastet_version` in the g4f package. The function has been renamed to `get_latest_version`.