### PR TITLE
Don't give up searching for accessToken in HAR file

### DIFF
--- a/g4f/Provider/openai/har_file.py
+++ b/g4f/Provider/openai/har_file.py
@@ -54,7 +54,10 @@ def readHAR():
                 if arkPreURL in v['request']['url']:
                     chatArks.append(parseHAREntry(v))
                 elif v['request']['url'] == sessionUrl:
-                    accessToken = json.loads(v["response"]["content"]["text"]).get("accessToken")
+                    try:
+                        accessToken = json.loads(v["response"]["content"]["text"]).get("accessToken")
+                    except KeyError:
+                        continue
                     cookies = {c['name']: c['value'] for c in v['request']['cookies']}
     if not accessToken:
         raise NoValidHarFileError("No accessToken found in .har files")


### PR DESCRIPTION
Addresses the following uncaught exception:

```py
ERROR:root:'text'
Traceback (most recent call last):
  File "/app/g4f/gui/server/api.py", line 229, in _create_response_stream
    for chunk in ChatCompletion.create(**kwargs):
  File "/app/g4f/providers/base_provider.py", line 206, in create_completion
    yield loop.run_until_complete(await_callback(gen.__anext__))
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/asyncio/base_events.py", line 653, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/app/g4f/providers/base_provider.py", line 202, in await_callback
    return await callback()
           ^^^^^^^^^^^^^^^^
  File "/app/g4f/Provider/needs_auth/OpenaiChat.py", line 360, in create_async_generator
    arkose_token, api_key, cookies = await getArkoseAndAccessToken(proxy)
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/g4f/Provider/openai/har_file.py", line 126, in getArkoseAndAccessToken
    chatArk, accessToken, cookies = readHAR()
                                    ^^^^^^^^^
  File "/app/g4f/Provider/openai/har_file.py", line 54, in readHAR
    accessToken = json.loads(v["response"]["content"]["text"]).get("accessToken")
                             ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
KeyError: 'text'
```