### PR TITLE
Fix error __str__ returned non-string (type list) when using reasonin model

### DIFF
--- a/g4f/client/__init__.py
+++ b/g4f/client/__init__.py
@@ -73,7 +73,18 @@ def iter_response(
         elif isinstance(chunk, Exception):
             continue
 
-        chunk = str(chunk)
+        if isinstance(chunk, list):
+            chunk = "".join(map(str, chunk))
+        else:
+
+            temp = chunk.__str__()
+            if not isinstance(temp, str):
+                if isinstance(temp, list):
+                    temp = "".join(map(str, temp))
+                else:
+                    temp = repr(chunk)
+            chunk = temp
+            
         content += chunk
 
         if max_tokens is not None and idx + 1 >= max_tokens:


### PR DESCRIPTION
When using reasoning models like deepseek-r1 and sonar-reasoning, an error occurs. Here is my small fix.

 Using PerplexityLabs provider and sonar-reasoning model
Traceback (most recent call last):
  File "....py", line 44, in <module>
    response = client.chat.completions.create(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../.venv/lib/python3.12/site-packages/g4f/client/__init__.py", line 281, in create
    return next(response)
           ^^^^^^^^^^^^^^
  File ".../.venv/lib/python3.12/site-packages/g4f/client/__init__.py", line 117, in iter_append_model_and_provider
    for chunk in response:
                 ^^^^^^^^
  File "..../.venv/lib/python3.12/site-packages/g4f/client/__init__.py", line 76, in iter_response
    chunk = str(chunk)
            ^^^^^^^^^^
TypeError: __str__ returned non-string (type list)