### PR TITLE
remove additional tags in Phind

### DIFF
--- a/g4f/Provider/Phind.py
+++ b/g4f/Provider/Phind.py
@@ -69,6 +69,8 @@ class Phind(AsyncGeneratorProvider):
                             pass
                         elif chunk.startswith(b"<PHIND_METADATA>") or chunk.startswith(b"<PHIND_INDICATOR>"):
                             pass
+                        elif chunk.startswith(b"<PHIND_SPAN_BEGIN>") or chunk.startswith(b"<PHIND_SPAN_END>"):
+                            pass
                         elif chunk:
                             yield chunk.decode()
                         elif new_line:


### PR DESCRIPTION
Phind added new additional tags to their reply and this commit removed them.

Example additional tags:

```
<PHIND_SPAN_BEGIN>{"id": "g30s0idmy56038rjky0i", "indicator": "Using GPT4", "parent": "qolbkr9srwccc7ir3m5f", "start": 1706418122.9927964, "end": null, "indent": 2, "children": []}</PHIND_SPAN_BEGIN><PHIND_SPAN_END>{"id": "g30s0idmy56038rjky0i", "indicator": "Using GPT4", "end": 1706418122.994516}</PHIND_SPAN_END>
```