### PR TITLE
Improve compatibility of openai-node

### DIFF
--- a/g4f/api/__init__.py
+++ b/g4f/api/__init__.py
@@ -120,7 +120,10 @@ class Api:
                 'created': 0,
                 'owned_by': model.base_provider
             } for model_id, model in model_list.items()]
-            return JSONResponse(model_list)
+            return JSONResponse({
+                "object": "list",
+                "data": model_list,
+            })
 
         @self.app.get("/v1/models/{model_name}")
         async def model_info(model_name: str):

--- a/g4f/client/stubs.py
+++ b/g4f/client/stubs.py
@@ -78,12 +78,14 @@ class ChatCompletionDelta(Model):
     def __init__(self, content: Union[str, None]):
         if content is not None:
             self.content = content
+            self.role = "assistant"
 
     def to_json(self):
         return self.__dict__
 
 class ChatCompletionDeltaChoice(Model):
     def __init__(self, delta: ChatCompletionDelta, finish_reason: Union[str, None]):
+        self.index = 0
         self.delta = delta
         self.finish_reason = finish_reason
 

--- a/g4f/typing.py
+++ b/g4f/typing.py
@@ -14,7 +14,7 @@ else:
 SHA256 = NewType('sha_256_hash', str)
 CreateResult = Iterator[str]
 AsyncResult = AsyncIterator[str]
-Messages = List[Dict[str, str]]
+Messages = List[Dict[str, Union[str,List[Dict[str,Union[str,Dict[str,str]]]]]]]
 Cookies = Dict[str, str]
 ImageType = Union[str, bytes, IO, Image, None]
 


### PR DESCRIPTION
When using the openai-node library,
the following error occurs in the code below due to a missing implementation of OpenAI's API.
```javascript
import OpenAI from 'openai';

const openai = new OpenAI({
    apiKey: "gpt4free",
    baseURL: "http:///gpt4free-api.url/v1",
});

stream = await openai.beta.chat.completions
    .stream({
      "model":"gpt-3.5-turbo",
      "stream":true,
      "messages":[{"role":"user","content":"Hello!"}],
    });

for await (const chunk of stream) {
    console.log(chunk.choices[0]?.delta?.content || '');
}
```
```
OpenAIError: stream ended without producing a ChatCompletionMessage with role=assistant
```