### PR TITLE
Automate refresh of har-files and auth_OpenaiChat.json on errors

### DIFF
--- a/g4f/Provider/openai/har_file.py
+++ b/g4f/Provider/openai/har_file.py
@@ -157,3 +157,11 @@ async def get_request_config(request_config: RequestConfig, proxy: str) -> Reque
     if request_config.arkose_request is not None:
         request_config.arkose_token = await sendRequest(genArkReq(request_config.arkose_request), proxy)
     return request_config
+
+async def refresh_har_files_on_error(error_code: int):
+    if error_code in [403, 422, 429]:
+        auth_file = os.path.join(get_cookies_dir(), "auth_OpenaiChat.json")
+        if os.path.exists(auth_file):
+            os.remove(auth_file)
+        request_config = RequestConfig()
+        await get_request_config(request_config, None)


### PR DESCRIPTION
Fixes #2774

Implement automated process to refresh har-files and delete `auth_OpenaiChat.json` file when errors 403, 422, or 429 occur.

* **g4f/Provider/needs_auth/OpenaiChat.py**
  - Add `handle_error` method to refresh har-files and delete `auth_OpenaiChat.json` file.
  - Modify `create_authed` method to call `handle_error` when errors 403, 422, or 429 occur.

* **g4f/requests/raise_for_status.py**
  - Modify `raise_for_status` function to trigger the automated refresh process when errors 403, 422, or 429 are detected.

* **g4f/Provider/openai/har_file.py**
  - Add `refresh_har_files_on_error` function to automatically refresh HAR files based on errors 403, 422, or 429.

