### PR TITLE
FIX: Bug fix for flux-pro aka flux-schnell

### DIFF
--- a/g4f/Provider/Airforce.py
+++ b/g4f/Provider/Airforce.py
@@ -36,7 +36,7 @@ class Airforce(AsyncGeneratorProvider, ProviderModelMixin):
 
     default_model = "gpt-4o-mini"
     default_image_model = "flux"
-    additional_models_imagine = ["stable-diffusion-xl-base", "stable-diffusion-xl-lightning", "Flux-1.1-Pro"]
+    additional_models_imagine = ["stable-diffusion-xl-base", "stable-diffusion-xl-lightning", "flux-1.1-pro"]
 
     @classmethod
     def get_models(cls):
@@ -86,7 +86,7 @@ class Airforce(AsyncGeneratorProvider, ProviderModelMixin):
         ### imagine ###
         "sdxl": "stable-diffusion-xl-base",
         "sdxl": "stable-diffusion-xl-lightning", 
-        "flux-pro": "Flux-1.1-Pro",
+        "flux-pro": "flux-1.1-pro",
     }
 
     @classmethod


### PR DESCRIPTION
https://api.airforce/imagine2?model=flux-4o

https://api.airforce/imagine2?model=flux-schnell 
and
https://api.airforce/imagine2?model=flux-1.1-pro

all generate same images but "Flux-1.1-Pro" doesnt work