### PR TITLE
Update base_provider: Do not nest patch uvloop loop.

### DIFF
--- a/g4f/providers/base_provider.py
+++ b/g4f/providers/base_provider.py
@@ -30,6 +30,13 @@ if sys.platform == 'win32':
 def get_running_loop(check_nested: bool) -> Union[AbstractEventLoop, None]:
     try:
         loop = asyncio.get_running_loop()
+        # Do not patch uvloop loop because its incompatible.
+        try:
+            import uvloop
+            if isinstance(loop, uvloop.Loop):
+                return
+        except (ImportError, ModuleNotFoundError):
+            pass
         if check_nested and not hasattr(loop.__class__, "_nest_patched"):
             try:
                 import nest_asyncio

--- a/g4f/providers/base_provider.py
+++ b/g4f/providers/base_provider.py
@@ -34,7 +34,7 @@ def get_running_loop(check_nested: bool) -> Union[AbstractEventLoop, None]:
         try:
             import uvloop
             if isinstance(loop, uvloop.Loop):
-                return
+                return loop
         except (ImportError, ModuleNotFoundError):
             pass
         if check_nested and not hasattr(loop.__class__, "_nest_patched"):


### PR DESCRIPTION
Check if currently running loop is uvloop patched and do not nest patch it due to incompatibility between the two.

error stack:
```python
  File "/usr/local/lib/python3.11/site-packages/g4f/client/client.py", line 114, in create
    return response if stream else next(response)
                                   ^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/g4f/client/client.py", line 53, in iter_append_model_and_provider
    for chunk in response:
  File "/usr/local/lib/python3.11/site-packages/g4f/client/client.py", line 28, in iter_response
    for idx, chunk in enumerate(response):
  File "/usr/local/lib/python3.11/site-packages/g4f/providers/retry_provider.py", line 95, in create_completion
    raise_exceptions(exceptions)
  File "/usr/local/lib/python3.11/site-packages/g4f/providers/retry_provider.py", line 231, in raise_exceptions
    raise RetryProviderError("RetryProvider failed:\n" + "\n".join([
g4f.errors.RetryProviderError: RetryProvider failed:
Cnote: ValueError: Can't patch loop of type <class 'uvloop.Loop'>
You: ValueError: Can't patch loop of type <class 'uvloop.Loop'>
Feedough: ValueError: Can't patch loop of type <class 'uvloop.Loop'>
OpenaiChat: ValueError: Can't patch loop of type <class 'uvloop.Loop'>
ChatgptNext: ValueError: Can't patch loop of type <class 'uvloop.Loop'>
Koala: ValueError: Can't patch loop of type <class 'uvloop.Loop'>
Aichatos: ValueError: Can't patch loop of type <class 'uvloop.Loop'>
FreeGpt: ValueError: Can't patch loop of type <class 'uvloop.Loop'>
```