### PR TITLE
Move GeminiProChat to a new provider #1596

### DIFF
--- a/g4f/Provider/GeminiChatbotSigma.py
+++ b/g4f/Provider/GeminiChatbotSigma.py
@@ -8,8 +8,8 @@ from ..typing import AsyncResult, Messages
 from .base_provider import AsyncGeneratorProvider
 
 
-class GeminiProChat(AsyncGeneratorProvider):
-    url = "https://geminiprochat.com"
+class GeminiChatbotSigma(AsyncGeneratorProvider):
+    url = "https://gemini-chatbot-sigma.vercel.app"
     working = True
     supports_gpt_35_turbo = True
 

--- a/g4f/Provider/GeminiProChat.py
+++ b/g4f/Provider/GeminiProChat.py
@@ -8,7 +8,7 @@ from ..typing import AsyncResult, Messages
 from .base_provider import AsyncGeneratorProvider
 
 
-class GeminiChatbotSigma(AsyncGeneratorProvider):
+class GeminiProChat(AsyncGeneratorProvider):
     url = "https://gemini-chatbot-sigma.vercel.app"
     working = True
     supports_gpt_35_turbo = True
@@ -22,13 +22,13 @@ class GeminiChatbotSigma(AsyncGeneratorProvider):
         **kwargs
     ) -> AsyncResult:
         headers = {
-            "User-Agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/119.0",
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:122.0) Gecko/20100101 Firefox/122.0",
             "Accept": "*/*",
-            "Accept-Language": "de,en-US;q=0.7,en;q=0.3",
+            "Accept-Language": "en-US,en;q=0.5",
             "Accept-Encoding": "gzip, deflate, br",
             "Content-Type": "text/plain;charset=UTF-8",
-            "Referer": "https://geminiprochat.com/",
-            "Origin": "https://geminiprochat.com",
+            "Referer": "https://gemini-chatbot-sigma.vercel.app/",
+            "Origin": "https://gemini-chatbot-sigma.vercel.app",
             "Sec-Fetch-Dest": "empty",
             "Sec-Fetch-Mode": "cors",
             "Sec-Fetch-Site": "same-origin",
@@ -51,6 +51,7 @@ class GeminiChatbotSigma(AsyncGeneratorProvider):
                 async for chunk in response.content.iter_any():
                     yield chunk.decode()
                         
-def generate_signature(time: int, text: str):
-    message = f'{time}:{text}:9C4680FB-A4E1-6BC7-052A-7F68F9F5AD1F';
+def generate_signature(time: int, text: str, secret: str = ""):
+    message = f'{time}:{text}:{secret}';
     return sha256(message.encode()).hexdigest()
+    


### PR DESCRIPTION
Since GeminiProChat is down I decided to take the existing provider file and adapt it for https://gemini-chatbot-sigma.vercel.app/ which is a provider with the same backend and frontend, just a different name. That one actually works.

Merging this would close #1596 