### PR TITLE
Align Model Naming with Provider Standards for ChatCompletion Compatibility

### DIFF
--- a/g4f/Provider/Liaobots.py
+++ b/g4f/Provider/Liaobots.py
@@ -17,7 +17,7 @@ models = {
         "tokenLimit": 14000,
         "context": "16K",
     },
-    "gpt-4-turbo-preview": {
+    "gpt-4-turbo": {
         "id": "gpt-4-turbo-preview",
         "name": "GPT-4-Turbo",
         "maxLength": 260000,

--- a/g4f/Provider/Liaobots.py
+++ b/g4f/Provider/Liaobots.py
@@ -24,7 +24,7 @@ models = {
         "tokenLimit": 126000,
         "context": "128K",
     },
-    "gpt-4-plus": {
+    "gpt-4": {
         "id": "gpt-4-plus",
         "name": "GPT-4-Plus",
         "maxLength": 130000,


### PR DESCRIPTION
Changes proposed:
- Rename `gpt-4-plus` to `gpt-4` in Liaobots to align with the naming conventions of other providers' models.
- Retain the `id` and `name` fields as "gpt-4-plus" to match the external service's API endpoints.

