### PR TITLE
Fixed FakeGPT error caused by empty token_ids list 

### DIFF
--- a/g4f/Provider/FakeGpt.py
+++ b/g4f/Provider/FakeGpt.py
@@ -36,7 +36,7 @@ class FakeGpt(AsyncGeneratorProvider):
                 async with session.get(f"{cls.url}/api/loads", params={"t": int(time.time())}, proxy=proxy) as response:
                     response.raise_for_status()
                     list = (await response.json())["loads"]
-                    token_ids = [t["token_id"] for t in list if t["count"] == 0]
+                    token_ids = [t["token_id"] for t in list]
                 data = {
                     "token_key": random.choice(token_ids),
                     "session_password": get_random_string()


### PR DESCRIPTION
Removed the condition for filtering token_id for count 0, because count:0 is not necessarily in the list of token_ids send by the server anymore hence resulting in an empty list and causing error.

Closes #1363 