### PR TITLE
Add o3-mini and Llama 3.3 70B Instruct Turbo to DDG (DuckDuckGo) provider

### DIFF
--- a/g4f/Provider/DDG.py
+++ b/g4f/Provider/DDG.py
@@ -36,12 +36,12 @@ class DDG(AsyncGeneratorProvider, ProviderModelMixin):
     supports_message_history = True
     
     default_model = "gpt-4o-mini"
-    models = [default_model, "claude-3-haiku-20240307", "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo", "mistralai/Mixtral-8x7B-Instruct-v0.1"]
+    models = [default_model, "o3-mini", "claude-3-haiku-20240307", "meta-llama/Meta-Llama-3.3-70B-Instruct-Turbo", "mistralai/Mixtral-8x7B-Instruct-v0.1"]
 
     model_aliases = {
         "gpt-4": "gpt-4o-mini",
         "claude-3-haiku": "claude-3-haiku-20240307",
-        "llama-3.1-70b": "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo",
+        "llama-3.3-70b": "meta-llama/Meta-Llama-3.3-70B-Instruct-Turbo",
         "mixtral-8x7b": "mistralai/Mixtral-8x7B-Instruct-v0.1",
     }
 

--- a/g4f/Provider/DDG.py
+++ b/g4f/Provider/DDG.py
@@ -36,12 +36,12 @@ class DDG(AsyncGeneratorProvider, ProviderModelMixin):
     supports_message_history = True
     
     default_model = "gpt-4o-mini"
-    models = [default_model, "o3-mini", "claude-3-haiku-20240307", "meta-llama/Meta-Llama-3.3-70B-Instruct-Turbo", "mistralai/Mixtral-8x7B-Instruct-v0.1"]
+    models = [default_model, "o3-mini", "claude-3-haiku-20240307", "meta-llama/Llama-3.3-70B-Instruct-Turbo", "mistralai/Mixtral-8x7B-Instruct-v0.1"]
 
     model_aliases = {
         "gpt-4": "gpt-4o-mini",
         "claude-3-haiku": "claude-3-haiku-20240307",
-        "llama-3.3-70b": "meta-llama/Meta-Llama-3.3-70B-Instruct-Turbo",
+        "llama-3.3-70b": "meta-llama/Llama-3.3-70B-Instruct-Turbo",
         "mixtral-8x7b": "mistralai/Mixtral-8x7B-Instruct-v0.1",
     }
 


### PR DESCRIPTION
This little change adds one new model - **o3-mini** - and replaces previously used Llama 3.1 70B with **Llama 3.3 70B Instruct** to the DDG provider. 