### PR TITLE
Fix docker armv7 cffi pillow

### DIFF
--- a/docker/Dockerfile-armv7
+++ b/docker/Dockerfile-armv7
@@ -13,7 +13,7 @@ ENV G4F_DIR /app
 RUN apt-get update && apt-get upgrade -y \
   && apt-get install -y git \
   && apt-get install --quiet --yes --no-install-recommends \
-      build-essential \
+      build-essential libffi-dev zlib1g-dev libjpeg-dev \
 # Add user and user group
   && groupadd -g $G4F_USER_ID $G4F_USER \
   && useradd -rm -G sudo -u $G4F_USER_ID -g $G4F_USER_ID $G4F_USER \


### PR DESCRIPTION
#2349 #2427
This should fix missing headers for **cffi** and **pillow** libraries.