### PR TITLE
Fix TypeError: 'Api' object is not callable

### DIFF
--- a/g4f/api/__init__.py
+++ b/g4f/api/__init__.py
@@ -115,9 +115,9 @@ class Api:
         async def completions():
             return Response(content=json.dumps({'info': 'Not working yet.'}, indent=4), media_type="application/json")
 
-    def run(self, ip):
+    def run(self, ip, use_colors : bool = False):
         split_ip = ip.split(":")
-        uvicorn.run(app=self.app, host=split_ip[0], port=int(split_ip[1]), use_colors=False)
+        uvicorn.run(app=self.app, host=split_ip[0], port=int(split_ip[1]), use_colors=use_colors)
 
 def format_exception(e: Exception, config: ChatCompletionsConfig) -> str:
     last_provider = g4f.get_last_provider(True)
@@ -130,4 +130,4 @@ def format_exception(e: Exception, config: ChatCompletionsConfig) -> str:
 def run_api(host: str = '0.0.0.0', port: int = 1337, debug: bool = False, use_colors=True) -> None:
     print(f'Starting server... [g4f v-{g4f.version.utils.current_version}]')
     app = Api(engine=g4f, debug=debug)
-    uvicorn.run(app=app, host=host, port=port, use_colors=use_colors)
+    app.run(f"{host}:{port}", use_colors=use_colors)


### PR DESCRIPTION
Run interference API from PyPi package results in a _TypeError: 'Api' object is not callable_ when attempting to make a request.

![errorAPI](https://github.com/xtekky/gpt4free/assets/13617054/ac96a145-4cdc-4c94-83a7-d5a9afa53231)

The adjustment ensures that the bug is fixed while keeping the same functionalities, including the _use_colors_ or run interference API from repo

![done](https://github.com/xtekky/gpt4free/assets/13617054/7afa8e13-19a7-479f-8348-45e3b0569933)
