### PR TITLE
Fix module 'g4f.debug' has no attribute 'get_version'

### DIFF
--- a/g4f/api/run.py
+++ b/g4f/api/run.py
@@ -2,5 +2,5 @@ import g4f
 import g4f.api
 
 if __name__ == "__main__":
-    print(f'Starting server... [g4f v-{g4f.debug.get_version()}]')
+    print(f'Starting server... [g4f v-{g4f.version.utils.current_version}]')
     g4f.api.Api(engine = g4f, debug = True).run(ip = "0.0.0.0:10000")


### PR DESCRIPTION
Fix error `module 'g4f.debug' has no attribute 'get_version' ` 

that occurs when running the API directly from the local repository using `python -m g4f.api.run`.

![image](https://github.com/xtekky/gpt4free/assets/13617054/dea6145f-5cd6-4055-91aa-d6e23f36f165)
