### PR TITLE
Fix Armv7 docker image

### DIFF
--- a/docker/Dockerfile-slim
+++ b/docker/Dockerfile-slim
@@ -26,6 +26,7 @@ USER $G4F_USER_ID
 WORKDIR $G4F_DIR
 
 ENV HOME /home/$G4F_USER
+ENV PATH "${HOME}/.local/bin:${PATH}"
 
 # Create app dir and copy the project's requirements file into it
 RUN mkdir -p $G4F_DIR

--- a/docker/Dockerfile-slim
+++ b/docker/Dockerfile-slim
@@ -3,6 +3,7 @@ FROM python:slim-bookworm
 ARG G4F_VERSION
 ARG G4F_USER=g4f
 ARG G4F_USER_ID=1000
+ARG PYDANTIC_VERSION=1.8.1
 
 ENV G4F_VERSION $G4F_VERSION
 ENV G4F_USER $G4F_USER
@@ -11,21 +12,20 @@ ENV G4F_DIR /app
 
 RUN apt-get update && apt-get upgrade -y \
   && apt-get install -y git \
+  && apt-get install --quiet --yes --no-install-recommends \
+      build-essential \
 # Add user and user group
   && groupadd -g $G4F_USER_ID $G4F_USER \
   && useradd -rm -G sudo -u $G4F_USER_ID -g $G4F_USER_ID $G4F_USER \
   && mkdir -p /var/log/supervisor \
   && chown "${G4F_USER_ID}:${G4F_USER_ID}" /var/log/supervisor \
   && echo "${G4F_USER}:${G4F_USER}" | chpasswd \
-  && python -m pip install --upgrade pip \
-  && apt-get clean \
-  && rm --recursive --force /var/lib/apt/lists/* /tmp/* /var/tmp/*
+  && python -m pip install --upgrade pip
 
 USER $G4F_USER_ID
 WORKDIR $G4F_DIR
 
 ENV HOME /home/$G4F_USER
-ENV PATH "${HOME}/.local/bin:${PATH}"
 
 # Create app dir and copy the project's requirements file into it
 RUN mkdir -p $G4F_DIR
@@ -33,7 +33,34 @@ COPY requirements-min.txt $G4F_DIR
 COPY requirements-slim.txt $G4F_DIR
 
 # Upgrade pip for the latest features and install the project's Python dependencies.
-RUN cat requirements-slim.txt | xargs -n 1 pip install --no-cache-dir || true
+RUN pip install --no-cache-dir -r requirements-min.txt \
+  && pip install --no-cache-dir --no-binary setuptools \
+    Cython==0.29.22 \
+    setuptools \
+  # Install PyDantic
+  && pip install \
+    -vvv \
+    --no-cache-dir \
+    --no-binary :all: \
+    --global-option=build_ext \
+    --global-option=-j8 \
+    pydantic==${PYDANTIC_VERSION}
+RUN cat requirements-slim.txt | xargs -n 1 pip install --no-cache-dir || true 
+
+# Remove build packages
+RUN pip uninstall --yes \
+      Cython \
+      setuptools
+
+USER root
+
+# Clean up build deps
+RUN apt-get purge --auto-remove --yes \
+    build-essential \
+  && apt-get clean \
+  && rm --recursive --force /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+USER $G4F_USER_ID
 
 # Copy the entire package into the container.
 ADD --chown=$G4F_USER:$G4F_USER g4f $G4F_DIR/g4f

--- a/requirements-slim.txt
+++ b/requirements-slim.txt
@@ -3,7 +3,6 @@ pycryptodome
 curl_cffi>=0.6.2
 aiohttp
 certifi
-duckduckgo-search>=5.0
 nest_asyncio
 werkzeug
 pillow


### PR DESCRIPTION
#2349 @hlohaus

Current **armv7** image fails build of critical components. My image should work.

You can test a local build on **ubuntu x64** with these commands from `gpt4free` folder
```bash
#qemu setup
docker run --privileged --rm tonistiigi/binfmt --install all

docker buildx build --platform linux/arm/v7 . -f docker/Dockerfile-slim 2>&1 | tee docker_build.log
```
Check the log file for **ERROR**s.

I removed `duckduckgo-search` because `primp` can't compile. If rust is installed it fails building `boring-sys`. These bugs could be related  [link1](https://www.github.com/cloudflare/boring/issues/283) [link2](https://www.github.com/cloudflare/boring/issues/242). I recommend waiting for the [PR](https://www.github.com/cloudflare/boring/pull/223).

If you want to test the `boring-sys` bug add these lines at **line 50** and build again.

```
USER root
RUN apt install -qqy curl

USER $G4F_USER_ID
ENV PATH "${HOME}/.local/bin:${HOME}/.cargo/bin:${PATH}"
RUN curl https://sh.rustup.rs/ -sSf | bash -s -- -y
RUN pip install primp duckduckgo-search>=5.0
```