### PR TITLE
Fix Clipboard copy bug (issue #2287)

### DIFF
--- a/g4f/gui/client/static/js/chat.v1.js
+++ b/g4f/gui/client/static/js/chat.v1.js
@@ -115,7 +115,10 @@ const register_message_buttons = async () => {
                 const message_el = el.parentElement.parentElement.parentElement;
                 const copyText = await get_message(window.conversation_id, message_el.dataset.index);
                
-            try {
+            try {        
+                if (!navigator.clipboard) {
+                    throw new Error("navigator.clipboard: Clipboard API unavailable.");
+                }
                 await navigator.clipboard.writeText(copyText);
             } catch (e) {
                 console.error(e);

--- a/g4f/gui/client/static/js/chat.v1.js
+++ b/g4f/gui/client/static/js/chat.v1.js
@@ -119,7 +119,7 @@ const register_message_buttons = async () => {
                 await navigator.clipboard.writeText(copyText);
             } catch (e) {
                 console.error(e);
-                console.error("Clipboard API failed! Fallback to document.exec("copy")...");
+                console.error("Clipboard API writeText() failed! Fallback to document.exec(\"copy\")...");
                 fallback_clipboard(copyText);
             }
             

--- a/g4f/gui/client/static/js/chat.v1.js
+++ b/g4f/gui/client/static/js/chat.v1.js
@@ -59,7 +59,7 @@ function filter_message(text) {
 
 function fallback_copy (text) {
     console.warn("Entering fallback_copy...")
-    var textBox = document.createElement("textbox");
+    var textBox = document.createElement("textarea");
     textBox.value = text; // Avoid scrolling to bottom
     textBox.style.top = "0";
     textBox.style.left = "0";
@@ -115,11 +115,7 @@ const register_message_buttons = async () => {
             el.dataset.click = "true";
             el.addEventListener("click", async () => {
                 const message_el = el.parentElement.parentElement.parentElement;
-            try {
                 const copyText = await get_message(window.conversation_id, message_el.dataset.index);
-            } catch(e) {
-                console.error(e);
-            };
                
             try {
                 console.warn("copyText type: ", typeof copyText)

--- a/g4f/gui/client/static/js/chat.v1.js
+++ b/g4f/gui/client/static/js/chat.v1.js
@@ -57,6 +57,27 @@ function filter_message(text) {
     )
 }
 
+function fallback_copy (text) {
+    console.warn("Entering fallback_copy...")
+    var textBox = document.createElement("textbox");
+    textBox.value = text; // Avoid scrolling to bottom
+    textBox.style.top = "0";
+    textBox.style.left = "0";
+    textBox.style.position = "fixed";
+    document.body.appendChild(textBox);
+    textBox.focus();
+    textBox.select();
+    try {
+        var success = document.execCommand('copy');
+        var msg = success ? 'succeeded' : 'failed';
+        console.log('Fallback: Copying text command ' + msg);
+    } catch (err) {
+        console.error('Fallback: Unable to copy', err);
+    };
+    document.body.removeChild(textBox);
+    
+}
+
 hljs.addPlugin(new CopyButtonPlugin());
 let typesetPromise = Promise.resolve();
 const highlight = (container) => {
@@ -100,6 +121,37 @@ const register_message_buttons = async () => {
             })
         }
     });
+
+
+    document.querySelectorAll(".message .fa-clipboard").forEach(async (el) => {
+        if (!("click" in el.dataset)) {
+            el.dataset.click = "true";
+            el.addEventListener("click", async () => {
+                const message_el = el.parentElement.parentElement.parentElement;
+            try {
+                const copyText = await get_message(window.conversation_id, message_el.dataset.index);
+            } catch(e) {
+                console.error(e);
+            };
+               
+            try {
+                console.warn("copyText type: ", typeof copyText)
+                console.warn("Current Text: " + copyText);
+                await navigator.clipboard.writeText(copyText);
+            } catch (e) {
+                console.error("Clipboard API failed!") 
+                console.error(e);
+                fallback_copy(copyText);
+            };
+            
+                el.classList.add("clicked");
+                setTimeout(() => el.classList.remove("clicked"), 1000);
+            })
+        }
+    });
+
+
+    
     document.querySelectorAll(".message .fa-volume-high").forEach(async (el) => {
         if (!("click" in el.dataset)) {
             el.dataset.click = "true";

--- a/g4f/gui/client/static/js/chat.v1.js
+++ b/g4f/gui/client/static/js/chat.v1.js
@@ -57,10 +57,9 @@ function filter_message(text) {
     )
 }
 
-function fallback_copy (text) {
-    console.warn("Entering fallback_copy...")
+function fallback_clipboard (text) {
     var textBox = document.createElement("textarea");
-    textBox.value = text; // Avoid scrolling to bottom
+    textBox.value = text;
     textBox.style.top = "0";
     textBox.style.left = "0";
     textBox.style.position = "fixed";
@@ -70,12 +69,11 @@ function fallback_copy (text) {
     try {
         var success = document.execCommand('copy');
         var msg = success ? 'succeeded' : 'failed';
-        console.log('Fallback: Copying text command ' + msg);
-    } catch (err) {
-        console.error('Fallback: Unable to copy', err);
-    };
+        console.log('Clipboard Fallback: Copying text command ' + msg);
+    } catch (e) {
+        console.error('Clipboard Fallback: Unable to copy', e);
+    }
     document.body.removeChild(textBox);
-    
 }
 
 hljs.addPlugin(new CopyButtonPlugin());
@@ -118,14 +116,12 @@ const register_message_buttons = async () => {
                 const copyText = await get_message(window.conversation_id, message_el.dataset.index);
                
             try {
-                console.warn("copyText type: ", typeof copyText)
-                console.warn("Current Text: " + copyText);
                 await navigator.clipboard.writeText(copyText);
             } catch (e) {
-                console.error("Clipboard API failed!") 
                 console.error(e);
-                fallback_copy(copyText);
-            };
+                console.error("Clipboard API failed! Fallback to document.exec("copy")...");
+                fallback_clipboard(copyText);
+            }
             
                 el.classList.add("clicked");
                 setTimeout(() => el.classList.remove("clicked"), 1000);
@@ -133,8 +129,6 @@ const register_message_buttons = async () => {
         }
     });
 
-
-    
     document.querySelectorAll(".message .fa-volume-high").forEach(async (el) => {
         if (!("click" in el.dataset)) {
             el.dataset.click = "true";

--- a/g4f/gui/client/static/js/chat.v1.js
+++ b/g4f/gui/client/static/js/chat.v1.js
@@ -109,19 +109,6 @@ const register_message_buttons = async () => {
             })
         }
     });
-    document.querySelectorAll(".message .fa-clipboard").forEach(async (el) => {
-        if (!("click" in el.dataset)) {
-            el.dataset.click = "true";
-            el.addEventListener("click", async () => {
-                const message_el = el.parentElement.parentElement.parentElement;
-                const copyText = await get_message(window.conversation_id, message_el.dataset.index);
-                navigator.clipboard.writeText(copyText);
-                el.classList.add("clicked");
-                setTimeout(() => el.classList.remove("clicked"), 1000);
-            })
-        }
-    });
-
 
     document.querySelectorAll(".message .fa-clipboard").forEach(async (el) => {
         if (!("click" in el.dataset)) {

--- a/g4f/gui/client/static/js/highlightjs-copy.min.js
+++ b/g4f/gui/client/static/js/highlightjs-copy.min.js
@@ -16,16 +16,14 @@ class CopyButtonPlugin {
         el.parentElement.appendChild(button);
         el.parentElement.style.setProperty("--hljs-theme-background", window.getComputedStyle(el).backgroundColor);
         button.onclick = async () => {
-            if (!navigator.clipboard) {
-                console.error("navigator.clipboard: Clipboard API unavailable.")
-                return;
-            }
             let newText = text;
             if (hook && typeof hook === "function") {
                 newText = hook(text, el) || text
             }
-
-            try {
+            try {            
+                if (!navigator.clipboard) {
+                    throw new Error("navigator.clipboard: Clipboard API unavailable.");
+                }
                 await navigator.clipboard.writeText(newText);
             } catch (e) {
                 console.error(e);

--- a/g4f/gui/client/static/js/highlightjs-copy.min.js
+++ b/g4f/gui/client/static/js/highlightjs-copy.min.js
@@ -15,13 +15,25 @@ class CopyButtonPlugin {
         el.parentElement.classList.add("hljs-copy-wrapper");
         el.parentElement.appendChild(button);
         el.parentElement.style.setProperty("--hljs-theme-background", window.getComputedStyle(el).backgroundColor);
-        button.onclick = function () {
-            if (!navigator.clipboard) return;
+        button.onclick = async () => {
+            if (!navigator.clipboard) {
+                console.error("navigator.clipboard: Clipboard API unavailable.")
+                return;
+            }
             let newText = text;
             if (hook && typeof hook === "function") {
                 newText = hook(text, el) || text
             }
-            navigator.clipboard.writeText(newText).then(function () {
+
+            try {
+                console.warn("newText type: ", typeof newText);
+                console.warn("Current Text: " + newText);
+                await navigator.clipboard.writeText(newText);
+            } catch (e) {
+                console.error("Clipboard API writeText failed!!") 
+                console.error(e);
+                fallback_copy(newText);
+            }
                 button.innerHTML = "Copied!";
                 button.dataset.copied = true;
                 let alert = Object.assign(document.createElement("div"), {
@@ -36,9 +48,11 @@ class CopyButtonPlugin {
                     el.parentElement.removeChild(alert);
                     alert = null
                 }, 2e3)
-            }).then(function () {
-                if (typeof callback === "function") return callback(newText, el)
-            })
+            }
+
+            
+            if (typeof callback === "function") return callback(newText, el);
+            
         }
-    }
+    
 }

--- a/g4f/gui/client/static/js/highlightjs-copy.min.js
+++ b/g4f/gui/client/static/js/highlightjs-copy.min.js
@@ -26,13 +26,11 @@ class CopyButtonPlugin {
             }
 
             try {
-                console.warn("newText type: ", typeof newText);
-                console.warn("Current Text: " + newText);
                 await navigator.clipboard.writeText(newText);
             } catch (e) {
-                console.error("Clipboard API writeText failed!!") 
                 console.error(e);
-                fallback_copy(newText);
+                console.error("Clipboard API writeText() failed! Fallback to document.exec(\"copy\")...");
+                fallback_clipboard(newText);
             }
                 button.innerHTML = "Copied!";
                 button.dataset.copied = true;

--- a/g4f/gui/client/static/js/highlightjs-copy.min.js
+++ b/g4f/gui/client/static/js/highlightjs-copy.min.js
@@ -1,1 +1,44 @@
-class CopyButtonPlugin{constructor(options={}){self.hook=options.hook;self.callback=options.callback}"after:highlightElement"({el,text}){let button=Object.assign(document.createElement("button"),{innerHTML:"Copy",className:"hljs-copy-button"});button.dataset.copied=false;el.parentElement.classList.add("hljs-copy-wrapper");el.parentElement.appendChild(button);el.parentElement.style.setProperty("--hljs-theme-background",window.getComputedStyle(el).backgroundColor);button.onclick=function(){if(!navigator.clipboard)return;let newText=text;if(hook&&typeof hook==="function"){newText=hook(text,el)||text}navigator.clipboard.writeText(newText).then(function(){button.innerHTML="Copied!";button.dataset.copied=true;let alert=Object.assign(document.createElement("div"),{role:"status",className:"hljs-copy-alert",innerHTML:"Copied to clipboard"});el.parentElement.appendChild(alert);setTimeout(()=>{button.innerHTML="Copy";button.dataset.copied=false;el.parentElement.removeChild(alert);alert=null},2e3)}).then(function(){if(typeof callback==="function")return callback(newText,el)})}}}
+class CopyButtonPlugin {
+    constructor(options = {}) {
+        self.hook = options.hook;
+        self.callback = options.callback
+    }
+    "after:highlightElement"({
+        el,
+        text
+    }) {
+        let button = Object.assign(document.createElement("button"), {
+            innerHTML: "Copy",
+            className: "hljs-copy-button"
+        });
+        button.dataset.copied = false;
+        el.parentElement.classList.add("hljs-copy-wrapper");
+        el.parentElement.appendChild(button);
+        el.parentElement.style.setProperty("--hljs-theme-background", window.getComputedStyle(el).backgroundColor);
+        button.onclick = function () {
+            if (!navigator.clipboard) return;
+            let newText = text;
+            if (hook && typeof hook === "function") {
+                newText = hook(text, el) || text
+            }
+            navigator.clipboard.writeText(newText).then(function () {
+                button.innerHTML = "Copied!";
+                button.dataset.copied = true;
+                let alert = Object.assign(document.createElement("div"), {
+                    role: "status",
+                    className: "hljs-copy-alert",
+                    innerHTML: "Copied to clipboard"
+                });
+                el.parentElement.appendChild(alert);
+                setTimeout(() => {
+                    button.innerHTML = "Copy";
+                    button.dataset.copied = false;
+                    el.parentElement.removeChild(alert);
+                    alert = null
+                }, 2e3)
+            }).then(function () {
+                if (typeof callback === "function") return callback(newText, el)
+            })
+        }
+    }
+}

--- a/g4f/version.py
+++ b/g4f/version.py
@@ -76,6 +76,7 @@ class VersionUtils:
 
         # Read from docker environment
         version = environ.get("G4F_VERSION")
+        version = "0.3.3.6"
         if version:
             return version
 

--- a/g4f/version.py
+++ b/g4f/version.py
@@ -76,12 +76,10 @@ class VersionUtils:
 
         # Read from docker environment
         version = environ.get("G4F_VERSION")
-        version = "0.3.3.6"
         if version:
             return version
 
-        # Read from git repository
-        try:
+        # Read from git repository        try:
             command = ["git", "describe", "--tags", "--abbrev=0"]
             return check_output(command, text=True, stderr=PIPE).strip()
         except CalledProcessError:

--- a/g4f/version.py
+++ b/g4f/version.py
@@ -79,7 +79,8 @@ class VersionUtils:
         if version:
             return version
 
-        # Read from git repository        try:
+        # Read from git repository
+        try:
             command = ["git", "describe", "--tags", "--abbrev=0"]
             return check_output(command, text=True, stderr=PIPE).strip()
         except CalledProcessError:


### PR DESCRIPTION
**Issue**
**Clipboard API** may fail if web page is not deemed a **Secure Context**,  causing issue #2287 [MDN Clipboard documentation](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API#security_considerations). 
[This MDN page](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) claims **localhost** origins are deemed secure, but decision may involve other [environment factors](https://w3c.github.io/webappsec-secure-contexts/#localhost) so it can't be guaranteed.

**Proposed Solution**
- Add error checking to **Clipboard API** and fallback to `browser.exec("copy")` if required.
- Use async syntax in **highlight.js** copy plugin

**Info:** There are two copy buttons. One of them uses **highlight.js** copy plugin, so I will open an issue there.

