### PR TITLE
Add support for CORS preflight OPTIONS requests (#2006)

### DIFF
--- a/g4f/api/__init__.py
+++ b/g4f/api/__init__.py
@@ -12,6 +12,7 @@ from fastapi.security import APIKeyHeader
 from starlette.exceptions import HTTPException
 from starlette.status import HTTP_422_UNPROCESSABLE_ENTITY, HTTP_401_UNAUTHORIZED, HTTP_403_FORBIDDEN
 from fastapi.encoders import jsonable_encoder
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from typing import Union, Optional
 
@@ -24,6 +25,13 @@ from g4f.cookies import read_cookie_files
 def create_app():
     app = FastAPI()
     api = Api(app)
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origin_regex=".*",
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
     api.register_routes()
     api.register_authorization()
     api.register_validation_exception_handler()


### PR DESCRIPTION
**Issue**
Interference API server doesn't support CORS protocol, so it can't handle **OPTIONS** preflight requests.
Issue #2006 shows a failed fetch request from browser and suggests a possible solution.
This feature is needed because local hosted browser apps can't call the API server, failing with CORS error mentioned in #2006.

**Proposed Solution**
Implement **FastAPI CORSMiddleware** handler.
 
**Info:** According to [FastAPI documentation](https://fastapi.tiangolo.com/tutorial/cors/), if allow_origins is set to ['\*'], credentials (Cookies, Authorization headers...) are not allowed, so origins must be specified to comply with [fetch() Browser standard](https://fetch.spec.whatwg.org/#cors-protocol-and-credentials).
So I follow this alternative solution [Puzzling  error with FastAPI's CORS middleware - StackOverflow](https://stackoverflow.com/a/68942988)
and use **allow_origin_regex=".*"** instead, which sets a correct Access-Control-Allow-Origin header.

