### PR TITLE
Duck Duck Go Async Text Search Bug Fix

### DIFF
--- a/g4f/gui/server/internet.py
+++ b/g4f/gui/server/internet.py
@@ -101,7 +101,7 @@ async def search(query: str, n_results: int = 5, max_words: int = 2500, add_text
         raise MissingRequirementsError('Install "duckduckgo-search" and "beautifulsoup4" package')
     async with AsyncDDGS() as ddgs:
         results = []
-        for result in await ddgs.text(
+        for result in  await ddgs.atext(
                 query,
                 region="wt-wt",
                 safesearch="moderate",


### PR DESCRIPTION
Fix DDG web search 'await' expression error in Python 3.12.6

- Resolve "object list can't be used in 'await' expression" error 
https://github.com/xtekky/gpt4free/issues/2236

## Fix DDG Web Search Error in Python 3.12.6

### Bug Description
When attempting to perform a web search using DuckDuckGo (DDG), an error occurs:
"Couldn't do web search: object list can't be used in 'await' expression"

### Solution
ddgs.text changed to ddgs.atext for supporting await

### Changes Made
