### PR TITLE
Replace bs4 with beautifulsoup4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,4 +26,4 @@ async-property
 undetected-chromedriver
 asyncstdlib
 async_property
-bs4
+beautifulsoup4


### PR DESCRIPTION
[`bs4`](https://pypi.org/project/bs4/) is a dummy package for [`beautifulsoup4`](https://pypi.org/project/beautifulsoup4/). Distributions usually only have `beautifulsoup4`. 