### PR TITLE
Update openai example

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,17 +369,19 @@ python -m g4f.api.run
 ```
 
 ```python
-import openai
+from openai import OpenAI
 
-# Set your Hugging Face token as the API key if you use embeddings
-# If you don't use embeddings, leave it empty
-openai.api_key = "YOUR_HUGGING_FACE_TOKEN"  # Replace with your actual token
+client = OpenAI(
+    # Set your Hugging Face token as the API key if you use embeddings
+    api_key="YOUR_HUGGING_FACE_TOKEN",
 
-# Set the API base URL if needed, e.g., for a local development environment
-openai.api_base = "http://localhost:1337/v1"
+    # Set the API base URL if needed, e.g., for a local development environment
+    base_url="http://localhost:1337/v1"
+)
+
 
 def main():
-    chat_completion = openai.ChatCompletion.create(
+    chat_completion = client.chat.completions.create(
         model="gpt-3.5-turbo",
         messages=[{"role": "user", "content": "write a poem about a tree"}],
         stream=True,
@@ -391,9 +393,10 @@ def main():
     else:
         # Streaming
         for token in chat_completion:
-            content = token["choices"][0]["delta"].get("content")
+            content = token.choices[0].delta.content
             if content is not None:
                 print(content, end="", flush=True)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
After the release of version 1.0.0 of the openai python package, openai.ChatCompletion is no longer supported.

This change updates the openai example to the latest version of the package.
