### PR TITLE
~ gui system prompt spacing

### DIFF
--- a/g4f/gui/client/css/style.css
+++ b/g4f/gui/client/css/style.css
@@ -1013,7 +1013,7 @@ a:-webkit-any-link {
     font-size: 15px;
     width: 100%;
     color: var(--colour-3);
-    height: 50px;
+    height: 59px;
     outline: none;
     padding: var(--inner-gap) var(--section-gap);
     resize: vertical;


### PR DESCRIPTION
The spacing was misaligned, a little increase in the width fixes it

before:
<img width="630" alt="image" src="https://github.com/xtekky/gpt4free/assets/98614666/940879bf-6b0d-4775-bb64-dc964c95aa80">

after:
<img width="631" alt="image" src="https://github.com/xtekky/gpt4free/assets/98614666/67072aff-190e-4d66-a378-fed1af19bb30">

on chrome, mac air m2