### PR TITLE
ChatGPT Reverse Engineering Update: Adapting to Arkose Detection Changes

### DIFF
--- a/g4f/Provider/needs_auth/OpenaiChat.py
+++ b/g4f/Provider/needs_auth/OpenaiChat.py
@@ -406,7 +406,12 @@ class OpenaiChat(AsyncGeneratorProvider, ProviderModelMixin):
                     cls._update_request_args(session)
                     await raise_for_status(response)
                     requirements = await response.json()
-                    need_arkose = requirements.get("arkose", {}).get("required")
+                    text_data = json.loads(requirements.get("text", "{}")) 
+                    need_arkose = text_data.get("turnstile", {}).get("required", False)
+                    if need_arkose:
+                        arkose_token = text_data.get("turnstile", {}).get("dx")
+                    else:
+                        need_arkose = requirements.get("arkose", {}).get("required", False) 
                     chat_token = requirements["token"]        
 
                 if need_arkose and arkose_token is None:


### PR DESCRIPTION
## ChatGPT Reverse Engineering Update: Adapting to Arkose Detection Changes

This pull request addresses a recent change in ChatGPT's backend that modified the way Arkose detection is signaled in API responses.


### Problem:

Previously, the code relied on checking the `requirements["arkose"]["required"]` flag to determine if an Arkose token was necessary. However, ChatGPT has adjusted its API, and this information is now nested within a `text` key within the `requirements` object. This change breaks the existing Arkose detection logic.

### Solution:

This PR modifies the `create_async_generator` function to correctly interpret the updated Arkose detection mechanism.

**Here's how the code is updated:**

**Original code:**

```python
                   as response:
                    cls._update_request_args(session)
                    await raise_for_status(response)
                    requirements = await response.json()
                    need_arkose = requirements.get("arkose", {}).get("required")
                    chat_token = requirements["token"]      
```

**Updated code:**

```python
                    as response:
                    cls._update_request_args(session)
                    await raise_for_status(response)
                    requirements = await response.json()
                    #Get from text
                    text_data = json.loads(requirements.get("text", "{}")) 
                    need_arkose = text_data.get("turnstile", {}).get("required", False)
                    if need_arkose:
                        arkose_token = text_data.get("turnstile", {}).get("dx")
                    else:
                        need_arkose = requirements.get("arkose", {}).get("required", False) 
                    chat_token = requirements["token"]
```

Instead of directly accessing `requirements["arkose"]`, the updated code:

1. Retrieves the data from the `text` key and parses it as JSON.
2. Checks for the presence of the `turnstile` key within the parsed JSON.
3. If `turnstile` exists, it further checks if the `required` flag is set to `True`.
4. If the `required` flag is `True`, the Arkose token is extracted from the `dx` key within `turnstile`.
5. For backward compatibility, it also checks the old `arkose` key in case it's still present.

This change ensures that the code can adapt to both the old and new API responses, allowing it to accurately detect Arkose challenges and proceed with the authentication process.


This pull request is related to this issue:
https://github.com/xtekky/gpt4free/issues/2087