### PR TITLE
Fixing an error that occurs due to a missing comma in async client

### DIFF
--- a/g4f/client/async_client.py
+++ b/g4f/client/async_client.py
@@ -144,7 +144,7 @@ class Completions():
             proxy=self.client.get_proxy() if proxy is None else proxy,
             max_tokens=max_tokens,
             stop=stop,
-            api_key=self.client.api_key if api_key is None else api_key
+            api_key=self.client.api_key if api_key is None else api_key,
             **kwargs
         )
         response = iter_response(response, stream, response_format, max_tokens, stop)


### PR DESCRIPTION
Fixing this error:
```
unsupported operand type(s) for ** or pow(): 'str' and 'dict'
```