### PR TITLE
Fix docker armv7 cryptography module build

### DIFF
--- a/docker/Dockerfile-armv7
+++ b/docker/Dockerfile-armv7
@@ -26,7 +26,7 @@ USER $G4F_USER_ID
 WORKDIR $G4F_DIR
 
 ENV HOME /home/$G4F_USER
-ENV PATH "${HOME}/.local/bin:${PATH}"
+ENV PATH "${HOME}/.local/bin:${HOME}/.cargo/bin:${PATH}"
 
 # Install rust toolchain
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y

--- a/docker/Dockerfile-armv7
+++ b/docker/Dockerfile-armv7
@@ -59,6 +59,7 @@ RUN pip uninstall --yes \
 USER root
 
 # Clean up build deps
+RUN rm --recursive --force "${HOME}/.rustup"
 RUN apt-get purge --auto-remove --yes \
     build-essential \
   && apt-get clean \

--- a/docker/Dockerfile-armv7
+++ b/docker/Dockerfile-armv7
@@ -11,9 +11,9 @@ ENV G4F_USER_ID $G4F_USER_ID
 ENV G4F_DIR /app
 
 RUN apt-get update && apt-get upgrade -y \
-  && apt-get install -y git \
+  && apt-get install -y git curl \
   && apt-get install --quiet --yes --no-install-recommends \
-      build-essential libffi-dev zlib1g-dev libjpeg-dev \
+      build-essential libffi-dev zlib1g-dev libjpeg-dev libssl-dev pkg-config \
 # Add user and user group
   && groupadd -g $G4F_USER_ID $G4F_USER \
   && useradd -rm -G sudo -u $G4F_USER_ID -g $G4F_USER_ID $G4F_USER \
@@ -27,6 +27,9 @@ WORKDIR $G4F_DIR
 
 ENV HOME /home/$G4F_USER
 ENV PATH "${HOME}/.local/bin:${PATH}"
+
+# Install rust toolchain
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 
 # Create app dir and copy the project's requirements file into it
 RUN mkdir -p $G4F_DIR


### PR DESCRIPTION
#2349 
This should fix **cryptography** module build error.
We can't clean up rust with `rustup self uninstall -y` because there's a bug `Value too large` [link](https://www.github.com/rust-lang/cargo/issues/8719), but we can remove `.rustup` folder.