### PR TITLE
add gemini-1.5-flash to GeminiPro provider

### DIFF
--- a/g4f/Provider/GeminiPro.py
+++ b/g4f/Provider/GeminiPro.py
@@ -18,7 +18,7 @@ class GeminiPro(AsyncGeneratorProvider, ProviderModelMixin):
     needs_auth = True
     default_model = "gemini-1.5-pro-latest"
     default_vision_model = default_model
-    models = [default_model, "gemini-pro", "gemini-pro-vision"]
+    models = [default_model, "gemini-pro", "gemini-pro-vision", "gemini-1.5-flash"]
 
     @classmethod
     async def create_async_generator(


### PR DESCRIPTION
Adding gemini-1.5-flash on GeminiPro provider.

Google is deprecating Gemini 1.0 Pro Vision model suggesting to use Gemini 1.5 Flash or Gemini 1.5 Pro as reported [here](https://ai.google.dev/gemini-api/docs/models/gemini)

`Note: The Gemini 1.0 Pro Vision model will be deprecated from Google AI services and tools as of June 12, 2024 (does not apply to Vertex AI). You'll be able to use Gemini 1.0 Pro Vision until July 12, 2024. After July 12, saved prompts using Gemini 1.0 Pro Vision in Google AI Studio will switch to using Gemini 1.5 Flash. API calls that specify Gemini 1.0 Pro Vision will fail so we recommend switching to Gemini 1.5 Flash or 1.5 Pro.`

