### PR TITLE
Tiny handler for unexpected finishReason of GeminiPro provider

### DIFF
--- a/g4f/Provider/GeminiPro.py
+++ b/g4f/Provider/GeminiPro.py
@@ -104,4 +104,8 @@ class GeminiPro(AsyncGeneratorProvider, ProviderModelMixin):
                             lines.append(chunk)
                 else:
                     data = await response.json()
-                    yield data["candidates"][0]["content"]["parts"][0]["text"]
+                    candidate = data["candidates"][0]
+                    if candidate["finishReason"] == "STOP":
+                        yield candidate["content"]["parts"][0]["text"]
+                    else:
+                        yield candidate["finishReason"] + ' ' + candidate["safetyRatings"]


### PR DESCRIPTION
Normally response has property 'finishReason' equal to 'STOP' and non-None 'content' property. However, if request to Gemini models does not fit Google's policies, returned response does not contain 'content' property and server returns status code 500 trying to find property 'parts' of None type.
Example `data['candidates'][0]`:
```
{
    'finishReason': 'SAFETY',
    'index': 0,
    'safetyRatings': [
        {'category': 'HARM_CATEGORY_SEXUALLY_EXPLICIT', 'probability': 'NEGLIGIBLE'},
        {'category': 'HARM_CATEGORY_HATE_SPEECH', 'probability': 'MEDIUM'},
        {'category': 'HARM_CATEGORY_HARASSMENT', 'probability': 'MEDIUM'},
        {'category': 'HARM_CATEGORY_DANGEROUS_CONTENT', 'probability': 'NEGLIGIBLE'}
]}
```