### PR TITLE
feat: docker add arm64 support

### DIFF
--- a/.github/workflows/publish-workflow.yaml
+++ b/.github/workflows/publish-workflow.yaml
@@ -11,6 +11,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Get metadata for Docker
         id: metadata
@@ -38,6 +42,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM selenium/node-chrome
+FROM seleniarm/node-chromium
 
 ARG G4F_VERSION
 ARG G4F_USER=g4f
@@ -81,7 +81,7 @@ WORKDIR $G4F_DIR
 COPY requirements.txt $G4F_DIR
 
 # Upgrade pip for the latest features and install the project's Python dependencies.
-RUN pip install --upgrade pip && pip install -r requirements.txt
+RUN pip install --break-system-packages --upgrade pip && pip install --break-system-packages -r requirements.txt
 
 # Copy the entire package into the container.
 ADD --chown=$G4F_USER:$G4F_USER g4f $G4F_DIR/g4f


### PR DESCRIPTION
When I started this project with Docker on my MacBook Pro M1 chip, I found that Chrome would get an error, probably because Chrome only supports the 4K Pagesize AMD64 platform, not Arm64. After investigating, the current `seleniumnode/chrome` image used by the dockerfile only supports amd64. The selenium community is already pushing for the arm64 merge https://github.com/SeleniumHQ/docker-selenium/issues/1847. For the time being, we are using the base image `seleniarm/node-chromium` that supports both arm64 and amd64 to ensure dual-architecture support. 

Currently, arm64 images support Pagesize 4k kernels, and there is no support plan for Pagesize 64k in the short term (Chrome does not support 64k Pagezie).