### PR TITLE
Fix process_image to handle transparency correctly

### DIFF
--- a/g4f/image.py
+++ b/g4f/image.py
@@ -166,7 +166,7 @@ def process_image(img: Image, new_width: int, new_height: int) -> Image:
     if img.mode != "RGB":
         img.load()
         white = new_image('RGB', img.size, (255, 255, 255))
-        white.paste(img, mask=img.split()[3]) 
+        white.paste(img, mask=img.convert('RGBA').split()[-1])
         return white
     return img
 


### PR DESCRIPTION
I encountered an issue while attempting to send an image to Bing Copilot yesterday... I got the following error:
```
2024-02-10 11:29:02 gpt4free-1  | INFO:werkzeug:172.19.0.1 - - [10/Feb/2024 14:29:02] "POST /backend-api/v2/conversation HTTP/1.1" 200 -
2024-02-10 11:29:04 gpt4free-1  | ERROR:root:tuple index out of range
2024-02-10 11:29:04 gpt4free-1  | Traceback (most recent call last):
2024-02-10 11:29:04 gpt4free-1  |   File "/app/g4f/gui/server/backend.py", line 185, in _create_response_stream
2024-02-10 11:29:04 gpt4free-1  |     for chunk in ChatCompletion.create(**kwargs):
2024-02-10 11:29:04 gpt4free-1  |   File "/app/g4f/Provider/base_provider.py", line 201, in create_completion
2024-02-10 11:29:04 gpt4free-1  |     yield loop.run_until_complete(gen.__anext__())
2024-02-10 11:29:04 gpt4free-1  |   File "/home/g4f/.local/lib/python3.10/site-packages/nest_asyncio.py", line 98, in run_until_complete
2024-02-10 11:29:04 gpt4free-1  |     return f.result()
2024-02-10 11:29:04 gpt4free-1  |   File "/usr/lib/python3.10/asyncio/futures.py", line 201, in result
2024-02-10 11:29:04 gpt4free-1  |     raise self._exception.with_traceback(self._exception_tb)
2024-02-10 11:29:04 gpt4free-1  |   File "/usr/lib/python3.10/asyncio/tasks.py", line 232, in __step
2024-02-10 11:29:04 gpt4free-1  |     result = coro.send(None)
2024-02-10 11:29:04 gpt4free-1  |   File "/app/g4f/Provider/Bing.py", line 290, in stream_generate
2024-02-10 11:29:04 gpt4free-1  |     image_request = await upload_image(session, image, tone) if image else None
2024-02-10 11:29:04 gpt4free-1  |   File "/app/g4f/Provider/bing/upload_image.py", line 42, in upload_image
2024-02-10 11:29:04 gpt4free-1  |     image = process_image(image, new_width, new_height)
2024-02-10 11:29:04 gpt4free-1  |   File "/app/g4f/image.py", line 169, in process_image
2024-02-10 11:29:04 gpt4free-1  |     white.paste(img, mask=img.split()[3])
2024-02-10 11:29:04 gpt4free-1  | IndexError: tuple index out of range
```

The problem is that the image does not have an alpha channel, I searched a little about this and someone else had the same error, look here:
https://stackoverflow.com/questions/9166400/convert-rgba-png-to-rgb-with-pil#comment17950830_9459208

So, I did his sugestion: "I had to convert the PNG to RGBA first and then slice it: alpha = img.split()[-1] then use that on the background mask."

Sorry if it's not the best solution, I'm not a python guy 😭.... You can simulate the error with the NodeJS code below:
```javascript
import axios from 'axios';

await (async function() {
    const serverUrl = 'http://127.0.0.1:8080/backend-api/v2/conversation';
    const imageUrl = 'https://pbs.twimg.com/media/GDLsAj5XAAAtvV7?format=png&name=orig';

    const imageData = await axios.get(imageUrl, {
        responseType: 'arraybuffer'
    }).then(response => {
        return new File([response.data], 'image.png');       
    });

    const jsonData = {
        'provider': 'Bing',
        'messages': [
            { 'role': 'user', 'content': 'can you identify the name of each ore of this image?' }
        ]
    };
    
    var data = new FormData();
    data.append('image', imageData, imageData.name);
    data.append('json', JSON.stringify(jsonData));

    const response = await axios.post(serverUrl, data, {
        headers: { 'content-type': 'multipart/form-data' },
        responseType: 'stream'
    });

    const stream = response.data;
    const chunks = [];

    stream.on('data', data => {
        const { content } = JSON.parse(data.toString());

        chunks.push(content);
    });

    stream.on('end', () => {
        console.log(chunks.join(''));
    });
})();
```

With this PR the error does not happen anymore.