### PR TITLE
Add new providers and enhance existing provider configurations

### DIFF
--- a/docs/providers-and-models.md
+++ b/docs/providers-and-models.md
@@ -59,6 +59,7 @@ This document provides an overview of various AI providers and models, including
 |[editor.imagelabs.net](editor.imagelabs.net)|No auth required|`g4f.Provider.ImageLabs`|❌|`sdxl-turbo`|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
 |[huggingface.co/spaces](https://huggingface.co/spaces)|Optional API key|`g4f.Provider.HuggingSpace`|`qvq-72b, qwen-2-72b, command-r, command-r-plus, command-r7b, command-a`|`flux-dev, flux-schnell, sd-3.5`|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
 |[jmuz.me](https://jmuz.me)|Optional API key|`g4f.Provider.Jmuz`|`claude-3-haiku, claude-3-opus, claude-3.5-sonnet, deepseek-r1, deepseek-chat, gemini-exp, gemini-1.5-flash, gemini-1.5-pro, gemini-2.0-flash-thinking, gpt-4, gpt-4o, gpt-4o-mini, llama-3-70b, llama-3-8b, llama-3.1-405b, llama-3.1-70b, llama-3.1-8b, llama-3.2-11b, llama-3.2-90b, llama-3.3-70b, mixtral-8x7b, qwen-2.5-72b, qwen-2.5-coder-32b, qwq-32b, wizardlm-2-8x22b`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[lambda.chat](https://lambda.chat)|No auth required|`g4f.Provider.LambdaChat`|`deepseek-v3, hermes-3, nemotron-70b, llama-3.3-70b`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
 |[liaobots.work](https://liaobots.work)|[Automatic cookies](https://liaobots.work)|`g4f.Provider.Liaobots`|`claude-3.5-sonnet, claude-3.7-sonnet, claude-3.7-sonnet-thinking, claude-3-opus, claude-3-sonnet, deepseek-r1, deepseek-v3, gemini-2.0-flash, gemini-2.0-flash-thinking, gemini-2.0-pro, gpt-4, gpt-4o, gpt-4o-mini, grok-3, grok-3-r1, o3-mini`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
 |[oi-vscode-server.onrender.com](https://oi-vscode-server.onrender.com)|No auth required|`g4f.Provider.OIVSCode`|`gpt-4o-mini, deepseek-v3`|❌|❌|`gpt-4o-mini`|✔|![](https://img.shields.io/badge/Active-brightgreen)|
 |[labs.perplexity.ai](https://labs.perplexity.ai)|No auth required|`g4f.Provider.PerplexityLabs`|`sonar, sonar-pro, sonar-reasoning, sonar-reasoning-pro`|❌|❌|❌|✔|![Error](https://img.shields.io/badge/Active-brightgreen)|
@@ -161,12 +162,13 @@ This document provides an overview of various AI providers and models, including
 |llama-3.2-3b|Meta Llama|1+ Providers|[huggingface.co](https://huggingface.co/meta-llama/Llama-3.2-3B)|
 |llama-3.2-11b|Meta Llama|3+ Providers|[ai.meta.com](https://ai.meta.com/blog/llama-3-2-connect-2024-vision-edge-mobile-devices/)|
 |llama-3.2-90b|Meta Llama|2+ Providers|[huggingface.co](https://huggingface.co/meta-llama/Llama-3.2-90B-Vision)|
-|llama-3.3-70b|Meta Llama|7+ Providers|[ai.meta.com](https://ai.meta.com/blog/llama-3-3/)|
+|llama-3.3-70b|Meta Llama|8+ Providers|[ai.meta.com](https://ai.meta.com/blog/llama-3-3/)|
 |mixtral-8x7b|Mistral|1+ Providers|[mistral.ai](https://mistral.ai/news/mixtral-of-experts/)|
 |mixtral-8x22b|Mistral|1+ Providers|[huggingface.co](https://huggingface.co/mistralai/Mixtral-8x22B-Instruct-v0.1)|
 |mistral-nemo|Mistral|3+ Providers|[huggingface.co](https://huggingface.co/mistralai/Mistral-Nemo-Instruct-2407)|
 |mixtral-small-24b|Mistral|3+ Providers|[huggingface.co](https://huggingface.co/mistralai/Mistral-Small-24B-Instruct-2501)|
 |hermes-2-dpo|NousResearch|1+ Providers|[huggingface.co](https://huggingface.co/NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO)|
+|hermes-3|NousResearch|1+ Providers|[huggingface.co](https://huggingface.co/NousResearch/Hermes-3-Llama-3.1-405B-FP8)|
 |phi-3.5-mini|Microsoft|1+ Providers|[huggingface.co](https://huggingface.co/microsoft/Phi-3.5-mini-instruct)|
 |phi-4|Microsoft|2+ Providers|[techcommunity.microsoft.com](https://techcommunity.microsoft.com/blog/aiplatformblog/introducing-phi-4-microsoft%E2%80%99s-newest-small-language-model-specializing-in-comple/4357090)|
 |wizardlm-2-7b|Microsoft|1+ Providers|[wizardlm.github.io](https://wizardlm.github.io/WizardLM2/)|
@@ -211,7 +213,7 @@ This document provides an overview of various AI providers and models, including
 |sonar-reasoning|Perplexity AI|1+ Providers|[sonar.perplexity.ai](https://sonar.perplexity.ai/)|
 |sonar-reasoning-pro|Perplexity AI|1+ Providers|[sonar.perplexity.ai](https://sonar.perplexity.ai/)|
 |r1-1776|Perplexity AI|1+ Providers|[perplexity.ai](https://www.perplexity.ai/hub/blog/open-sourcing-r1-1776)|
-|nemotron-70b|Nvidia|2+ Providers|[build.nvidia.com](https://build.nvidia.com/nvidia/llama-3_1-nemotron-70b-instruct)|
+|nemotron-70b|Nvidia|3+ Providers|[build.nvidia.com](https://build.nvidia.com/nvidia/llama-3_1-nemotron-70b-instruct)|
 |dbrx-instruct|Databricks|2+ Providers|[huggingface.co](https://huggingface.co/databricks/dbrx-instruct)|
 |glm-4|THUDM|1+ Providers|[github.com/THUDM](https://github.com/THUDM/GLM-4)|
 |mini_max|MiniMax|1+ Providers|[hailuo.ai](https://www.hailuo.ai/)|

--- a/docs/providers-and-models.md
+++ b/docs/providers-and-models.md
@@ -49,7 +49,7 @@ This document provides an overview of various AI providers and models, including
 |[playground.ai.cloudflare.com](https://playground.ai.cloudflare.com)|[Automatic cookies](https://playground.ai.cloudflare.com)|`g4f.Provider.Cloudflare`|`llama-2-7b, llama-3-8b, llama-3.1-8b, llama-3.2-1b, qwen-1.5-7b`|❌|❌|❌|✔|![Error](https://img.shields.io/badge/Active-brightgreen)|❌|
 |[copilot.microsoft.com](https://copilot.microsoft.com)|Optional API key|`g4f.Provider.Copilot`|`gpt-4, o1`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
 |[duckduckgo.com/aichat](https://duckduckgo.com/aichat)|No auth required|`g4f.Provider.DDG`|`gpt-4, gpt-4o-mini, llama-3.3-70b, claude-3-haiku, o3-mini, mixtral-small-24b`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[deepinfra.com/chat](https://deepinfra.com/chat)|No auth required|`g4f.Provider.DeepInfraChat`|`llama-3.1-8b, llama-3.2-90b, llama-3.3-70b, deepseek-v3, mixtral-small-28b, deepseek-r1, phi-4, wizardlm-2-8x22b, qwen-2.5-72b, yi-34b, qwen-2-72b, dolphin-2.6, dolphin-2.9, dbrx-instruct, airoboros-70b, lzlv-70b, wizardlm-2-7b, mixtral-8x22b, minicpm-2.5`|❌|❌|`llama-3.2-90b, minicpm-2.5`|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[deepinfra.com/chat](https://deepinfra.com/chat)|No auth required|`g4f.Provider.DeepInfraChat`|`llama-3.1-8b, llama-3.2-90b, llama-3.3-70b, deepseek-v3, mixtral-small-24b, deepseek-r1, phi-4, wizardlm-2-8x22b, qwen-2.5-72b, yi-34b, qwen-2-72b, dolphin-2.6, dolphin-2.9, dbrx-instruct, airoboros-70b, lzlv-70b, wizardlm-2-7b, mixtral-8x22b, minicpm-2.5`|❌|❌|`llama-3.2-90b, minicpm-2.5`|✔|![](https://img.shields.io/badge/Active-brightgreen)|
 |[dynaspark.onrender.com](https://dynaspark.onrender.com)|No auth required|`g4f.Provider.Dynaspark`|`gemini-1.5-flash, gemini-2.0-flash`|❌|❌|`gemini-1.5-flash, gemini-2.0-flash`|✔|![](https://img.shields.io/badge/Active-brightgreen)|
 |[chat10.free2gpt.xyz](https://chat10.free2gpt.xyz)|No auth required|`g4f.Provider.Free2GPT`|`gemini-1.5-pro, gemini-1.5-flash`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
 |[freegptsnav.aifree.site](https://freegptsnav.aifree.site)|No auth required|`g4f.Provider.FreeGpt`|`gemini-1.5-pro, gemini-1.5-flash`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
@@ -165,8 +165,7 @@ This document provides an overview of various AI providers and models, including
 |mixtral-8x7b|Mistral|1+ Providers|[mistral.ai](https://mistral.ai/news/mixtral-of-experts/)|
 |mixtral-8x22b|Mistral|1+ Providers|[huggingface.co](https://huggingface.co/mistralai/Mixtral-8x22B-Instruct-v0.1)|
 |mistral-nemo|Mistral|3+ Providers|[huggingface.co](https://huggingface.co/mistralai/Mistral-Nemo-Instruct-2407)|
-|mixtral-small-24b|Mistral|2+ Providers|[huggingface.co](https://huggingface.co/mistralai/Mistral-Small-24B-Instruct-2501)|
-|mixtral-small-28b|Mistral|1+ Providers|[mistral.ai](https://mistral.ai/news/mixtral-small-28b/)|
+|mixtral-small-24b|Mistral|3+ Providers|[huggingface.co](https://huggingface.co/mistralai/Mistral-Small-24B-Instruct-2501)|
 |hermes-2-dpo|NousResearch|1+ Providers|[huggingface.co](https://huggingface.co/NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO)|
 |phi-3.5-mini|Microsoft|1+ Providers|[huggingface.co](https://huggingface.co/microsoft/Phi-3.5-mini-instruct)|
 |phi-4|Microsoft|2+ Providers|[techcommunity.microsoft.com](https://techcommunity.microsoft.com/blog/aiplatformblog/introducing-phi-4-microsoft%E2%80%99s-newest-small-language-model-specializing-in-comple/4357090)|

--- a/docs/providers-and-models.md
+++ b/docs/providers-and-models.md
@@ -55,6 +55,7 @@ This document provides an overview of various AI providers and models, including
 |[freegptsnav.aifree.site](https://freegptsnav.aifree.site)|No auth required|`g4f.Provider.FreeGpt`|`gemini-1.5-pro, gemini-1.5-flash`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
 |[app.giz.ai/assistant](https://app.giz.ai/assistant)|No auth required|`g4f.Provider.GizAI`|`gemini-1.5-flash`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
 |[glider.so](https://glider.so)|No auth required|`g4f.Provider.Glider`|`llama-3.1-70b, llama-3.1-8b, llama-3.2-3b, deepseek-r1`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[goabror.uz](https://goabror.uz)|No auth required|`g4f.Provider.Goabror`|`gpt-4`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
 |[hailuo.ai](https://www.hailuo.ai)|No auth required|`g4f.Provider.HailuoAI`|`MiniMax` _**(1+)**_|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
 |[editor.imagelabs.net](editor.imagelabs.net)|No auth required|`g4f.Provider.ImageLabs`|❌|`sdxl-turbo`|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
 |[huggingface.co/spaces](https://huggingface.co/spaces)|Optional API key|`g4f.Provider.HuggingSpace`|`qvq-72b, qwen-2-72b, command-r, command-r-plus, command-r7b, command-a`|`flux-dev, flux-schnell, sd-3.5`|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
@@ -144,7 +145,7 @@ This document provides an overview of various AI providers and models, including
 ### Text generation models
 | Model | Base Provider | Providers | Website |
 |-------|---------------|-----------|---------|
-|gpt-4|OpenAI|8+ Providers|[platform.openai.com](https://platform.openai.com/docs/models/gpt-4-turbo-and-gpt-4)|
+|gpt-4|OpenAI|9+ Providers|[platform.openai.com](https://platform.openai.com/docs/models/gpt-4-turbo-and-gpt-4)|
 |gpt-4o|OpenAI|6+ Providers|[platform.openai.com](https://platform.openai.com/docs/models/gpt-4o)|
 |gpt-4o-mini|OpenAI|7+ Providers|[platform.openai.com](https://platform.openai.com/docs/models/gpt-4o-mini)|
 |o1|OpenAI|3+ Providers|[openai.com](https://openai.com/index/introducing-openai-o1-preview/)|

--- a/docs/providers-and-models.md
+++ b/docs/providers-and-models.md
@@ -123,7 +123,7 @@ This document provides an overview of various AI providers and models, including
 |[ai.google.dev](https://ai.google.dev)|[Get API key](https://aistudio.google.com/u/0/apikey)|`g4f.Provider.GeminiPro`|`gemini-1.5-flash, gemini-1.5-pro, gemini-2.0-flash`|❌|❌|`gemini-1.5-pro`|❌|![](https://img.shields.io/badge/Active-brightgreen)|
 |[developers.sber.ru/gigachat](https://developers.sber.ru/gigachat)|[Manual cookies](https://developers.sber.ru/gigachat)|`g4f.Provider.GigaChat`|✔ _**(3+)**_|❌|❌|❌|❌|![](https://img.shields.io/badge/Active-brightgreen)|
 |[github.com/copilot](https://github.com/copilot)|[Manual cookies](https://github.com/copilot)|`g4f.Provider.GithubCopilot`|✔ _**(4+)**_|❌|❌|❌|❌|![](https://img.shields.io/badge/Active-brightgreen)|
-|[glhf.chat](https://glhf.chat)|[Get API key](https://glhf.chat/user-settings/api)|`g4f.Provider.GlhfChat`|✔ _**(22+)**_|❌|❌|❌|![](https://img.shields.io/badge/Active-brightgreen)|
+|[glhf.chat](https://glhf.chat)|[Get API key](https://glhf.chat/user-settings/api)|`g4f.Provider.GlhfChat`|✔ _**(22+)**_|❌|❌|❌|❌|![](https://img.shields.io/badge/Active-brightgreen)|
 |[console.groq.com/playground](https://console.groq.com/playground)|[Get API key](https://console.groq.com/keys)|`g4f.Provider.Groq`|✔ _**(18+)**_|❌|❌|✔|❌|![](https://img.shields.io/badge/Active-brightgreen)|
 |[meta.ai](https://www.meta.ai)|[Manual cookies](https://www.meta.ai)|`g4f.Provider.MetaAI`|`meta-ai`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|✔|
 |[meta.ai](https://www.meta.ai)|[Manual cookies](https://www.meta.ai)|`g4f.Provider.MetaAIAccount`|❌|`meta-ai`|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|

--- a/docs/providers-and-models.md
+++ b/docs/providers-and-models.md
@@ -42,7 +42,7 @@ This document provides an overview of various AI providers and models, including
 |----------|-------------|--------------|---------------|--------|--------|------|------|------|
 |[playground.allenai.org](https://playground.allenai.org)|No auth required|`g4f.Provider.AllenAI`|`tulu-3-405b, olmo-2-13b, tulu-3-1-8b, tulu-3-70b, olmoe-0125`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
 |[ai-arta.com](https://ai-arta.com)|No auth required|`g4f.Provider.ARTA`|❌|✔ _**(17+)**_|❌|❌|❌|![](https://img.shields.io/badge/Active-brightgreen)|
-|[blackbox.ai](https://www.blackbox.ai)|No auth required|`g4f.Provider.Blackbox`|`blackboxai, gemini-1.5-flash, blackboxai-pro, llama-3.1-8b, llama-3.1-70b, llama-3-1-405b, llama-3.3-70b, mixtral-small-24b, deepseek-chat, dbrx-instruct, qwq-32b, hermes-2-dpo, deepseek-v3, deepseek-r1, gemini-2.0-flash, gpt-4o, o1, o3-mini, gemini-1.5-pro, claude-3.7-sonnet` _**(29+)**_|`flux`|❌|`blackboxai, gpt-4o, o1, o3-mini, gemini-1.5-pro, gemini-1.5-flash, llama-3.1-8b, llama-3.1-70b, llama-3.1-405b, gemini-2.0-flash, deepseek-v3`|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[blackbox.ai](https://www.blackbox.ai)|No auth required|`g4f.Provider.Blackbox`|`blackboxai, gpt-4o-mini, deepseek-chat, deepseek-v3, deepseek-r1, gpt-4o, o1, o3-mini, claude-3.7-sonnet` _**(40+)**_|`flux`|❌|`blackboxai, gpt-4o, o1, o3-mini, deepseek-v3` _**(7+)**_|✔|![](https://img.shields.io/badge/Active-brightgreen)|
 |[chatglm.cn](https://chatglm.cn)|No auth required|`g4f.Provider.ChatGLM`|`glm-4`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
 |[chatgpt.com](https://chatgpt.com)|No auth required|`g4f.Provider.ChatGpt`|✔ _**(7+)**_|❌|❌|❌|✔|![Error](https://img.shields.io/badge/HTTPError-f48d37)|
 |[chatgpt.es](https://chatgpt.es)|No auth required|`g4f.Provider.ChatGptEs`|`gpt-4, gpt-4o, gpt-4o-mini`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
@@ -147,7 +147,7 @@ This document provides an overview of various AI providers and models, including
 |-------|---------------|-----------|---------|
 |gpt-4|OpenAI|9+ Providers|[platform.openai.com](https://platform.openai.com/docs/models/gpt-4-turbo-and-gpt-4)|
 |gpt-4o|OpenAI|6+ Providers|[platform.openai.com](https://platform.openai.com/docs/models/gpt-4o)|
-|gpt-4o-mini|OpenAI|7+ Providers|[platform.openai.com](https://platform.openai.com/docs/models/gpt-4o-mini)|
+|gpt-4o-mini|OpenAI|8+ Providers|[platform.openai.com](https://platform.openai.com/docs/models/gpt-4o-mini)|
 |o1|OpenAI|3+ Providers|[openai.com](https://openai.com/index/introducing-openai-o1-preview/)|
 |o1-mini|OpenAI|1+ Providers|[openai.com](https://openai.com/index/openai-o1-mini-advancing-cost-efficient-reasoning/)|
 |o3-mini|OpenAI|3+ Providers|[openai.com](https://openai.com/index/openai-o3-mini/)|
@@ -156,29 +156,28 @@ This document provides an overview of various AI providers and models, including
 |llama-2-7b|Meta Llama|1+ Providers|[huggingface.co](https://huggingface.co/meta-llama/Llama-2-7b)|
 |llama-3-8b|Meta Llama|2+ Providers|[ai.meta.com](https://ai.meta.com/blog/meta-llama-3/)|
 |llama-3-70b|Meta Llama|1+ Providers|[huggingface.co](https://huggingface.co/meta-llama/Meta-Llama-3-70B)|
-|llama-3.1-8b|Meta Llama|7+ Providers|[ai.meta.com](https://ai.meta.com/blog/meta-llama-3-1/)|
-|llama-3.1-70b|Meta Llama|4+ Providers|[ai.meta.com](https://ai.meta.com/blog/meta-llama-3-1/)|
-|llama-3.1-405b|Meta Llama|3+ Providers|[huggingface.co](https://huggingface.co/meta-llama/Llama-3.1-405B)|
+|llama-3.1-8b|Meta Llama|6+ Providers|[ai.meta.com](https://ai.meta.com/blog/meta-llama-3-1/)|
+|llama-3.1-70b|Meta Llama|3+ Providers|[ai.meta.com](https://ai.meta.com/blog/meta-llama-3-1/)|
+|llama-3.1-405b|Meta Llama|2+ Providers|[huggingface.co](https://huggingface.co/meta-llama/Llama-3.1-405B)|
 |llama-3.2-1b|Meta Llama|1+ Providers|[huggingface.co](https://huggingface.co/meta-llama/Llama-3.2-1B)|
 |llama-3.2-3b|Meta Llama|1+ Providers|[huggingface.co](https://huggingface.co/meta-llama/Llama-3.2-3B)|
 |llama-3.2-11b|Meta Llama|3+ Providers|[ai.meta.com](https://ai.meta.com/blog/llama-3-2-connect-2024-vision-edge-mobile-devices/)|
 |llama-3.2-90b|Meta Llama|2+ Providers|[huggingface.co](https://huggingface.co/meta-llama/Llama-3.2-90B-Vision)|
-|llama-3.3-70b|Meta Llama|8+ Providers|[ai.meta.com](https://ai.meta.com/blog/llama-3-3/)|
+|llama-3.3-70b|Meta Llama|7+ Providers|[ai.meta.com](https://ai.meta.com/blog/llama-3-3/)|
 |mixtral-8x7b|Mistral|1+ Providers|[mistral.ai](https://mistral.ai/news/mixtral-of-experts/)|
 |mixtral-8x22b|Mistral|1+ Providers|[huggingface.co](https://huggingface.co/mistralai/Mixtral-8x22B-Instruct-v0.1)|
 |mistral-nemo|Mistral|3+ Providers|[huggingface.co](https://huggingface.co/mistralai/Mistral-Nemo-Instruct-2407)|
-|mixtral-small-24b|Mistral|3+ Providers|[huggingface.co](https://huggingface.co/mistralai/Mistral-Small-24B-Instruct-2501)|
-|hermes-2-dpo|NousResearch|1+ Providers|[huggingface.co](https://huggingface.co/NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO)|
+|mixtral-small-24b|Mistral|2+ Providers|[huggingface.co](https://huggingface.co/mistralai/Mistral-Small-24B-Instruct-2501)|
 |hermes-3|NousResearch|1+ Providers|[huggingface.co](https://huggingface.co/NousResearch/Hermes-3-Llama-3.1-405B-FP8)|
 |phi-3.5-mini|Microsoft|1+ Providers|[huggingface.co](https://huggingface.co/microsoft/Phi-3.5-mini-instruct)|
 |phi-4|Microsoft|2+ Providers|[techcommunity.microsoft.com](https://techcommunity.microsoft.com/blog/aiplatformblog/introducing-phi-4-microsoft%E2%80%99s-newest-small-language-model-specializing-in-comple/4357090)|
 |wizardlm-2-7b|Microsoft|1+ Providers|[wizardlm.github.io](https://wizardlm.github.io/WizardLM2/)|
 |wizardlm-2-8x22b|Microsoft|2+ Providers|[wizardlm.github.io](https://wizardlm.github.io/WizardLM2/)|
-|gemini-2.0|Google DeepMind|1+ Providers|[deepmind.google](http://deepmind.google/technologies/gemini/)|
 |gemini-exp|Google DeepMind|1+ Providers|[blog.google](https://blog.google/feed/gemini-exp-1206/)|
-|gemini-1.5-flash|Google DeepMind|8+ Providers|[deepmind.google](https://deepmind.google/technologies/gemini/flash/)|
-|gemini-1.5-pro|Google DeepMind|7+ Providers|[deepmind.google](https://deepmind.google/technologies/gemini/pro/)|
-|gemini-2.0-flash|Google DeepMind|4+ Providers|[deepmind.google](https://deepmind.google/technologies/gemini/flash/)|
+|gemini-1.5-flash|Google DeepMind|7+ Providers|[deepmind.google](https://deepmind.google/technologies/gemini/flash/)|
+|gemini-1.5-pro|Google DeepMind|6+ Providers|[deepmind.google](https://deepmind.google/technologies/gemini/pro/)|
+|gemini-2.0|Google DeepMind|1+ Providers|[deepmind.google](http://deepmind.google/technologies/gemini/)|
+|gemini-2.0-flash|Google DeepMind|3+ Providers|[deepmind.google](https://deepmind.google/technologies/gemini/flash/)|
 |gemini-2.0-flash-thinking|Google DeepMind|1+ Providers|[ai.google.dev](https://ai.google.dev/gemini-api/docs/thinking-mode)|
 |gemini-2.0-pro|Google DeepMind|1+ Providers|[deepmind.google](https://deepmind.google/technologies/gemini/flash-thinking/)|
 |claude-3-haiku|Anthropic|2+ Providers|[anthropic.com](https://www.anthropic.com/news/claude-3-haiku)|
@@ -189,7 +188,6 @@ This document provides an overview of various AI providers and models, including
 |claude-3.7-sonnet-thinking|Anthropic|1+ Providers|[anthropic.com](https://www.anthropic.com/claude/sonnet)|
 |reka-core|Reka AI|1+ Providers|[reka.ai](https://www.reka.ai/ourmodels)|
 |blackboxai|Blackbox AI|1+ Providers|[docs.blackbox.chat](https://docs.blackbox.chat/blackbox-ai-1)|
-|blackboxai-pro|Blackbox AI|1+ Providers|[docs.blackbox.chat](https://docs.blackbox.chat/blackbox-ai-1)|
 |command-r|CohereForAI|1+ Providers|[docs.cohere.com](https://docs.cohere.com/docs/command-r-plus)|
 |command-r-plus|CohereForAI|2+ Providers|[docs.cohere.com](https://docs.cohere.com/docs/command-r-plus)|
 |command-r7b|CohereForAI|1+ Providers|[huggingface.co](https://huggingface.co/CohereForAI/c4ai-command-r7b-12-2024)|
@@ -200,7 +198,7 @@ This document provides an overview of various AI providers and models, including
 |qwen-2.5-72b|Qwen|1+ Providers|[huggingface.co](https://huggingface.co/Qwen/Qwen2.5-72B-Instruct)|
 |qwen-2.5-coder-32b|Qwen|3+ Providers|[huggingface.co](https://huggingface.co/Qwen/Qwen2.5-Coder-32B)|
 |qwen-2.5-1m-demo|Qwen|1+ Providers|[huggingface.co](https://huggingface.co/Qwen/Qwen2.5-1M-Demo)|
-|qwq-32b|Qwen|3+ Providers|[huggingface.co](https://huggingface.co/Qwen/QwQ-32B-Preview)|
+|qwq-32b|Qwen|2+ Providers|[huggingface.co](https://huggingface.co/Qwen/QwQ-32B-Preview)|
 |qvq-72b|Qwen|1+ Providers|[huggingface.co](https://huggingface.co/Qwen/QVQ-72B-Preview)|
 |pi|Inflection|1+ Providers|[inflection.ai](https://inflection.ai/blog/inflection-2-5)|
 |deepseek-chat|DeepSeek|2+ Providers|[huggingface.co](https://huggingface.co/deepseek-ai/deepseek-llm-67b-chat)|
@@ -215,7 +213,7 @@ This document provides an overview of various AI providers and models, including
 |sonar-reasoning-pro|Perplexity AI|1+ Providers|[sonar.perplexity.ai](https://sonar.perplexity.ai/)|
 |r1-1776|Perplexity AI|1+ Providers|[perplexity.ai](https://www.perplexity.ai/hub/blog/open-sourcing-r1-1776)|
 |nemotron-70b|Nvidia|3+ Providers|[build.nvidia.com](https://build.nvidia.com/nvidia/llama-3_1-nemotron-70b-instruct)|
-|dbrx-instruct|Databricks|2+ Providers|[huggingface.co](https://huggingface.co/databricks/dbrx-instruct)|
+|dbrx-instruct|Databricks|1+ Providers|[huggingface.co](https://huggingface.co/databricks/dbrx-instruct)|
 |glm-4|THUDM|1+ Providers|[github.com/THUDM](https://github.com/THUDM/GLM-4)|
 |mini_max|MiniMax|1+ Providers|[hailuo.ai](https://www.hailuo.ai/)|
 |yi-34b|01-ai|1+ Providers|[huggingface.co](https://huggingface.co/01-ai/Yi-34B-Chat)|

--- a/docs/providers-and-models.md
+++ b/docs/providers-and-models.md
@@ -17,8 +17,8 @@ This document provides an overview of various AI providers and models, including
     - [MiniMax](#providers-minimax)
     - [Needs auth](#providers-needs-auth)
   - [Models](#models)
-    - [Text Models](#text-models)
-    - [Image Models](#image-models)
+    - [Text generation models](#text-generation-models)
+    - [Image generation models](#image-generation-models)
   - [Conclusion and Usage Tips](#conclusion-and-usage-tips)
 
 ---
@@ -38,112 +38,115 @@ This document provides an overview of various AI providers and models, including
 
 ---
 ### Providers No auth required
-| Website | API Credentials | Provider | Text Models | Image Models | Vision (Image Upload) | Stream | Status |
-|----------|-------------|--------------|---------------|--------|--------|------|------|
-|[playground.allenai.org](https://playground.allenai.org)|No auth required|`g4f.Provider.AllenAI`|`tulu-3-405b, olmo-2-13b, tulu-3-1-8b, tulu-3-70b, olmoe-0125`|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[blackbox.ai](https://www.blackbox.ai)|No auth required|`g4f.Provider.Blackbox`|`blackboxai, gemini-1.5-flash, blackboxai-pro, llama-3.1-8b, llama-3.1-70b, llama-3-1-405b, llama-3.3-70b, mixtral-small-28b, deepseek-chat, dbrx-instruct, qwq-32b, hermes-2-dpo, deepseek-v3, deepseek-r1, gemini-2.0-flash, gpt-4o, o1, o3-mini, gemini-1.5-pro, claude-3.7-sonnet` _**(+29)**_|`flux`|`blackboxai, gpt-4o, o1, o3-mini, gemini-1.5-pro, gemini-1.5-flash, llama-3.1-8b, llama-3.1-70b, llama-3.1-405b, gemini-2.0-flash, deepseek-v3`|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[chatglm.cn](https://chatglm.cn)|No auth required|`g4f.Provider.ChatGLM`|`glm-4`|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[chatgpt.com](https://chatgpt.com)|No auth required|`g4f.Provider.ChatGpt`|✔ _**(+7)**_|❌|❌|✔|![Error](https://img.shields.io/badge/HTTPError-f48d37)|
-|[chatgpt.es](https://chatgpt.es)|No auth required|`g4f.Provider.ChatGptEs`|`gpt-4, gpt-4o, gpt-4o-mini`|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[playground.ai.cloudflare.com](https://playground.ai.cloudflare.com)|[Automatic cookies](https://playground.ai.cloudflare.com)|`g4f.Provider.Cloudflare`|`llama-2-7b, llama-3-8b, llama-3.1-8b, llama-3.2-1b, qwen-1.5-7b`|❌|❌|✔|![Error](https://img.shields.io/badge/Active-brightgreen)|❌|
-|[copilot.microsoft.com](https://copilot.microsoft.com)|Optional API key|`g4f.Provider.Copilot`|`gpt-4, gpt-4o`|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[duckduckgo.com/aichat](https://duckduckgo.com/aichat)|No auth required|`g4f.Provider.DDG`|`gpt-4, gpt-4o-mini, llama-3.3-70b, claude-3-haiku, o3-mini, mixtral-small-24b`|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[deepinfra.com/chat](https://deepinfra.com/chat)|No auth required|`g4f.Provider.DeepInfraChat`|`llama-3.1-8b, llama-3.2-90b, llama-3.3-70b, deepseek-v3, mixtral-small-28b, deepseek-r1, phi-4, wizardlm-2-8x22b, qwen-2.5-72b, yi-34b, qwen-2-72b, dolphin-2.6, dolphin-2.9, dbrx-instruct, airoboros-70b, lzlv-70b, wizardlm-2-7b, mixtral-8x22b, minicpm-2.5`|❌|`llama-3.2-90b, minicpm-2.5`|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[chat10.free2gpt.xyz](https://chat10.free2gpt.xyz)|No auth required|`g4f.Provider.Free2GPT`|`gemini-1.5-pro, gemini-1.5-flash`|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[freegptsnav.aifree.site](https://freegptsnav.aifree.site)|No auth required|`g4f.Provider.FreeGpt`|`gemini-1.5-pro, gemini-1.5-flash`|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[app.giz.ai/assistant](https://app.giz.ai/assistant)|No auth required|`g4f.Provider.GizAI`|`gemini-1.5-flash`|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[glider.so](https://glider.so)|No auth required|`g4f.Provider.Glider`|`llama-3.1-70b, llama-3.1-8b, llama-3.2-3b, deepseek-r1`|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[hailuo.ai](https://www.hailuo.ai)|No auth required|`g4f.Provider.HailuoAI`|`MiniMax` _**(1)**_|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[editor.imagelabs.net](editor.imagelabs.net)|No auth required|`g4f.Provider.ImageLabs`|❌|`sdxl-turbo`|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[huggingface.co/spaces](https://huggingface.co/spaces)|Optional API key|`g4f.Provider.HuggingSpace`|`qvq-72b, qwen-2-72b, command-r, command-r-plus, command-r7b`|`flux-dev, flux-schnell, sd-3.5`|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[jmuz.me](https://jmuz.me)|Optional API key|`g4f.Provider.Jmuz`|`claude-3-haiku, claude-3-opus, claude-3-haiku, claude-3.5-sonnet, deepseek-r1, deepseek-chat, gemini-exp, gemini-1.5-flash, gemini-1.5-pro, gemini-2.0-flash-thinking, gpt-4, gpt-4o, gpt-4o-mini, llama-3-70b, llama-3-8b, llama-3.1-405b, llama-3.1-70b, llama-3.1-8b, llama-3.2-11b, llama-3.2-90b, llama-3.3-70b, mixtral-8x7b, qwen-2.5-72b, qwen-2.5-coder-32b, qwq-32b, wizardlm-2-8x22b`|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[liaobots.work](https://liaobots.work)|[Automatic cookies](https://liaobots.work)|`g4f.Provider.Liaobots`|`claude-3.5-sonnet, claude-3.7-sonnet, claude-3.7-sonnet-thinking, claude-3-opus, claude-3-sonnet, deepseek-r1, deepseek-v3, gemini-2.0-flash, gemini-2.0-flash-thinking, gemini-2.0-pro, gpt-4, gpt-4o, gpt-4o-mini, grok-3, grok-3-r1, o3-mini`|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[oi-vscode-server.onrender.com](https://oi-vscode-server.onrender.com)|No auth required|`g4f.Provider.OIVSCode`|`gpt-4o-mini, deepseek-v3`|❌|`gpt-4o-mini`|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[labs.perplexity.ai](https://labs.perplexity.ai)|No auth required|`g4f.Provider.PerplexityLabs`|`sonar, sonar-pro, sonar-reasoning, sonar-reasoning-pro`|❌|❌|✔|![Error](https://img.shields.io/badge/Active-brightgreen)|
-|[pi.ai/talk](https://pi.ai/talk)|[Manual cookies](https://pi.ai/talk)|`g4f.Provider.Pi`|`pi`|❌|❌|✔|![Error](https://img.shields.io/badge/Active-brightgreen)|
-|[pizzagpt.it](https://www.pizzagpt.it)|No auth required|`g4f.Provider.Pizzagpt`|`gpt-4o-mini`|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[pollinations.ai](https://pollinations.ai)|No auth required|`g4f.Provider.PollinationsAI`|`gpt-4o-mini, gpt-4o, o1-mini, qwen-2.5-coder-32b, llama-3.3-70b, mistral-nemo, llama-3.1-8b, deepseek-r1, phi-4` _**(6+)**_|`flux, flux-pro, flux-dev, flux-schnell, dall-e-3, sdxl-turbo`|gpt-4o, gpt-4o-mini, o1-mini|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[pollinations.ai](https://pollinations.ai)|No auth required|`g4f.Provider.PollinationsImage`|❌|`flux, flux-pro, flux-dev, flux-schnell, dall-e-3, sdxl-turbo`|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[app.prodia.com](https://app.prodia.com)|No auth required|`g4f.Provider.Prodia`|❌|✔ _**(46)**_|❌|❌|![](https://img.shields.io/badge/Active-brightgreen)|
-|[teach-anything.com](https://www.teach-anything.com)|No auth required|`g4f.Provider.TeachAnything`|`gemini-1.5-pro, gemini-1.5-flash`|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[you.com](https://you.com)|[Manual cookies](https://you.com)|`g4f.Provider.You`|✔|✔|✔|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[chat9.yqcloud.top](https://chat9.yqcloud.top)|No auth required|`g4f.Provider.Yqcloud`|`gpt-4`|✔|✔|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+| Website | API Credentials | Provider | Text generation | Image generation | Audio generation | Vision (Image Upload) | Streaming | Status |
+|----------|-------------|--------------|---------------|--------|--------|------|------|------|
+|[playground.allenai.org](https://playground.allenai.org)|No auth required|`g4f.Provider.AllenAI`|`tulu-3-405b, olmo-2-13b, tulu-3-1-8b, tulu-3-70b, olmoe-0125`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[ai-arta.com](https://ai-arta.com)|No auth required|`g4f.Provider.ARTA`|❌|✔ _**(17+)**_|❌|❌|❌|![](https://img.shields.io/badge/Active-brightgreen)|
+|[blackbox.ai](https://www.blackbox.ai)|No auth required|`g4f.Provider.Blackbox`|`blackboxai, gemini-1.5-flash, blackboxai-pro, llama-3.1-8b, llama-3.1-70b, llama-3-1-405b, llama-3.3-70b, mixtral-small-28b, deepseek-chat, dbrx-instruct, qwq-32b, hermes-2-dpo, deepseek-v3, deepseek-r1, gemini-2.0-flash, gpt-4o, o1, o3-mini, gemini-1.5-pro, claude-3.7-sonnet` _**(29+)**_|`flux`|❌|`blackboxai, gpt-4o, o1, o3-mini, gemini-1.5-pro, gemini-1.5-flash, llama-3.1-8b, llama-3.1-70b, llama-3.1-405b, gemini-2.0-flash, deepseek-v3`|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[chatglm.cn](https://chatglm.cn)|No auth required|`g4f.Provider.ChatGLM`|`glm-4`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[chatgpt.com](https://chatgpt.com)|No auth required|`g4f.Provider.ChatGpt`|✔ _**(7+)**_|❌|❌|❌|✔|![Error](https://img.shields.io/badge/HTTPError-f48d37)|
+|[chatgpt.es](https://chatgpt.es)|No auth required|`g4f.Provider.ChatGptEs`|`gpt-4, gpt-4o, gpt-4o-mini`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[playground.ai.cloudflare.com](https://playground.ai.cloudflare.com)|[Automatic cookies](https://playground.ai.cloudflare.com)|`g4f.Provider.Cloudflare`|`llama-2-7b, llama-3-8b, llama-3.1-8b, llama-3.2-1b, qwen-1.5-7b`|❌|❌|❌|✔|![Error](https://img.shields.io/badge/Active-brightgreen)|❌|
+|[copilot.microsoft.com](https://copilot.microsoft.com)|Optional API key|`g4f.Provider.Copilot`|`gpt-4, o1`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[duckduckgo.com/aichat](https://duckduckgo.com/aichat)|No auth required|`g4f.Provider.DDG`|`gpt-4, gpt-4o-mini, llama-3.3-70b, claude-3-haiku, o3-mini, mixtral-small-24b`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[deepinfra.com/chat](https://deepinfra.com/chat)|No auth required|`g4f.Provider.DeepInfraChat`|`llama-3.1-8b, llama-3.2-90b, llama-3.3-70b, deepseek-v3, mixtral-small-28b, deepseek-r1, phi-4, wizardlm-2-8x22b, qwen-2.5-72b, yi-34b, qwen-2-72b, dolphin-2.6, dolphin-2.9, dbrx-instruct, airoboros-70b, lzlv-70b, wizardlm-2-7b, mixtral-8x22b, minicpm-2.5`|❌|❌|`llama-3.2-90b, minicpm-2.5`|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[dynaspark.onrender.com](https://dynaspark.onrender.com)|No auth required|`g4f.Provider.Dynaspark`|`gemini-1.5-flash, gemini-2.0-flash`|❌|❌|`gemini-1.5-flash, gemini-2.0-flash`|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[chat10.free2gpt.xyz](https://chat10.free2gpt.xyz)|No auth required|`g4f.Provider.Free2GPT`|`gemini-1.5-pro, gemini-1.5-flash`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[freegptsnav.aifree.site](https://freegptsnav.aifree.site)|No auth required|`g4f.Provider.FreeGpt`|`gemini-1.5-pro, gemini-1.5-flash`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[app.giz.ai/assistant](https://app.giz.ai/assistant)|No auth required|`g4f.Provider.GizAI`|`gemini-1.5-flash`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[glider.so](https://glider.so)|No auth required|`g4f.Provider.Glider`|`llama-3.1-70b, llama-3.1-8b, llama-3.2-3b, deepseek-r1`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[hailuo.ai](https://www.hailuo.ai)|No auth required|`g4f.Provider.HailuoAI`|`MiniMax` _**(1+)**_|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[editor.imagelabs.net](editor.imagelabs.net)|No auth required|`g4f.Provider.ImageLabs`|❌|`sdxl-turbo`|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[huggingface.co/spaces](https://huggingface.co/spaces)|Optional API key|`g4f.Provider.HuggingSpace`|`qvq-72b, qwen-2-72b, command-r, command-r-plus, command-r7b`|`flux-dev, flux-schnell, sd-3.5`|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[jmuz.me](https://jmuz.me)|Optional API key|`g4f.Provider.Jmuz`|`claude-3-haiku, claude-3-opus, claude-3.5-sonnet, deepseek-r1, deepseek-chat, gemini-exp, gemini-1.5-flash, gemini-1.5-pro, gemini-2.0-flash-thinking, gpt-4, gpt-4o, gpt-4o-mini, llama-3-70b, llama-3-8b, llama-3.1-405b, llama-3.1-70b, llama-3.1-8b, llama-3.2-11b, llama-3.2-90b, llama-3.3-70b, mixtral-8x7b, qwen-2.5-72b, qwen-2.5-coder-32b, qwq-32b, wizardlm-2-8x22b`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[liaobots.work](https://liaobots.work)|[Automatic cookies](https://liaobots.work)|`g4f.Provider.Liaobots`|`claude-3.5-sonnet, claude-3.7-sonnet, claude-3.7-sonnet-thinking, claude-3-opus, claude-3-sonnet, deepseek-r1, deepseek-v3, gemini-2.0-flash, gemini-2.0-flash-thinking, gemini-2.0-pro, gpt-4, gpt-4o, gpt-4o-mini, grok-3, grok-3-r1, o3-mini`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[oi-vscode-server.onrender.com](https://oi-vscode-server.onrender.com)|No auth required|`g4f.Provider.OIVSCode`|`gpt-4o-mini, deepseek-v3`|❌|❌|`gpt-4o-mini`|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[labs.perplexity.ai](https://labs.perplexity.ai)|No auth required|`g4f.Provider.PerplexityLabs`|`sonar, sonar-pro, sonar-reasoning, sonar-reasoning-pro`|❌|❌|❌|✔|![Error](https://img.shields.io/badge/Active-brightgreen)|
+|[pi.ai/talk](https://pi.ai/talk)|[Manual cookies](https://pi.ai/talk)|`g4f.Provider.Pi`|`pi`|❌|❌|❌|✔|![Error](https://img.shields.io/badge/Active-brightgreen)|
+|[pizzagpt.it](https://www.pizzagpt.it)|No auth required|`g4f.Provider.Pizzagpt`|`gpt-4o-mini`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[pollinations.ai](https://pollinations.ai)|No auth required|`g4f.Provider.PollinationsAI`|`gpt-4o-mini, gpt-4o, o1-mini, qwen-2.5-coder-32b, llama-3.3-70b, mistral-nemo, llama-3.1-8b, deepseek-r1, phi-4` _**(9+)**_|`flux, flux-pro, flux-dev, flux-schnell, dall-e-3, sdxl-turbo`|✔ _**(1+)**_|`gpt-4o, gpt-4o-mini, o1-mini, o3-mini`|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[pollinations.ai](https://pollinations.ai)|No auth required|`g4f.Provider.PollinationsImage`|❌|`flux, flux-pro, flux-dev, flux-schnell, dall-e-3, sdxl-turbo`|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[teach-anything.com](https://www.teach-anything.com)|No auth required|`g4f.Provider.TeachAnything`|`gemini-1.5-pro, gemini-1.5-flash`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[you.com](https://you.com)|[Manual cookies](https://you.com)|`g4f.Provider.You`|✔|✔|❌|✔|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[websim.ai](https://websim.ai)|No auth required|`g4f.Provider.Websim`|`gemini-1.5-pro, gemini-1.5-flash`|`flux`|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[chat9.yqcloud.top](https://chat9.yqcloud.top)|No auth required|`g4f.Provider.Yqcloud`|`gpt-4`|✔|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
 
 ---
 ### Providers HuggingFace
-| Website | API Credentials | Provider | Text Models | Image Models | Vision (Image Upload) | Stream | Status |
-|----------|-------------|--------------|---------------|--------|--------|------|------|
-|[huggingface.co/chat](https://huggingface.co/chat)|[Manual cookies](https://huggingface.co/chat)|`g4f.Provider.HuggingChat`|`qwen-2.5-72b, llama-3.3-70b, command-r-plus, deepseek-r1, qwq-32b, nemotron-70b, llama-3.2-11b, mistral-nemo, phi-3.5-mini`|`flux-dev, flux-schnell`|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[huggingface.co/chat](https://huggingface.co/chat)|[API key / Cookies](https://huggingface.co/settings/tokens)|`g4f.Provider.HuggingFace`|✔ _**(47+)**_|✔ _**(9+)**_|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[api-inference.huggingface.co](https://api-inference.huggingface.co)|[Get API key](https://huggingface.co/settings/tokens)|`g4f.Provider.HuggingFaceAPI`|✔ _**(9+)**_|✔ _**(2+)**_|✔ _**(1+)**_|❌|![](https://img.shields.io/badge/Active-brightgreen)|✔|
+| Website | API Credentials | Provider | Text generation | Image generation | Audio generation | Vision (Image Upload) | Streaming | Status |
+|----------|-------------|--------------|---------------|--------|--------|------|------|------|
+|[huggingface.co/chat](https://huggingface.co/chat)|[Manual cookies](https://huggingface.co/chat)|`g4f.Provider.HuggingChat`|`qwen-2.5-72b, llama-3.3-70b, command-r-plus, deepseek-r1, qwq-32b, nemotron-70b, llama-3.2-11b, mistral-nemo, phi-3.5-mini`|`flux-dev, flux-schnell`|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[huggingface.co/chat](https://huggingface.co/chat)|[API key / Cookies](https://huggingface.co/settings/tokens)|`g4f.Provider.HuggingFace`|✔ _**(47+)**_|✔ _**(9+)**_|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[api-inference.huggingface.co](https://api-inference.huggingface.co)|[Get API key](https://huggingface.co/settings/tokens)|`g4f.Provider.HuggingFaceAPI`|✔ _**(9+)**_|✔ _**(2+)**_|❌|✔ _**(1+)**_|❌|![](https://img.shields.io/badge/Active-brightgreen)|✔|
 
 ---
 ### Providers HuggingSpace
-| Website | API Credentials | Provider | Text Models | Image Models | Vision (Image Upload) | Stream | Status | Auth |
+| Website | API Credentials | Provider | Text generation | Image generation | Audio generation | Vision (Image Upload) | Streaming | Status |
 |----------|-------------|--------------|---------------|--------|--------|------|------|------|
-|[black-forest-labs-flux-1-dev.hf.space](https://black-forest-labs-flux-1-dev.hf.space)|[Get API key](https://huggingface.co/settings/tokens)|`g4f.Provider.BlackForestLabsFlux1Dev`|❌|`flux-dev`|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[black-forest-labs-flux-1-schnell.hf.space](https://black-forest-labs-flux-1-schnell.hf.space)|[Get API key](https://huggingface.co/settings/tokens)|`g4f.Provider.BlackForestLabsFlux1Schnell`|❌|`flux-schnell`|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[cohereforai-c4ai-command.hf.space](https://cohereforai-c4ai-command.hf.space)|[Get API key](https://huggingface.co/settings/tokens)|`g4f.Provider.CohereForAI`|`command-r, command-r-plus, command-r7b`|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[roxky-flux-1-dev.hf.space](https://roxky-flux-1-dev.hf.space)|[Get API key](https://huggingface.co/settings/tokens)|❌|❌|✔ _**(3)**_|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[huggingface.co/spaces/deepseek-ai/Janus-Pro-7B](https://huggingface.co/spaces/deepseek-ai/Janus-Pro-7B)|[Get API key](https://huggingface.co/settings/tokens)|`g4f.Provider.Janus_Pro_7B`|✔|✔|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[qwen-qvq-72b-preview.hf.space](https://qwen-qvq-72b-preview.hf.space)|[Get API key](https://huggingface.co/settings/tokens)|`g4f.Provider.Qwen_QVQ_72B`|`qvq-72b`|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[qwen-qwen2-5-1m-demo.hf.space](https://qwen-qwen2-5-1m-demo.hf.space)|[Get API key](https://huggingface.co/settings/tokens)|`g4f.Provider.Qwen_Qwen_2_5M_Demo`|`qwen-2.5-1m-demo`|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[qwen-qwen2-72b-instruct.hf.space](https://qwen-qwen2-72b-instruct.hf.space)|[Get API key](https://huggingface.co/settings/tokens)|`g4f.Provider.Qwen_Qwen_2_72B_Instruct`|`qwen-2-72b`|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[stabilityai-stable-diffusion-3-5-large.hf.space](https://stabilityai-stable-diffusion-3-5-large.hf.space)|[Get API key](https://huggingface.co/settings/tokens)|`g4f.Provider.StableDiffusion35Large`|❌|`sd-3.5`|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[voodoohop-flux-1-schnell.hf.space](https://voodoohop-flux-1-schnell.hf.space)|[Get API key](https://huggingface.co/settings/tokens)|`g4f.Provider.VoodoohopFlux1Schnell`|❌|`flux-schnell`|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[black-forest-labs-flux-1-dev.hf.space](https://black-forest-labs-flux-1-dev.hf.space)|[Get API key](https://huggingface.co/settings/tokens)|`g4f.Provider.BlackForestLabs_Flux1Dev`|❌|`flux-dev`|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[black-forest-labs-flux-1-schnell.hf.space](https://black-forest-labs-flux-1-schnell.hf.space)|[Get API key](https://huggingface.co/settings/tokens)|`g4f.Provider.BlackForestLabs_Flux1Schnell`|❌|`flux-schnell`|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[cohereforai-c4ai-command.hf.space](https://cohereforai-c4ai-command.hf.space)|[Get API key](https://huggingface.co/settings/tokens)|`g4f.Provider.CohereForAI_C4AI_Command`|`command-r, command-r-plus, command-r7b`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[huggingface.co/spaces/deepseek-ai/Janus-Pro-7B](https://huggingface.co/spaces/deepseek-ai/Janus-Pro-7B)|[Get API key](https://huggingface.co/settings/tokens)|`g4f.Provider.DeepseekAI_Janus_Pro_7b`|✔|✔|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[roxky-flux-1-dev.hf.space](https://roxky-flux-1-dev.hf.space)|[Get API key](https://huggingface.co/settings/tokens)|`g4f.Provider.G4F`|✔ _**(1+)**_|✔ _**(4+)**_|❌|✔ _**(1+)**_|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[microsoft-phi-4-multimodal.hf.space](https://microsoft-phi-4-multimodal.hf.space)|[Get API key](https://huggingface.co/settings/tokens)|`g4f.Provider.Microsoft_Phi_4`|✔ _**(1+)**_|❌|❌|✔ _**(1+)**_|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[qwen-qvq-72b-preview.hf.space](https://qwen-qvq-72b-preview.hf.space)|[Get API key](https://huggingface.co/settings/tokens)|`g4f.Provider.Qwen_QVQ_72B`|`qvq-72b`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[qwen-qwen2-5-1m-demo.hf.space](https://qwen-qwen2-5-1m-demo.hf.space)|[Get API key](https://huggingface.co/settings/tokens)|`g4f.Provider.Qwen_Qwen_2_5M_Demo`|`qwen-2.5-1m-demo`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[qwen-qwen2-72b-instruct.hf.space](https://qwen-qwen2-72b-instruct.hf.space)|[Get API key](https://huggingface.co/settings/tokens)|`g4f.Provider.Qwen_Qwen_2_72B_Instruct`|`qwen-2-72b`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[stabilityai-stable-diffusion-3-5-large.hf.space](https://stabilityai-stable-diffusion-3-5-large.hf.space)|[Get API key](https://huggingface.co/settings/tokens)|`g4f.Provider.StabilityAI_SD35Large`|❌|`sd-3.5`|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[voodoohop-flux-1-schnell.hf.space](https://voodoohop-flux-1-schnell.hf.space)|[Get API key](https://huggingface.co/settings/tokens)|`g4f.Provider.Voodoohop_Flux1Schnell`|❌|`flux-schnell`|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
 
 ### Providers Local
-| Website | API Credentials | Provider | Text Models | Image Models | Vision (Image Upload) | Stream | Status |
-|----------|-------------|--------------|---------------|--------|--------|------|------|
-|[]( )|No auth required|`g4f.Provider.Local`|✔|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[ollama.com](https://ollama.com)|No auth required|`g4f.Provider.Ollama`|✔|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+| Website | API Credentials | Provider | Text generation | Image generation | Audio generation | Vision (Image Upload) | Streaming | Status |
+|----------|-------------|--------------|---------------|--------|--------|------|------|------|
+|[]( )|No auth required|`g4f.Provider.Local`|✔|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[ollama.com](https://ollama.com)|No auth required|`g4f.Provider.Ollama`|✔|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
 
 ---
 ### Providers MiniMax
-| Website | API Credentials | Provider | Text Models | Image Models | Vision (Image Upload) | Stream | Status |
-|----------|-------------|--------------|---------------|--------|--------|------|------|
-|[hailuo.ai/chat](https://www.hailuo.ai/chat)|[Get API key](https://intl.minimaxi.com/user-center/basic-information/interface-key)|`g4f.Provider.MiniMax`|`MiniMax`  _**(1)**_|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+| Website | API Credentials | Provider | Text generation | Image generation| Audio generation | Vision (Image Upload) | Stream | Status |
+|----------|-------------|--------------|---------------|--------|--------|------|------|------|
+|[hailuo.ai/chat](https://www.hailuo.ai/chat)|[Get API key](https://intl.minimaxi.com/user-center/basic-information/interface-key)|`g4f.Provider.MiniMax`|`MiniMax`  _**(1)**_|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
 
 
 ---
 ### Providers Needs Auth
-| Website | API Credentials | Provider | Text Models | Image Models | Vision (Image Upload) | Stream | Status |
-|----------|-------------|--------------|---------------|--------|--------|------|------|
-|[console.anthropic.com](https://console.anthropic.com)|[Get API key](https://console.anthropic.com/settings/keys)|`g4f.Provider.Anthropic`|✔ _**(8+)**_|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[bing.com/images/create](https://www.bing.com/images/create)|[Manual cookies](https://www.bing.com)|`g4f.Provider.BingCreateImages`|❌|`dall-e-3`|❌|❌|![](https://img.shields.io/badge/Active-brightgreen)|
-|[cablyai.com/chat](https://cablyai.com/chat)|[Get API key](https://cablyai.com)|`g4f.Provider.CablyAI`|✔|✔|✔|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[inference.cerebras.ai](https://inference.cerebras.ai/)|[Get API key](https://cloud.cerebras.ai)|`g4f.Provider.Cerebras`|✔ _**(3+)**_|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[copilot.microsoft.com](https://copilot.microsoft.com)|[Manual cookies](https://copilot.microsoft.com)|`g4f.Provider.CopilotAccount`|✔ _**(1+)**_|✔ _**(1+)**_|✔ _**(1+)**_|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[deepinfra.com](https://deepinfra.com)|[Get API key](https://deepinfra.com/dash/api_keys)|`g4f.Provider.DeepInfra`|✔ _**(17+)**_|✔ _**(6+)**_|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[platform.deepseek.com](https://platform.deepseek.com)|[Get API key](https://platform.deepseek.com/api_keys)|`g4f.Provider.DeepSeek`|✔ _**(1+)**_|❌|❌|❌|![](https://img.shields.io/badge/Active-brightgreen)|
-|[gemini.google.com](https://gemini.google.com)|[Manual cookies](https://gemini.google.com)|`g4f.Provider.Gemini`|`gemini-2.0`|`gemini-2.0`|`gemini-2.0`|❌|![](https://img.shields.io/badge/Active-brightgreen)|
-|[ai.google.dev](https://ai.google.dev)|[Get API key](https://aistudio.google.com/u/0/apikey)|`g4f.Provider.GeminiPro`|`gemini-1.5-flash, gemini-1.5-pro, gemini-2.0-flash`|❌|`gemini-1.5-pro`|❌|![](https://img.shields.io/badge/Active-brightgreen)|
-|[developers.sber.ru/gigachat](https://developers.sber.ru/gigachat)|[Manual cookies](https://developers.sber.ru/gigachat)|`g4f.Provider.GigaChat`|✔ _**(3+)**_|❌|❌|❌|![](https://img.shields.io/badge/Active-brightgreen)|
-|[github.com/copilot](https://github.com/copilot)|[Manual cookies](https://github.com/copilot)|`g4f.Provider.GithubCopilot`|✔ _**(4+)**_|❌|❌|❌|![](https://img.shields.io/badge/Active-brightgreen)|
+| Website | API Credentials | Provider | Text generation | Image generation | Audio generation | Vision (Image Upload) | Streaming | Status |
+|----------|-------------|--------------|---------------|--------|--------|------|------|------|
+|[console.anthropic.com](https://console.anthropic.com)|[Get API key](https://console.anthropic.com/settings/keys)|`g4f.Provider.Anthropic`|✔ _**(8+)**_|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[bing.com/images/create](https://www.bing.com/images/create)|[Manual cookies](https://www.bing.com)|`g4f.Provider.BingCreateImages`|❌|`dall-e-3`|❌|❌|❌|![](https://img.shields.io/badge/Active-brightgreen)|
+|[cablyai.com/chat](https://cablyai.com/chat)|[Get API key](https://cablyai.com)|`g4f.Provider.CablyAI`|✔|✔|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[inference.cerebras.ai](https://inference.cerebras.ai/)|[Get API key](https://cloud.cerebras.ai)|`g4f.Provider.Cerebras`|✔ _**(3+)**_|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[copilot.microsoft.com](https://copilot.microsoft.com)|[Manual cookies](https://copilot.microsoft.com)|`g4f.Provider.CopilotAccount`|✔ _**(1+)**_|✔ _**(1+)**_|❌|✔ _**(1+)**_|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[deepinfra.com](https://deepinfra.com)|[Get API key](https://deepinfra.com/dash/api_keys)|`g4f.Provider.DeepInfra`|✔ _**(17+)**_|✔ _**(6+)**_|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[platform.deepseek.com](https://platform.deepseek.com)|[Get API key](https://platform.deepseek.com/api_keys)|`g4f.Provider.DeepSeek`|✔ _**(1+)**_|❌|❌|❌|❌|![](https://img.shields.io/badge/Active-brightgreen)|
+|[gemini.google.com](https://gemini.google.com)|[Manual cookies](https://gemini.google.com)|`g4f.Provider.Gemini`|`gemini-2.0`|`gemini-2.0`|❌|`gemini-2.0`|❌|![](https://img.shields.io/badge/Active-brightgreen)|
+|[ai.google.dev](https://ai.google.dev)|[Get API key](https://aistudio.google.com/u/0/apikey)|`g4f.Provider.GeminiPro`|`gemini-1.5-flash, gemini-1.5-pro, gemini-2.0-flash`|❌|❌|`gemini-1.5-pro`|❌|![](https://img.shields.io/badge/Active-brightgreen)|
+|[developers.sber.ru/gigachat](https://developers.sber.ru/gigachat)|[Manual cookies](https://developers.sber.ru/gigachat)|`g4f.Provider.GigaChat`|✔ _**(3+)**_|❌|❌|❌|❌|![](https://img.shields.io/badge/Active-brightgreen)|
+|[github.com/copilot](https://github.com/copilot)|[Manual cookies](https://github.com/copilot)|`g4f.Provider.GithubCopilot`|✔ _**(4+)**_|❌|❌|❌|❌|![](https://img.shields.io/badge/Active-brightgreen)|
 |[glhf.chat](https://glhf.chat)|[Get API key](https://glhf.chat/user-settings/api)|`g4f.Provider.GlhfChat`|✔ _**(22+)**_|❌|❌|❌|![](https://img.shields.io/badge/Active-brightgreen)|
-|[console.groq.com/playground](https://console.groq.com/playground)|[Get API key](https://console.groq.com/keys)|`g4f.Provider.Groq`|✔ _**(18+)**_|❌|✔|❌|![](https://img.shields.io/badge/Active-brightgreen)|
-|[meta.ai](https://www.meta.ai)|[Manual cookies](https://www.meta.ai)|`g4f.Provider.MetaAI`|`meta-ai`|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|✔|
-|[meta.ai](https://www.meta.ai)|[Manual cookies](https://www.meta.ai)|`g4f.Provider.MetaAIAccount`|❌|`meta-ai`|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[designer.microsoft.com](https://designer.microsoft.com)|[Manual cookies](https://designer.microsoft.com)|`g4f.Provider.MicrosoftDesigner`|❌|`dall-e-3`|❌|❌|![](https://img.shields.io/badge/Active-brightgreen)|
-|[platform.openai.com](https://platform.openai.com)|[Get API key](https://platform.openai.com/settings/organization/api-keys)|`g4f.Provider.OpenaiAPI`|✔|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[chatgpt.com](https://chatgpt.com)|[Manual cookies](https://chatgpt.com)|`g4f.Provider.OpenaiChat`|`gpt-4o, gpt-4o-mini, gpt-4` _**(8+)**_|✔_**(1)**_|✔_**(8+)**_|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[perplexity.ai](https://www.perplexity.ai)|[Get API key](https://www.perplexity.ai/settings/api)|`g4f.Provider.PerplexityApi`|✔ _**(6+)**_|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[chat.reka.ai](https://chat.reka.ai)|[Manual cookies](https://chat.reka.ai)|`g4f.Provider.Reka`|`reka-core`|❌|✔|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[replicate.com](https://replicate.com)|[Get API key](https://replicate.com/account/api-tokens)|`g4f.Provider.Replicate`|✔ _**(1+)**_|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[beta.theb.ai](https://beta.theb.ai)|[Get API key](https://beta.theb.ai)|`g4f.Provider.ThebApi`|✔ _**(21+)**_|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[whiterabbitneo.com](https://www.whiterabbitneo.com)|[Manual cookies](https://www.whiterabbitneo.com)|`g4f.Provider.WhiteRabbitNeo`|✔|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[console.x.ai](https://console.x.ai)|[Get API key](https://console.x.ai)|`g4f.Provider.xAI`|✔|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[console.groq.com/playground](https://console.groq.com/playground)|[Get API key](https://console.groq.com/keys)|`g4f.Provider.Groq`|✔ _**(18+)**_|❌|❌|✔|❌|![](https://img.shields.io/badge/Active-brightgreen)|
+|[meta.ai](https://www.meta.ai)|[Manual cookies](https://www.meta.ai)|`g4f.Provider.MetaAI`|`meta-ai`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|✔|
+|[meta.ai](https://www.meta.ai)|[Manual cookies](https://www.meta.ai)|`g4f.Provider.MetaAIAccount`|❌|`meta-ai`|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[designer.microsoft.com](https://designer.microsoft.com)|[Manual cookies](https://designer.microsoft.com)|`g4f.Provider.MicrosoftDesigner`|❌|`dall-e-3`|❌|❌|❌|![](https://img.shields.io/badge/Active-brightgreen)|
+|[platform.openai.com](https://platform.openai.com)|[Get API key](https://platform.openai.com/settings/organization/api-keys)|`g4f.Provider.OpenaiAPI`|✔|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[chatgpt.com](https://chatgpt.com)|[Manual cookies](https://chatgpt.com)|`g4f.Provider.OpenaiChat`|`gpt-4o, gpt-4o-mini, gpt-4` _**(8+)**_|✔ _**(1)**_|❌|✔ _**(8+)**_|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[perplexity.ai](https://www.perplexity.ai)|[Get API key](https://www.perplexity.ai/settings/api)|`g4f.Provider.PerplexityApi`|✔ _**(6+)**_|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[chat.reka.ai](https://chat.reka.ai)|[Manual cookies](https://chat.reka.ai)|`g4f.Provider.Reka`|`reka-core`|✔|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[replicate.com](https://replicate.com)|[Get API key](https://replicate.com/account/api-tokens)|`g4f.Provider.Replicate`|✔ _**(1+)**_|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[beta.theb.ai](https://beta.theb.ai)|[Get API key](https://beta.theb.ai)|`g4f.Provider.ThebApi`|✔ _**(21+)**_|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[whiterabbitneo.com](https://www.whiterabbitneo.com)|[Manual cookies](https://www.whiterabbitneo.com)|`g4f.Provider.WhiteRabbitNeo`|✔|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[console.x.ai](https://console.x.ai)|[Get API key](https://console.x.ai)|`g4f.Provider.xAI`|✔|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
 
 ---
 ## Models
 
-### Text Models
+### Text generation models
 | Model | Base Provider | Providers | Website |
 |-------|---------------|-----------|---------|
 |gpt-4|OpenAI|8+ Providers|[platform.openai.com](https://platform.openai.com/docs/models/gpt-4-turbo-and-gpt-4)|
-|gpt-4o|OpenAI|7+ Providers|[platform.openai.com](https://platform.openai.com/docs/models/gpt-4o)|
+|gpt-4o|OpenAI|6+ Providers|[platform.openai.com](https://platform.openai.com/docs/models/gpt-4o)|
 |gpt-4o-mini|OpenAI|7+ Providers|[platform.openai.com](https://platform.openai.com/docs/models/gpt-4o-mini)|
-|o1|OpenAI|2+ Providers|[openai.com](https://openai.com/index/introducing-openai-o1-preview/)|
+|o1|OpenAI|3+ Providers|[openai.com](https://openai.com/index/introducing-openai-o1-preview/)|
 |o1-mini|OpenAI|1+ Providers|[openai.com](https://openai.com/index/openai-o1-mini-advancing-cost-efficient-reasoning/)|
 |o3-mini|OpenAI|3+ Providers|[openai.com](https://openai.com/index/openai-o3-mini/)|
 |gigachat|GigaChat|1+ Providers|[developers.sber.ru/gigachat](https://developers.sber.ru/gigachat)|
@@ -151,9 +154,9 @@ This document provides an overview of various AI providers and models, including
 |llama-2-7b|Meta Llama|1+ Providers|[huggingface.co](https://huggingface.co/meta-llama/Llama-2-7b)|
 |llama-3-8b|Meta Llama|2+ Providers|[ai.meta.com](https://ai.meta.com/blog/meta-llama-3/)|
 |llama-3-70b|Meta Llama|1+ Providers|[huggingface.co](https://huggingface.co/meta-llama/Meta-Llama-3-70B)|
-|llama-3.1-8b|Meta Llama|6+ Providers|[ai.meta.com](https://ai.meta.com/blog/meta-llama-3-1/)|
-|llama-3.1-70b|Meta Llama|3+ Providers|[ai.meta.com](https://ai.meta.com/blog/meta-llama-3-1/)|
-|llama-3.1-405b|Meta Llama|2+ Providers|[huggingface.co](https://huggingface.co/meta-llama/Llama-3.1-405B)|
+|llama-3.1-8b|Meta Llama|7+ Providers|[ai.meta.com](https://ai.meta.com/blog/meta-llama-3-1/)|
+|llama-3.1-70b|Meta Llama|4+ Providers|[ai.meta.com](https://ai.meta.com/blog/meta-llama-3-1/)|
+|llama-3.1-405b|Meta Llama|3+ Providers|[huggingface.co](https://huggingface.co/meta-llama/Llama-3.1-405B)|
 |llama-3.2-1b|Meta Llama|1+ Providers|[huggingface.co](https://huggingface.co/meta-llama/Llama-3.2-1B)|
 |llama-3.2-3b|Meta Llama|1+ Providers|[huggingface.co](https://huggingface.co/meta-llama/Llama-3.2-3B)|
 |llama-3.2-11b|Meta Llama|3+ Providers|[ai.meta.com](https://ai.meta.com/blog/llama-3-2-connect-2024-vision-edge-mobile-devices/)|
@@ -171,9 +174,9 @@ This document provides an overview of various AI providers and models, including
 |wizardlm-2-8x22b|Microsoft|2+ Providers|[wizardlm.github.io](https://wizardlm.github.io/WizardLM2/)|
 |gemini-2.0|Google DeepMind|1+ Providers|[deepmind.google](http://deepmind.google/technologies/gemini/)|
 |gemini-exp|Google DeepMind|1+ Providers|[blog.google](https://blog.google/feed/gemini-exp-1206/)|
-|gemini-1.5-flash|Google DeepMind|6+ Providers|[deepmind.google](https://deepmind.google/technologies/gemini/flash/)|
-|gemini-1.5-pro|Google DeepMind|6+ Providers|[deepmind.google](https://deepmind.google/technologies/gemini/pro/)|
-|gemini-2.0-flash|Google DeepMind|3+ Providers|[deepmind.google](https://deepmind.google/technologies/gemini/flash/)|
+|gemini-1.5-flash|Google DeepMind|8+ Providers|[deepmind.google](https://deepmind.google/technologies/gemini/flash/)|
+|gemini-1.5-pro|Google DeepMind|7+ Providers|[deepmind.google](https://deepmind.google/technologies/gemini/pro/)|
+|gemini-2.0-flash|Google DeepMind|4+ Providers|[deepmind.google](https://deepmind.google/technologies/gemini/flash/)|
 |gemini-2.0-flash-thinking|Google DeepMind|1+ Providers|[ai.google.dev](https://ai.google.dev/gemini-api/docs/thinking-mode)|
 |gemini-2.0-pro|Google DeepMind|1+ Providers|[deepmind.google](https://deepmind.google/technologies/gemini/flash-thinking/)|
 |claude-3-haiku|Anthropic|2+ Providers|[anthropic.com](https://www.anthropic.com/news/claude-3-haiku)|
@@ -226,18 +229,17 @@ This document provides an overview of various AI providers and models, including
 |evil|Evil Mode - Experimental|1+ Providers|[]( )|
 
 ---
-### Image Models
+### Image generation models
 | Model | Base Provider | Providers | Website |
 |-------|---------------|-----------|---------|
 |sdxl-turbo|Stability AI|2+ Providers|[huggingface.co](https://huggingface.co/stabilityai/sdxl-turbo)|
 |sd-3.5|Stability AI|1+ Providers|[huggingface.co](https://huggingface.co/stabilityai/stable-diffusion-3.5-large)|
-|flux|Black Forest Labs|3+ Providers|[github.com/black-forest-labs/flux](https://github.com/black-forest-labs/flux)|
+|flux|Black Forest Labs|4+ Providers|[github.com/black-forest-labs/flux](https://github.com/black-forest-labs/flux)|
 |flux-pro|Black Forest Labs|1+ Providers|[huggingface.co](https://huggingface.co/enhanceaiteam/FLUX.1-Pro)|
 |flux-dev|Black Forest Labs|4+ Providers|[huggingface.co](https://huggingface.co/black-forest-labs/FLUX.1-dev)|
 |flux-schnell|Black Forest Labs|4+ Providers|[huggingface.co](https://huggingface.co/black-forest-labs/FLUX.1-schnell)|
 |dall-e-3|OpenAI|5+ Providers|[openai.com](https://openai.com/index/dall-e/)|
 |midjourney|Midjourney|1+ Providers|[docs.midjourney.com](https://docs.midjourney.com/docs/model-versions)|
-
 
 
 ## Conclusion and Usage Tips

--- a/docs/providers-and-models.md
+++ b/docs/providers-and-models.md
@@ -42,7 +42,7 @@ This document provides an overview of various AI providers and models, including
 |----------|-------------|--------------|---------------|--------|--------|------|------|------|
 |[playground.allenai.org](https://playground.allenai.org)|No auth required|`g4f.Provider.AllenAI`|`tulu-3-405b, olmo-2-13b, tulu-3-1-8b, tulu-3-70b, olmoe-0125`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
 |[ai-arta.com](https://ai-arta.com)|No auth required|`g4f.Provider.ARTA`|❌|✔ _**(17+)**_|❌|❌|❌|![](https://img.shields.io/badge/Active-brightgreen)|
-|[blackbox.ai](https://www.blackbox.ai)|No auth required|`g4f.Provider.Blackbox`|`blackboxai, gemini-1.5-flash, blackboxai-pro, llama-3.1-8b, llama-3.1-70b, llama-3-1-405b, llama-3.3-70b, mixtral-small-28b, deepseek-chat, dbrx-instruct, qwq-32b, hermes-2-dpo, deepseek-v3, deepseek-r1, gemini-2.0-flash, gpt-4o, o1, o3-mini, gemini-1.5-pro, claude-3.7-sonnet` _**(29+)**_|`flux`|❌|`blackboxai, gpt-4o, o1, o3-mini, gemini-1.5-pro, gemini-1.5-flash, llama-3.1-8b, llama-3.1-70b, llama-3.1-405b, gemini-2.0-flash, deepseek-v3`|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[blackbox.ai](https://www.blackbox.ai)|No auth required|`g4f.Provider.Blackbox`|`blackboxai, gemini-1.5-flash, blackboxai-pro, llama-3.1-8b, llama-3.1-70b, llama-3-1-405b, llama-3.3-70b, mixtral-small-24b, deepseek-chat, dbrx-instruct, qwq-32b, hermes-2-dpo, deepseek-v3, deepseek-r1, gemini-2.0-flash, gpt-4o, o1, o3-mini, gemini-1.5-pro, claude-3.7-sonnet` _**(29+)**_|`flux`|❌|`blackboxai, gpt-4o, o1, o3-mini, gemini-1.5-pro, gemini-1.5-flash, llama-3.1-8b, llama-3.1-70b, llama-3.1-405b, gemini-2.0-flash, deepseek-v3`|✔|![](https://img.shields.io/badge/Active-brightgreen)|
 |[chatglm.cn](https://chatglm.cn)|No auth required|`g4f.Provider.ChatGLM`|`glm-4`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
 |[chatgpt.com](https://chatgpt.com)|No auth required|`g4f.Provider.ChatGpt`|✔ _**(7+)**_|❌|❌|❌|✔|![Error](https://img.shields.io/badge/HTTPError-f48d37)|
 |[chatgpt.es](https://chatgpt.es)|No auth required|`g4f.Provider.ChatGptEs`|`gpt-4, gpt-4o, gpt-4o-mini`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
@@ -165,8 +165,8 @@ This document provides an overview of various AI providers and models, including
 |mixtral-8x7b|Mistral|1+ Providers|[mistral.ai](https://mistral.ai/news/mixtral-of-experts/)|
 |mixtral-8x22b|Mistral|1+ Providers|[huggingface.co](https://huggingface.co/mistralai/Mixtral-8x22B-Instruct-v0.1)|
 |mistral-nemo|Mistral|3+ Providers|[huggingface.co](https://huggingface.co/mistralai/Mistral-Nemo-Instruct-2407)|
-|mixtral-small-24b|Mistral|1+ Providers|[huggingface.co](https://huggingface.co/mistralai/Mistral-Small-24B-Instruct-2501)|
-|mixtral-small-28b|Mistral|2+ Providers|[mistral.ai](https://mistral.ai/news/mixtral-small-28b/)|
+|mixtral-small-24b|Mistral|2+ Providers|[huggingface.co](https://huggingface.co/mistralai/Mistral-Small-24B-Instruct-2501)|
+|mixtral-small-28b|Mistral|1+ Providers|[mistral.ai](https://mistral.ai/news/mixtral-small-28b/)|
 |hermes-2-dpo|NousResearch|1+ Providers|[huggingface.co](https://huggingface.co/NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO)|
 |phi-3.5-mini|Microsoft|1+ Providers|[huggingface.co](https://huggingface.co/microsoft/Phi-3.5-mini-instruct)|
 |phi-4|Microsoft|2+ Providers|[techcommunity.microsoft.com](https://techcommunity.microsoft.com/blog/aiplatformblog/introducing-phi-4-microsoft%E2%80%99s-newest-small-language-model-specializing-in-comple/4357090)|

--- a/docs/providers-and-models.md
+++ b/docs/providers-and-models.md
@@ -59,7 +59,7 @@ This document provides an overview of various AI providers and models, including
 |[editor.imagelabs.net](editor.imagelabs.net)|No auth required|`g4f.Provider.ImageLabs`|❌|`sdxl-turbo`|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
 |[huggingface.co/spaces](https://huggingface.co/spaces)|Optional API key|`g4f.Provider.HuggingSpace`|`qvq-72b, qwen-2-72b, command-r, command-r-plus, command-r7b, command-a`|`flux-dev, flux-schnell, sd-3.5`|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
 |[jmuz.me](https://jmuz.me)|Optional API key|`g4f.Provider.Jmuz`|`claude-3-haiku, claude-3-opus, claude-3.5-sonnet, deepseek-r1, deepseek-chat, gemini-exp, gemini-1.5-flash, gemini-1.5-pro, gemini-2.0-flash-thinking, gpt-4, gpt-4o, gpt-4o-mini, llama-3-70b, llama-3-8b, llama-3.1-405b, llama-3.1-70b, llama-3.1-8b, llama-3.2-11b, llama-3.2-90b, llama-3.3-70b, mixtral-8x7b, qwen-2.5-72b, qwen-2.5-coder-32b, qwq-32b, wizardlm-2-8x22b`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[lambda.chat](https://lambda.chat)|No auth required|`g4f.Provider.LambdaChat`|`deepseek-v3, hermes-3, nemotron-70b, llama-3.3-70b`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[lambda.chat](https://lambda.chat)|No auth required|`g4f.Provider.LambdaChat`|`deepseek-v3, deepseek-r1, hermes-3, nemotron-70b, llama-3.3-70b`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
 |[liaobots.work](https://liaobots.work)|[Automatic cookies](https://liaobots.work)|`g4f.Provider.Liaobots`|`claude-3.5-sonnet, claude-3.7-sonnet, claude-3.7-sonnet-thinking, claude-3-opus, claude-3-sonnet, deepseek-r1, deepseek-v3, gemini-2.0-flash, gemini-2.0-flash-thinking, gemini-2.0-pro, gpt-4, gpt-4o, gpt-4o-mini, grok-3, grok-3-r1, o3-mini`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
 |[oi-vscode-server.onrender.com](https://oi-vscode-server.onrender.com)|No auth required|`g4f.Provider.OIVSCode`|`gpt-4o-mini, deepseek-v3`|❌|❌|`gpt-4o-mini`|✔|![](https://img.shields.io/badge/Active-brightgreen)|
 |[labs.perplexity.ai](https://labs.perplexity.ai)|No auth required|`g4f.Provider.PerplexityLabs`|`sonar, sonar-pro, sonar-reasoning, sonar-reasoning-pro`|❌|❌|❌|✔|![Error](https://img.shields.io/badge/Active-brightgreen)|
@@ -204,7 +204,7 @@ This document provides an overview of various AI providers and models, including
 |pi|Inflection|1+ Providers|[inflection.ai](https://inflection.ai/blog/inflection-2-5)|
 |deepseek-chat|DeepSeek|2+ Providers|[huggingface.co](https://huggingface.co/deepseek-ai/deepseek-llm-67b-chat)|
 |deepseek-v3|DeepSeek|4+ Providers|[api-docs.deepseek.com](https://api-docs.deepseek.com/news/news250120)|
-|deepseek-r1|DeepSeek|8+ Providers|[api-docs.deepseek.com](https://api-docs.deepseek.com/news/news250120)|
+|deepseek-r1|DeepSeek|9+ Providers|[api-docs.deepseek.com](https://api-docs.deepseek.com/news/news250120)|
 |janus-pro-7b|DeepSeek|2+ Providers|[api-docs.deepseek.com](https://api-docs.deepseek.com/docs/janus-pro-7b)|
 |grok-3|x.ai|1+ Providers|[x.ai](https://x.ai/blog/grok-3)|
 |grok-3-r1|x.ai|1+ Providers|[x.ai](https://x.ai/blog/grok-3)|
@@ -228,6 +228,7 @@ This document provides an overview of various AI providers and models, including
 |tulu-3-1-8b|Ai2|1+ Providers|[allenai.org](https://allenai.org/documentation)|
 |tulu-3-70b|Ai2|1+ Providers|[allenai.org](https://allenai.org/documentation)|
 |olmoe-0125|Ai2|1+ Providers|[allenai.org](https://allenai.org/documentation)|
+|lfm-40b|Liquid AI|1+ Providers|[liquid.ai](https://www.liquid.ai/liquid-foundation-models)|
 |evil|Evil Mode - Experimental|1+ Providers|[]( )|
 
 ---

--- a/docs/providers-and-models.md
+++ b/docs/providers-and-models.md
@@ -57,7 +57,7 @@ This document provides an overview of various AI providers and models, including
 |[glider.so](https://glider.so)|No auth required|`g4f.Provider.Glider`|`llama-3.1-70b, llama-3.1-8b, llama-3.2-3b, deepseek-r1`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
 |[hailuo.ai](https://www.hailuo.ai)|No auth required|`g4f.Provider.HailuoAI`|`MiniMax` _**(1+)**_|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
 |[editor.imagelabs.net](editor.imagelabs.net)|No auth required|`g4f.Provider.ImageLabs`|❌|`sdxl-turbo`|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
-|[huggingface.co/spaces](https://huggingface.co/spaces)|Optional API key|`g4f.Provider.HuggingSpace`|`qvq-72b, qwen-2-72b, command-r, command-r-plus, command-r7b`|`flux-dev, flux-schnell, sd-3.5`|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
+|[huggingface.co/spaces](https://huggingface.co/spaces)|Optional API key|`g4f.Provider.HuggingSpace`|`qvq-72b, qwen-2-72b, command-r, command-r-plus, command-r7b, command-a`|`flux-dev, flux-schnell, sd-3.5`|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
 |[jmuz.me](https://jmuz.me)|Optional API key|`g4f.Provider.Jmuz`|`claude-3-haiku, claude-3-opus, claude-3.5-sonnet, deepseek-r1, deepseek-chat, gemini-exp, gemini-1.5-flash, gemini-1.5-pro, gemini-2.0-flash-thinking, gpt-4, gpt-4o, gpt-4o-mini, llama-3-70b, llama-3-8b, llama-3.1-405b, llama-3.1-70b, llama-3.1-8b, llama-3.2-11b, llama-3.2-90b, llama-3.3-70b, mixtral-8x7b, qwen-2.5-72b, qwen-2.5-coder-32b, qwq-32b, wizardlm-2-8x22b`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
 |[liaobots.work](https://liaobots.work)|[Automatic cookies](https://liaobots.work)|`g4f.Provider.Liaobots`|`claude-3.5-sonnet, claude-3.7-sonnet, claude-3.7-sonnet-thinking, claude-3-opus, claude-3-sonnet, deepseek-r1, deepseek-v3, gemini-2.0-flash, gemini-2.0-flash-thinking, gemini-2.0-pro, gpt-4, gpt-4o, gpt-4o-mini, grok-3, grok-3-r1, o3-mini`|❌|❌|❌|✔|![](https://img.shields.io/badge/Active-brightgreen)|
 |[oi-vscode-server.onrender.com](https://oi-vscode-server.onrender.com)|No auth required|`g4f.Provider.OIVSCode`|`gpt-4o-mini, deepseek-v3`|❌|❌|`gpt-4o-mini`|✔|![](https://img.shields.io/badge/Active-brightgreen)|
@@ -191,6 +191,7 @@ This document provides an overview of various AI providers and models, including
 |command-r|CohereForAI|1+ Providers|[docs.cohere.com](https://docs.cohere.com/docs/command-r-plus)|
 |command-r-plus|CohereForAI|2+ Providers|[docs.cohere.com](https://docs.cohere.com/docs/command-r-plus)|
 |command-r7b|CohereForAI|1+ Providers|[huggingface.co](https://huggingface.co/CohereForAI/c4ai-command-r7b-12-2024)|
+|command-a|CohereForAI|1+ Providers|[docs.cohere.com](https://docs.cohere.com/v2/docs/command-a)|
 |qwen-1.5-7b|Qwen|1+ Providers|[huggingface.co](https://huggingface.co/Qwen/Qwen1.5-7B)|
 |qwen-2-72b|Qwen|2+ Providers|[huggingface.co](https://huggingface.co/Qwen/Qwen2-72B)|
 |qwen-2-vl-7b|Qwen|1+ Providers|[huggingface.co](https://huggingface.co/Qwen/Qwen2-VL-7B)|

--- a/etc/examples/vision_images.py
+++ b/etc/examples/vision_images.py
@@ -2,16 +2,13 @@ import g4f
 import requests
 
 from g4f.client import Client
-from g4f.Provider.Blackbox import Blackbox
 
-client = Client(
-    provider=Blackbox
-)
+client = Client()
 
 # Processing remote image
 remote_image = requests.get("https://raw.githubusercontent.com/xtekky/gpt4free/refs/heads/main/docs/images/cat.jpeg", stream=True).content
 response_remote = client.chat.completions.create(
-    model=g4f.models.default,
+    model=g4f.models.default_vision,
     messages=[
         {"role": "user", "content": "What are on this image?"}
     ],
@@ -25,7 +22,7 @@ print("\n" + "-"*50 + "\n")  # Separator
 # Processing local image
 local_image = open("docs/images/cat.jpeg", "rb")
 response_local = client.chat.completions.create(
-    model=g4f.models.default,
+    model=g4f.models.default_vision,
     messages=[
         {"role": "user", "content": "What are on this image?"}
     ],

--- a/g4f/Provider/AllenAI.py
+++ b/g4f/Provider/AllenAI.py
@@ -48,6 +48,9 @@ class AllenAI(AsyncGeneratorProvider, ProviderModelMixin):
         "olmo-2-13b": "OLMo-2-1124-13B-Instruct",
         "tulu-3-1-8b": "tulu-3-1-8b",
         "tulu-3-70b": "Llama-3-1-Tulu-3-70B",
+        "llama-3.1-405b": "Llama-3-1-Tulu-3-70B",
+        "llama-3.1-8b": "tulu-3-1-8b",
+        "llama-3.1-70b": "Llama-3-1-Tulu-3-70B",
     }
 
     @classmethod

--- a/g4f/Provider/Blackbox.py
+++ b/g4f/Provider/Blackbox.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from aiohttp import ClientSession
+import os
 import re
 import json
 import random
@@ -8,6 +9,7 @@ import string
 import base64
 from pathlib import Path
 from typing import Optional
+from datetime import datetime, timedelta
 
 from ..typing import AsyncResult, Messages, ImagesType
 from ..requests.raise_for_status import raise_for_status
@@ -17,6 +19,7 @@ from ..cookies import get_cookies_dir
 from .helper import format_prompt, format_image_prompt
 from ..providers.response import JsonConversation, ImageResponse
 from ..errors import ModelNotSupportedError
+from .. import debug
 
 class Conversation(JsonConversation):
     validated_value: str = None
@@ -38,78 +41,157 @@ class Blackbox(AsyncGeneratorProvider, ProviderModelMixin):
     
     default_model = "blackboxai"
     default_vision_model = default_model
-    default_image_model = 'flux' 
+    default_image_model = 'flux'
+    
+    # Completely free models
+    fallback_models = [
+        "blackboxai", 
+        "gpt-4o-mini", 
+        "GPT-4o", 
+        "o1", 
+        "o3-mini", 
+        "Claude-sonnet-3.7", 
+        "DeepSeek-V3", 
+        "DeepSeek-R1", 
+        "DeepSeek-LLM-Chat-(67B)",
+        # Image models
+        "flux",
+        # Trending agent modes
+        'Python Agent',
+        'HTML Agent',
+        'Builder Agent',
+        'Java Agent',
+        'JavaScript Agent',
+        'React Agent',
+        'Android Agent',
+        'Flutter Agent',
+        'Next.js Agent',
+        'AngularJS Agent',
+        'Swift Agent',
+        'MongoDB Agent',
+        'PyTorch Agent',
+        'Xcode Agent',
+        'Azure Agent',
+        'Bitbucket Agent',
+        'DigitalOcean Agent',
+        'Docker Agent',
+        'Electron Agent',
+        'Erlang Agent',
+        'FastAPI Agent',
+        'Firebase Agent',
+        'Flask Agent',
+        'Git Agent',
+        'Gitlab Agent',
+        'Go Agent',
+        'Godot Agent',
+        'Google Cloud Agent',
+        'Heroku Agent'
+    ]
     
     image_models = [default_image_model]   
-    vision_models = [default_vision_model, 'gpt-4o', 'o1', 'o3-mini', 'gemini-pro', 'gemini-1.5-flash', 'llama-3.1-8b', 'llama-3.1-70b', 'llama-3.1-405b', 'gemini-2.0-flash', 'deepseek-v3']
+    vision_models = [default_vision_model, 'GPT-4o', 'o1', 'o3-mini', 'Gemini-PRO', 'Gemini Agent', 'llama-3.1-8b Agent', 'llama-3.1-70b Agent', 'llama-3.1-405 Agent', 'Gemini-Flash-2.0', 'DeepSeek-V3']
 
-    userSelectedModel = ['gpt-4o', 'o1', 'o3-mini', 'gemini-pro', 'claude-sonnet-3.7', 'deepseek-v3', 'deepseek-r1', 'blackboxai-pro', 'Meta-Llama-3.3-70B-Instruct-Turbo', 'Mistral-Small-24B-Instruct-2501', 'DeepSeek-LLM-Chat-(67B)', 'dbrx-instruct', 'Qwen-QwQ-32B-Preview', 'Nous-Hermes-2-Mixtral-8x7B-DPO', 'gemini-2.0-flash']
+    userSelectedModel = ['GPT-4o', 'o1', 'o3-mini', 'Gemini-PRO', 'Claude-sonnet-3.7', 'DeepSeek-V3', 'DeepSeek-R1', 'Meta-Llama-3.3-70B-Instruct-Turbo', 'Mistral-Small-24B-Instruct-2501', 'DeepSeek-LLM-Chat-(67B)', 'DBRX-Instruct', 'Qwen-QwQ-32B-Preview', 'Nous-Hermes-2-Mixtral-8x7B-DPO', 'Gemini-Flash-2.0']
 
+    # Agent mode configurations
     agentMode = {
-        'deepseek-v3': {'mode': True, 'id': "deepseek-chat", 'name': "DeepSeek-V3"},
-        'deepseek-r1': {'mode': True, 'id': "deepseek-reasoner", 'name': "DeepSeek-R1"},
+        'GPT-4o': {'mode': True, 'id': "GPT-4o", 'name': "GPT-4o"},
+        'Gemini-PRO': {'mode': True, 'id': "Gemini-PRO", 'name': "Gemini-PRO"},
+        'Claude-sonnet-3.7': {'mode': True, 'id': "Claude-sonnet-3.7", 'name': "Claude-sonnet-3.7"},
+        'DeepSeek-V3': {'mode': True, 'id': "deepseek-chat", 'name': "DeepSeek-V3"},
+        'DeepSeek-R1': {'mode': True, 'id': "deepseek-reasoner", 'name': "DeepSeek-R1"},
         'Meta-Llama-3.3-70B-Instruct-Turbo': {'mode': True, 'id': "meta-llama/Llama-3.3-70B-Instruct-Turbo", 'name': "Meta-Llama-3.3-70B-Instruct-Turbo"},
+        'Gemini-Flash-2.0': {'mode': True, 'id': "Gemini/Gemini-Flash-2.0", 'name': "Gemini-Flash-2.0"},
         'Mistral-Small-24B-Instruct-2501': {'mode': True, 'id': "mistralai/Mistral-Small-24B-Instruct-2501", 'name': "Mistral-Small-24B-Instruct-2501"},
         'DeepSeek-LLM-Chat-(67B)': {'mode': True, 'id': "deepseek-ai/deepseek-llm-67b-chat", 'name': "DeepSeek-LLM-Chat-(67B)"},
-        'dbrx-instruct': {'mode': True, 'id': "databricks/dbrx-instruct", 'name': "DBRX-Instruct"},
+        'DBRX-Instruct': {'mode': True, 'id': "databricks/dbrx-instruct", 'name': "DBRX-Instruct"},
         'Qwen-QwQ-32B-Preview': {'mode': True, 'id': "Qwen/QwQ-32B-Preview", 'name': "Qwen-QwQ-32B-Preview"},
         'Nous-Hermes-2-Mixtral-8x7B-DPO': {'mode': True, 'id': "NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO", 'name': "Nous-Hermes-2-Mixtral-8x7B-DPO"},
-        'gemini-2.0-flash': {'mode': True, 'id': "Gemini/Gemini-Flash-2.0", 'name': "Gemini-Flash-2.0"},
     }
 
+    # Trending agent modes
     trendingAgentMode = {
-        "gemini-1.5-flash": {'mode': True, 'id': 'Gemini'},
-        "llama-3.1-8b": {'mode': True, 'id': "llama-3.1-8b"},
-        'llama-3.1-70b': {'mode': True, 'id': "llama-3.1-70b"},
-        'llama-3.1-405b': {'mode': True, 'id': "llama-3.1-405"},
-        'Python Agent': {'mode': True, 'id': "Python Agent"},
-        'Java Agent': {'mode': True, 'id': "Java Agent"},
-        'JavaScript Agent': {'mode': True, 'id': "JavaScript Agent"},
-        'HTML Agent': {'mode': True, 'id': "HTML Agent"},
-        'Google Cloud Agent': {'mode': True, 'id': "Google Cloud Agent"},
-        'Android Developer': {'mode': True, 'id': "Android Developer"},
-        'Swift Developer': {'mode': True, 'id': "Swift Developer"},
-        'Next.js Agent': {'mode': True, 'id': "Next.js Agent"},
-        'MongoDB Agent': {'mode': True, 'id': "MongoDB Agent"},
-        'PyTorch Agent': {'mode': True, 'id': "PyTorch Agent"},
-        'React Agent': {'mode': True, 'id': "React Agent"},
-        'Xcode Agent': {'mode': True, 'id': "Xcode Agent"},
-        'blackboxai-pro': {'mode': True, 'id': "BLACKBOXAI-PRO"},
-        'Heroku Agent': {'mode': True, 'id': "Heroku Agent"},
-        'Godot Agent': {'mode': True, 'id': "Godot Agent"},
-        'Go Agent': {'mode': True, 'id': "Go Agent"},
-        'Gitlab Agent': {'mode': True, 'id': "Gitlab Agent"},
-        'Git Agent': {'mode': True, 'id': "Git Agent"},
-        'Flask Agent': {'mode': True, 'id': "Flask Agent"},
-        'Firebase Agent': {'mode': True, 'id': "Firebase Agent"},
-        'FastAPI Agent': {'mode': True, 'id': "FastAPI Agent"},
-        'Erlang Agent': {'mode': True, 'id': "Erlang Agent"},
-        'Electron Agent': {'mode': True, 'id': "Electron Agent"},
-        'Docker Agent': {'mode': True, 'id': "Docker Agent"},
-        'DigitalOcean Agent': {'mode': True, 'id': "DigitalOcean Agent"},
-        'Bitbucket Agent': {'mode': True, 'id': "Bitbucket Agent"},
-        'Azure Agent': {'mode': True, 'id': "Azure Agent"},
-        'Flutter Agent': {'mode': True, 'id': "Flutter Agent"},
-        'Youtube Agent': {'mode': True, 'id': "Youtube Agent"},
-        'builder Agent': {'mode': True, 'id': "builder Agent"},
+        "Gemini Agent": {'mode': True, 'id': 'gemini'},
+        "llama-3.1-405 Agent": {'mode': True, 'id': "llama-3.1-405"},
+        'llama-3.1-70b Agent': {'mode': True, 'id': "llama-3.1-70b"},
+        'llama-3.1-8b Agent': {'mode': True, 'id': "llama-3.1-8b"},
+        'Python Agent': {'mode': True, 'id': "python"},
+        'HTML Agent': {'mode': True, 'id': "html"},
+        'Builder Agent': {'mode': True, 'id': "builder"},
+        'Java Agent': {'mode': True, 'id': "java"},
+        'JavaScript Agent': {'mode': True, 'id': "javascript"},
+        'React Agent': {'mode': True, 'id': "react"},
+        'Android Agent': {'mode': True, 'id': "android"},
+        'Flutter Agent': {'mode': True, 'id': "flutter"},
+        'Next.js Agent': {'mode': True, 'id': "next.js"},
+        'AngularJS Agent': {'mode': True, 'id': "angularjs"},
+        'Swift Agent': {'mode': True, 'id': "swift"},
+        'MongoDB Agent': {'mode': True, 'id': "mongodb"},
+        'PyTorch Agent': {'mode': True, 'id': "pytorch"},
+        'Xcode Agent': {'mode': True, 'id': "xcode"},
+        'Azure Agent': {'mode': True, 'id': "azure"},
+        'Bitbucket Agent': {'mode': True, 'id': "bitbucket"},
+        'DigitalOcean Agent': {'mode': True, 'id': "digitalocean"},
+        'Docker Agent': {'mode': True, 'id': "docker"},
+        'Electron Agent': {'mode': True, 'id': "electron"},
+        'Erlang Agent': {'mode': True, 'id': "erlang"},
+        'FastAPI Agent': {'mode': True, 'id': "fastapi"},
+        'Firebase Agent': {'mode': True, 'id': "firebase"},
+        'Flask Agent': {'mode': True, 'id': "flask"},
+        'Git Agent': {'mode': True, 'id': "git"},
+        'Gitlab Agent': {'mode': True, 'id': "gitlab"},
+        'Go Agent': {'mode': True, 'id': "go"},
+        'Godot Agent': {'mode': True, 'id': "godot"},
+        'Google Cloud Agent': {'mode': True, 'id': "googlecloud"},
+        'Heroku Agent': {'mode': True, 'id': "heroku"},
     }
     
-    models = list(dict.fromkeys([default_model, *userSelectedModel, *image_models, *list(agentMode.keys()), *list(trendingAgentMode.keys())]))
-
-    model_aliases = {
-        "gemini-1.5-flash": "gemini-1.5-flash",
-        "gemini-1.5-pro": "gemini-pro",
-        "llama-3.3-70b": "Meta-Llama-3.3-70B-Instruct-Turbo",
-        "mixtral-small-24b": "Mistral-Small-24B-Instruct-2501",
-        "deepseek-chat": "DeepSeek-LLM-Chat-(67B)",
-        "qwq-32b": "Qwen-QwQ-32B-Preview",
-        "hermes-2-dpo": "Nous-Hermes-2-Mixtral-8x7B-DPO",
-        "claude-3.7-sonnet": "claude-sonnet-3.7",
-    }
+    # Complete list of all models (for authorized users)
+    _all_models = list(dict.fromkeys([
+        default_model,
+        *userSelectedModel,
+        *image_models,
+        *list(agentMode.keys()),
+        *list(trendingAgentMode.keys())
+    ]))
     
-    ENCRYPTED_SESSION = "eyJ1c2VyIjogeyJuYW1lIjogIkJMQUNLQk9YIEFJIiwgImVtYWlsIjogImdpc2VsZUBibGFja2JveC5haSIsICJpbWFnZSI6ICJodHRwczovL3l0My5nb29nbGV1c2VyY29udGVudC5jb20vQjd6RVlVSzUxWnNQYmFSUFVhMF9ZbnQ1WV9URFZoTE4tVjAzdndRSHM0eF96a2g4a1psLXkxcXFxb3hoeFFzcS1wUVBHS0R0WFE9czE2MC1jLWstYzB4MDBmZmZmZmYtbm8tcmoifSwgImV4cGlyZXMiOiBudWxsfQ=="
-    ENCRYPTED_SUBSCRIPTION_CACHE = "eyJzdGF0dXMiOiAiUFJFTUlVTSIsICJleHBpcnlUaW1lc3RhbXAiOiBudWxsLCAibGFzdENoZWNrZWQiOiBudWxsLCAiaXNUcmlhbFN1YnNjcmlwdGlvbiI6IHRydWV9"
-    ENCRYPTED_IS_PREMIUM = "dHJ1ZQ=="
+    @classmethod
+    def generate_session(cls, id_length: int = 21, days_ahead: int = 365) -> dict:
+        """
+        Generate a dynamic session with proper ID and expiry format.
+        
+        Args:
+            id_length: Length of the numeric ID (default: 21)
+            days_ahead: Number of days ahead for expiry (default: 365)
+        
+        Returns:
+            dict: A session dictionary with user information and expiry
+        """
+        # Generate numeric ID
+        numeric_id = ''.join(random.choice('0123456789') for _ in range(id_length))
+        
+        # Generate future expiry date
+        future_date = datetime.now() + timedelta(days=days_ahead)
+        expiry = future_date.strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z'
+        
+        # Decode the encoded email
+        encoded_email = "Z2lzZWxlQGJsYWNrYm94LmFp"  # Base64 encoded email
+        email = base64.b64decode(encoded_email).decode('utf-8')
+        
+        # Generate random image ID for the new URL format
+        chars = string.ascii_letters + string.digits + "-"
+        random_img_id = ''.join(random.choice(chars) for _ in range(48))
+        image_url = f"https://lh3.googleusercontent.com/a/ACg8oc{random_img_id}=s96-c"
+        
+        return {
+            "user": {
+                "name": "BLACKBOX AI", 
+                "email": email, 
+                "image": image_url, 
+                "id": numeric_id
+            }, 
+            "expires": expiry
+        }
 
     @classmethod
     async def fetch_validated(cls, url: str = "https://www.blackbox.ai", force_refresh: bool = False) -> Optional[str]:
@@ -122,7 +204,7 @@ class Blackbox(AsyncGeneratorProvider, ProviderModelMixin):
                     if data.get('validated_value'):
                         return data['validated_value']
             except Exception as e:
-                print(f"Error reading cache: {e}")
+                debug.log(f"Blackbox: Error reading cache: {e}")
         
         js_file_pattern = r'static/chunks/\d{4}-[a-fA-F0-9]+\.js'
         uuid_pattern = r'["\']([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})["\']'
@@ -157,12 +239,12 @@ class Blackbox(AsyncGeneratorProvider, ProviderModelMixin):
                                         with open(cache_file, 'w') as f:
                                             json.dump({'validated_value': validated_value}, f)
                                     except Exception as e:
-                                        print(f"Error writing cache: {e}")
+                                        debug.log(f"Blackbox: Error writing cache: {e}")
                                         
                                     return validated_value
 
             except Exception as e:
-                print(f"Error retrieving validated_value: {e}")
+                debug.log(f"Blackbox: Error retrieving validated_value: {e}")
 
         return None
 
@@ -171,20 +253,190 @@ class Blackbox(AsyncGeneratorProvider, ProviderModelMixin):
         chars = string.ascii_letters + string.digits
         return ''.join(random.choice(chars) for _ in range(length))
     
-    @staticmethod
-    def decrypt_data(encrypted_data):
-        try:
-            return json.loads(base64.b64decode(encrypted_data).decode('utf-8'))
-        except:
-            return None
+    @classmethod
+    def get_models(cls) -> list:
+        """
+        Returns a list of available models based on authorization status.
+        Authorized users get the full list of models.
+        Unauthorized users only get fallback_models.
+        """
+        # Check if there are valid session data in HAR files
+        has_premium_access = cls._check_premium_access()
+        
+        if has_premium_access:
+            # For authorized users - all models
+            debug.log(f"Blackbox: Returning full model list with {len(cls._all_models)} models")
+            return cls._all_models
+        else:
+            # For demo accounts - only free models
+            debug.log(f"Blackbox: Returning free model list with {len(cls.fallback_models)} models")
+            return cls.fallback_models
     
-    @staticmethod
-    def decrypt_bool(encrypted_data):
+    @classmethod
+    def _check_premium_access(cls) -> bool:
+        """
+        Checks for an authorized session in HAR files.
+        Returns True if a valid session is found that differs from the demo.
+        """
         try:
-            return base64.b64decode(encrypted_data).decode('utf-8').lower() == 'true'
-        except:
+            har_dir = get_cookies_dir()
+            if not os.access(har_dir, os.R_OK):
+                return False
+                
+            for root, _, files in os.walk(har_dir):
+                for file in files:
+                    if file.endswith(".har"):
+                        try:
+                            with open(os.path.join(root, file), 'rb') as f:
+                                har_data = json.load(f)
+                                
+                            for entry in har_data['log']['entries']:
+                                # Only check requests to blackbox API
+                                if 'blackbox.ai/api' in entry['request']['url']:
+                                    if 'response' in entry and 'content' in entry['response']:
+                                        content = entry['response']['content']
+                                        if ('text' in content and 
+                                            isinstance(content['text'], str) and 
+                                            '"user"' in content['text'] and 
+                                            '"email"' in content['text']):
+                                            
+                                            try:
+                                                # Process request text
+                                                text = content['text'].strip()
+                                                if text.startswith('{') and text.endswith('}'):
+                                                    text = text.replace('\\"', '"')
+                                                    session_data = json.loads(text)
+                                                    
+                                                    # Check if this is a valid session
+                                                    if (isinstance(session_data, dict) and 
+                                                        'user' in session_data and 
+                                                        'email' in session_data['user']):
+                                                        
+                                                        # Check if this is not a demo session
+                                                        demo_session = cls.generate_session()
+                                                        if (session_data['user'].get('email') != 
+                                                            demo_session['user'].get('email')):
+                                                            # This is not a demo session, so user has premium access
+                                                            return True
+                                            except:
+                                                pass
+                        except:
+                            pass
             return False
-            
+        except Exception as e:
+            debug.log(f"Blackbox: Error checking premium access: {e}")
+            return False
+    
+    # Initialize models with fallback_models
+    models = fallback_models
+    
+    model_aliases = {
+        "gpt-4o": "GPT-4o",
+        "claude-3.7-sonnet": "Claude-sonnet-3.7",
+        "deepseek-v3": "DeepSeek-V3",
+        "deepseek-r1": "DeepSeek-R1",
+        "deepseek-chat": "DeepSeek-LLM-Chat-(67B)",
+    }
+
+    @classmethod
+    def generate_session(cls, id_length: int = 21, days_ahead: int = 365) -> dict:
+        """
+        Generate a dynamic session with proper ID and expiry format.
+        
+        Args:
+            id_length: Length of the numeric ID (default: 21)
+            days_ahead: Number of days ahead for expiry (default: 365)
+        
+        Returns:
+            dict: A session dictionary with user information and expiry
+        """
+        # Generate numeric ID
+        numeric_id = ''.join(random.choice('0123456789') for _ in range(id_length))
+        
+        # Generate future expiry date
+        future_date = datetime.now() + timedelta(days=days_ahead)
+        expiry = future_date.strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z'
+        
+        # Decode the encoded email
+        encoded_email = "Z2lzZWxlQGJsYWNrYm94LmFp"  # Base64 encoded email
+        email = base64.b64decode(encoded_email).decode('utf-8')
+        
+        # Generate random image ID for the new URL format
+        chars = string.ascii_letters + string.digits + "-"
+        random_img_id = ''.join(random.choice(chars) for _ in range(48))
+        image_url = f"https://lh3.googleusercontent.com/a/ACg8oc{random_img_id}=s96-c"
+        
+        return {
+            "user": {
+                "name": "BLACKBOX AI", 
+                "email": email, 
+                "image": image_url, 
+                "id": numeric_id
+            }, 
+            "expires": expiry
+        }
+
+
+    @classmethod
+    async def fetch_validated(cls, url: str = "https://www.blackbox.ai", force_refresh: bool = False) -> Optional[str]:
+        cache_file = Path(get_cookies_dir()) / 'blackbox.json'
+        
+        if not force_refresh and cache_file.exists():
+            try:
+                with open(cache_file, 'r') as f:
+                    data = json.load(f)
+                    if data.get('validated_value'):
+                        return data['validated_value']
+            except Exception as e:
+                debug.log(f"Blackbox: Error reading cache: {e}")
+        
+        js_file_pattern = r'static/chunks/\d{4}-[a-fA-F0-9]+\.js'
+        uuid_pattern = r'["\']([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})["\']'
+
+        def is_valid_context(text: str) -> bool:
+            return any(char + '=' in text for char in 'abcdefghijklmnopqrstuvwxyz')
+
+        async with ClientSession() as session:
+            try:
+                async with session.get(url) as response:
+                    if response.status != 200:
+                        return None
+
+                    page_content = await response.text()
+                    js_files = re.findall(js_file_pattern, page_content)
+
+                for js_file in js_files:
+                    js_url = f"{url}/_next/{js_file}"
+                    async with session.get(js_url) as js_response:
+                        if js_response.status == 200:
+                            js_content = await js_response.text()
+                            for match in re.finditer(uuid_pattern, js_content):
+                                start = max(0, match.start() - 10)
+                                end = min(len(js_content), match.end() + 10)
+                                context = js_content[start:end]
+
+                                if is_valid_context(context):
+                                    validated_value = match.group(1)
+                                    
+                                    cache_file.parent.mkdir(exist_ok=True)
+                                    try:
+                                        with open(cache_file, 'w') as f:
+                                            json.dump({'validated_value': validated_value}, f)
+                                    except Exception as e:
+                                        debug.log(f"Blackbox: Error writing cache: {e}")
+                                        
+                                    return validated_value
+
+            except Exception as e:
+                debug.log(f"Blackbox: Error retrieving validated_value: {e}")
+
+        return None
+
+    @classmethod
+    def generate_id(cls, length: int = 7) -> str:
+        chars = string.ascii_letters + string.digits
+        return ''.join(random.choice(chars) for _ in range(length))
+    
     @classmethod
     async def create_async_generator(
         cls,
@@ -240,6 +492,71 @@ class Blackbox(AsyncGeneratorProvider, ProviderModelMixin):
                     "title": ""
                 }
 
+            # Try to get session data from HAR files
+            session_data = cls.generate_session()  # Default fallback
+            session_found = False
+
+            # Look for HAR session data
+            har_dir = get_cookies_dir()
+            if os.access(har_dir, os.R_OK):
+                for root, _, files in os.walk(har_dir):
+                    for file in files:
+                        if file.endswith(".har"):
+                            try:
+                                with open(os.path.join(root, file), 'rb') as f:
+                                    har_data = json.load(f)
+                                    
+                                for entry in har_data['log']['entries']:
+                                    # Only look at blackbox API responses
+                                    if 'blackbox.ai/api' in entry['request']['url']:
+                                        # Look for a response that has the right structure
+                                        if 'response' in entry and 'content' in entry['response']:
+                                            content = entry['response']['content']
+                                            # Look for both regular and Google auth session formats
+                                            if ('text' in content and 
+                                                isinstance(content['text'], str) and 
+                                                '"user"' in content['text'] and 
+                                                '"email"' in content['text'] and
+                                                '"expires"' in content['text']):
+                                                
+                                                try:
+                                                    # Remove any HTML or other non-JSON content
+                                                    text = content['text'].strip()
+                                                    if text.startswith('{') and text.endswith('}'):
+                                                        # Replace escaped quotes
+                                                        text = text.replace('\\"', '"')
+                                                        har_session = json.loads(text)
+                                                        
+                                                        # Check if this is a valid session object (supports both regular and Google auth)
+                                                        if (isinstance(har_session, dict) and 
+                                                            'user' in har_session and 
+                                                            'email' in har_session['user'] and
+                                                            'expires' in har_session):
+                                                            
+                                                            file_path = os.path.join(root, file)
+                                                            debug.log(f"Blackbox: Found session in HAR file")
+                                                            
+                                                            session_data = har_session
+                                                            session_found = True
+                                                            break
+                                                except json.JSONDecodeError as e:
+                                                    # Only print error for entries that truly look like session data
+                                                    if ('"user"' in content['text'] and 
+                                                        '"email"' in content['text']):
+                                                        debug.log(f"Blackbox: Error parsing likely session data: {e}")
+                                        
+                                    if session_found:
+                                        break
+                                        
+                            except Exception as e:
+                                debug.log(f"Blackbox: Error reading HAR file: {e}")
+                            
+                            if session_found:
+                                break
+                                
+                    if session_found:
+                        break
+
             data = {
                 "messages": current_messages,
                 "agentMode": cls.agentMode.get(model, {}) if model in cls.agentMode else {},
@@ -276,13 +593,30 @@ class Blackbox(AsyncGeneratorProvider, ProviderModelMixin):
                     "additionalInfo": "",
                     "enableNewChats": False
                 },
-                "session": cls.decrypt_data(cls.ENCRYPTED_SESSION),
-                "isPremium": cls.decrypt_bool(cls.ENCRYPTED_IS_PREMIUM), 
-                "subscriptionCache": cls.decrypt_data(cls.ENCRYPTED_SUBSCRIPTION_CACHE),
+                "session": session_data if session_data else cls.generate_session(),
+                "isPremium": True, 
+                "subscriptionCache": None,
                 "beastMode": False,
                 "webSearchMode": False
             }
-            
+
+            # Add debugging before making the API call
+            if isinstance(session_data, dict) and 'user' in session_data:
+                # Генеруємо демо-сесію для порівняння
+                demo_session = cls.generate_session()
+                is_demo = False
+                
+                if demo_session and isinstance(demo_session, dict) and 'user' in demo_session:
+                    if session_data['user'].get('email') == demo_session['user'].get('email'):
+                        is_demo = True
+                
+                if is_demo:
+                    debug.log(f"Blackbox: Making API request with built-in Developer Premium Account")
+                else:
+                    user_email = session_data['user'].get('email', 'unknown')
+                    debug.log(f"Blackbox: Making API request with HAR session email: {user_email}")
+                
+            # Continue with the API request and async generator behavior
             async with session.post(cls.api_endpoint, json=data, proxy=proxy) as response:
                 await raise_for_status(response)
                 

--- a/g4f/Provider/Blackbox.py
+++ b/g4f/Provider/Blackbox.py
@@ -100,7 +100,7 @@ class Blackbox(AsyncGeneratorProvider, ProviderModelMixin):
         "gemini-1.5-flash": "gemini-1.5-flash",
         "gemini-1.5-pro": "gemini-pro",
         "llama-3.3-70b": "Meta-Llama-3.3-70B-Instruct-Turbo",
-        "mixtral-small-28b": "Mistral-Small-24B-Instruct-2501",
+        "mixtral-small-24b": "Mistral-Small-24B-Instruct-2501",
         "deepseek-chat": "DeepSeek-LLM-Chat-(67B)",
         "qwq-32b": "Qwen-QwQ-32B-Preview",
         "hermes-2-dpo": "Nous-Hermes-2-Mixtral-8x7B-DPO",

--- a/g4f/Provider/Copilot.py
+++ b/g4f/Provider/Copilot.py
@@ -48,7 +48,7 @@ class Copilot(AbstractProvider, ProviderModelMixin):
     models = [default_model]
     model_aliases = {
         "gpt-4": default_model,
-        "gpt-4o": default_model,
+        "o1": default_model,
     }
 
     websocket_url = "wss://copilot.microsoft.com/c/api/chat?api-version=2"

--- a/g4f/Provider/DeepInfraChat.py
+++ b/g4f/Provider/DeepInfraChat.py
@@ -41,7 +41,7 @@ class DeepInfraChat(OpenaiTemplate):
         "llama-3.3-70b": "meta-llama/Llama-3.3-70B-Instruct-Turbo",
         "llama-3.3-70b": "meta-llama/Llama-3.3-70B-Instruct",
         "deepseek-v3": default_model,
-        "mixtral-small-28b": "mistralai/Mistral-Small-24B-Instruct-2501",
+        "mixtral-small-24b": "mistralai/Mistral-Small-24B-Instruct-2501",
         "deepseek-r1": "deepseek-ai/DeepSeek-R1-Turbo",
         "deepseek-r1": "deepseek-ai/DeepSeek-R1",
         "deepseek-r1-distill-llama": "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",

--- a/g4f/Provider/Dynaspark.py
+++ b/g4f/Provider/Dynaspark.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+from aiohttp import ClientSession, FormData
+
+from ..typing import AsyncResult, Messages, ImagesType
+from .base_provider import AsyncGeneratorProvider, ProviderModelMixin
+from ..requests.raise_for_status import raise_for_status
+from ..image import to_data_uri, to_bytes, is_accepted_format
+from .helper import format_prompt
+
+
+class Dynaspark(AsyncGeneratorProvider, ProviderModelMixin):
+    url = "https://dynaspark.onrender.com"
+    login_url = None
+    api_endpoint = "https://dynaspark.onrender.com/generate_response"
+    
+    working = True
+    needs_auth = False
+    use_nodriver = True
+    supports_stream = True
+    supports_system_message = False
+    supports_message_history = False
+
+    default_model = 'gemini-1.5-flash'
+    default_vision_model = default_model
+    vision_models = [default_vision_model, 'gemini-1.5-flash-8b', 'gemini-2.0-flash', 'gemini-2.0-flash-lite']
+    models = vision_models
+    
+    model_aliases = {
+        "gemini-1.5-flash": "gemini-1.5-flash-8b",
+        "gemini-2.0-flash": "gemini-2.0-flash-lite",
+    }
+
+    @classmethod
+    async def create_async_generator(
+        cls,
+        model: str,
+        messages: Messages,
+        proxy: str = None,
+        images: ImagesType = None,
+        **kwargs
+    ) -> AsyncResult:
+        headers = {
+            'accept': '*/*',
+            'accept-language': 'en-US,en;q=0.9',
+            'origin': 'https://dynaspark.onrender.com',
+            'referer': 'https://dynaspark.onrender.com/',
+            'user-agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36',
+            'x-requested-with': 'XMLHttpRequest'
+        }
+        
+        async with ClientSession(headers=headers) as session:
+            form = FormData()
+            form.add_field('user_input', format_prompt(messages))
+            form.add_field('ai_model', model)
+            
+            if images is not None and len(images) > 0:
+                image, image_name = images[0]
+                image_bytes = to_bytes(image)
+                form.add_field('file', image_bytes, filename=image_name, content_type=is_accepted_format(image_bytes))
+            
+            async with session.post(f"{cls.api_endpoint}", data=form, proxy=proxy) as response:
+                await raise_for_status(response)
+                response_text = await response.text()
+                response_json = json.loads(response_text)
+                yield response_json["response"]

--- a/g4f/Provider/Goabror.py
+++ b/g4f/Provider/Goabror.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+from aiohttp import ClientSession
+
+from ..typing import AsyncResult, Messages
+from .base_provider import AsyncGeneratorProvider, ProviderModelMixin
+from ..requests.raise_for_status import raise_for_status
+from .helper import format_prompt
+
+
+class Goabror(AsyncGeneratorProvider, ProviderModelMixin):
+    url = "https://goabror.uz"
+    api_endpoint = "https://goabror.uz/api/gpt.php"
+    
+    working = True
+
+    default_model = 'gpt-4'
+    models = [default_model]
+
+    @classmethod
+    async def create_async_generator(
+        cls,
+        model: str,
+        messages: Messages,
+        proxy: str = None,
+        **kwargs
+    ) -> AsyncResult:
+        headers = {
+            'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
+            'accept-language': 'en-US,en;q=0.9',
+            'user-agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36'
+        }
+        
+        async with ClientSession(headers=headers) as session:
+            params = {
+                "user": format_prompt(messages)
+            }
+            async with session.get(f"{cls.api_endpoint}", params=params, proxy=proxy) as response:
+                await raise_for_status(response)
+                text_response = await response.text()
+                try:
+                    json_response = json.loads(text_response)
+                    if "data" in json_response:
+                        yield json_response["data"]
+                    else:
+                        yield text_response
+                except json.JSONDecodeError:
+                    yield text_response

--- a/g4f/Provider/LambdaChat.py
+++ b/g4f/Provider/LambdaChat.py
@@ -19,9 +19,10 @@ class LambdaChat(AsyncGeneratorProvider, ProviderModelMixin):
     working = True
 
     default_model = "deepseek-llama3.3-70b"
+    reasoning_model = "deepseek-r1"
     models = [
         default_model,
-        "deepseek-r1",
+        reasoning_model,
         "hermes-3-llama-3.1-405b-fp8",
         "hermes3-405b-fp8-128k",
         "llama3.1-nemotron-70b-instruct",
@@ -166,7 +167,7 @@ class LambdaChat(AsyncGeneratorProvider, ProviderModelMixin):
                             yield token
                     elif data.get("type") == "title":
                         yield TitleGeneration(data.get("title", ""))
-                    elif data.get("type") == "reasoning":  # Added reasoning processing
+                    elif data.get("type") == "reasoning" and model == cls.reasoning_model:  # Only process reasoning for reasoning_model
                         subtype = data.get("subtype")
                         token = data.get("token", "").replace("\u0000", "")
                         status = data.get("status", "")

--- a/g4f/Provider/LambdaChat.py
+++ b/g4f/Provider/LambdaChat.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from aiohttp import ClientSession, FormData
+
+from ..typing import AsyncResult, Messages
+from ..requests import raise_for_status
+from .base_provider import AsyncGeneratorProvider, ProviderModelMixin
+from .helper import format_prompt, get_last_user_message
+from ..providers.response import JsonConversation, TitleGeneration, Reasoning
+
+class LambdaChat(AsyncGeneratorProvider, ProviderModelMixin):
+    label = "Lambda Chat"
+    url = "https://lambda.chat"
+    conversation_url = f"{url}/conversation"
+
+    working = True
+
+    default_model = "deepseek-llama3.3-70b"
+    models = [
+        default_model,
+        "deepseek-r1",
+        "hermes-3-llama-3.1-405b-fp8",
+        "hermes3-405b-fp8-128k",
+        "llama3.1-nemotron-70b-instruct",
+        "lfm-40b",
+        "llama3.3-70b-instruct-fp8"
+    ]
+    model_aliases = {
+        "deepseek-v3": default_model,
+        "hermes-3": "hermes-3-llama-3.1-405b-fp8",
+        "hermes-3": "hermes3-405b-fp8-128k",
+        "nemotron-70b": "llama3.1-nemotron-70b-instruct",
+        "llama-3.3-70b": "llama3.3-70b-instruct-fp8"
+    }
+
+    @classmethod
+    async def create_async_generator(
+        cls, model: str, messages: Messages,
+        api_key: str = None, 
+        proxy: str = None,
+        cookies: dict = None,
+        **kwargs
+    ) -> AsyncResult:
+        model = cls.get_model(model)
+        headers = {
+            "Origin": cls.url,
+            "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36",
+            "Accept": "*/*",
+            "Accept-Language": "en-US,en;q=0.9",
+            "Referer": cls.url,
+            "Sec-Fetch-Dest": "empty",
+            "Sec-Fetch-Mode": "cors",
+            "Sec-Fetch-Site": "same-origin",
+            "Priority": "u=1, i",
+            "Pragma": "no-cache",
+            "Cache-Control": "no-cache"
+        }
+        
+        # Initialize cookies if not provided
+        if cookies is None:
+            cookies = {
+                "hf-chat": str(uuid.uuid4())  # Generate a session ID
+            }
+        
+        async with ClientSession(headers=headers, cookies=cookies) as session:
+            # Step 1: Create a new conversation
+            data = {"model": model}
+            async with session.post(cls.conversation_url, json=data, proxy=proxy) as response:
+                await raise_for_status(response)
+                conversation_response = await response.json()
+                conversation_id = conversation_response["conversationId"]
+                
+                # Update cookies with any new ones from the response
+                for cookie_name, cookie in response.cookies.items():
+                    cookies[cookie_name] = cookie.value
+            
+            # Step 2: Get data for this conversation to extract message ID
+            async with session.get(
+                f"{cls.conversation_url}/{conversation_id}/__data.json?x-sveltekit-invalidated=11", 
+                proxy=proxy
+            ) as response:
+                await raise_for_status(response)
+                response_text = await response.text()
+                
+                # Update cookies again
+                for cookie_name, cookie in response.cookies.items():
+                    cookies[cookie_name] = cookie.value
+                
+                try:
+                    data_line = response_text.splitlines()[0]
+                    data_json = json.loads(data_line)
+                    
+                    # Navigate to the data section containing message info
+                    message_id = None
+                    
+                    # For debugging, print the JSON structure
+                    if "nodes" in data_json and len(data_json["nodes"]) > 1:
+                        node = data_json["nodes"][1]
+                        if "data" in node:
+                            data = node["data"]
+                            
+                            # Try to find the system message ID
+                            if len(data) > 1 and isinstance(data[1], list) and len(data[1]) > 2:
+                                for item in data[1]:
+                                    if isinstance(item, dict) and "id" in item:
+                                        # Found a potential message ID
+                                        message_id = item["id"]
+                                        break
+                    
+                    if not message_id:
+                        # Fallback: Just search for any UUID in the response
+                        uuid_pattern = r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                        uuids = re.findall(uuid_pattern, response_text)
+                        if uuids:
+                            message_id = uuids[0]
+                    
+                    if not message_id:
+                        raise ValueError("Could not find message ID in response")
+                        
+                except (IndexError, KeyError, ValueError, json.JSONDecodeError) as e:
+                    raise RuntimeError(f"Failed to parse conversation data: {str(e)}")
+            
+            # Step 3: Send the user message
+            user_message = get_last_user_message(messages)
+            
+            # Prepare form data exactly
+            form_data = FormData()
+            form_data.add_field(
+                "data",
+                json.dumps({
+                    "inputs": user_message, 
+                    "id": message_id, 
+                    "is_retry": False, 
+                    "is_continue": False, 
+                    "web_search": False, 
+                    "tools": []
+                }),
+                content_type="application/json"
+            )
+            
+            async with session.post(
+                f"{cls.conversation_url}/{conversation_id}", 
+                data=form_data,
+                proxy=proxy
+            ) as response:
+                await raise_for_status(response)
+                
+                async for chunk in response.content:
+                    if not chunk:
+                        continue
+                        
+                    chunk_str = chunk.decode('utf-8', errors='ignore')
+                    
+                    try:
+                        data = json.loads(chunk_str)
+                    except json.JSONDecodeError:
+                        continue
+                        
+                    # Handling different types of responses
+                    if data.get("type") == "stream" and "token" in data:
+                        token = data["token"].replace("\u0000", "")
+                        if token:
+                            yield token
+                    elif data.get("type") == "title":
+                        yield TitleGeneration(data.get("title", ""))
+                    elif data.get("type") == "reasoning":  # Added reasoning processing
+                        subtype = data.get("subtype")
+                        token = data.get("token", "").replace("\u0000", "")
+                        status = data.get("status", "")
+                        
+                        if subtype == "stream" and token:
+                            yield Reasoning(token=token)
+                        elif subtype == "status" and status:
+                            yield Reasoning(status=status)
+                    elif data.get("type") == "finalAnswer":
+                        break

--- a/g4f/Provider/PollinationsAI.py
+++ b/g4f/Provider/PollinationsAI.py
@@ -21,13 +21,6 @@ DEFAULT_HEADERS = {
     "accept": "*/*",
     'accept-language': 'en-US,en;q=0.9',
     "user-agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36",
-    "priority": "u=1, i",
-    "sec-ch-ua": "\"Not(A:Brand\";v=\"99\", \"Google Chrome\";v=\"133\", \"Chromium\";v=\"133\"",
-    "sec-ch-ua-mobile": "?0",
-    "sec-ch-ua-platform": "\"Linux\"",
-    "sec-fetch-dest": "empty",
-    "sec-fetch-mode": "cors",
-    "sec-fetch-site": "same-site",
     "referer": "https://pollinations.ai/",
     "origin": "https://pollinations.ai",
 }
@@ -71,6 +64,8 @@ class PollinationsAI(AsyncGeneratorProvider, ProviderModelMixin):
         "gemini-2.0": "gemini",
         "gemini-2.0-flash": "gemini",
         "gemini-2.0-flash-thinking": "gemini-thinking",
+        "deepseek-r1": "deepseek-r1-llama",
+        "gpt-4o-audio": "openai-audio",
         
         ### Image Models ###
         "sdxl-turbo": "turbo",

--- a/g4f/Provider/Websim.py
+++ b/g4f/Provider/Websim.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import json
+import random
+import string
+import asyncio
+from aiohttp import ClientSession
+
+from ..typing import AsyncResult, Messages
+from .base_provider import AsyncGeneratorProvider, ProviderModelMixin
+from ..requests.raise_for_status import raise_for_status
+from ..errors import ResponseStatusError
+from ..providers.response import ImageResponse
+from .helper import format_prompt, format_image_prompt
+
+
+class Websim(AsyncGeneratorProvider, ProviderModelMixin):
+    url = "https://websim.ai"
+    login_url = None
+    chat_api_endpoint = "https://websim.ai/api/v1/inference/run_chat_completion"
+    image_api_endpoint = "https://websim.ai/api/v1/inference/run_image_generation"
+    
+    working = True
+    needs_auth = False
+    use_nodriver = False
+    supports_stream = False
+    supports_system_message = True
+    supports_message_history = True
+
+    default_model = 'gemini-1.5-pro'
+    default_image_model = 'flux'
+    image_models = [default_image_model]
+    models = [default_model, 'gemini-1.5-flash'] + image_models
+
+    @staticmethod
+    def generate_project_id(for_image=False):
+        """
+        Generate a project ID in the appropriate format
+        
+        For chat: format like 'ke3_xh5gai3gjkmruomu'
+        For image: format like 'kx0m131_rzz66qb2xoy7'
+        """
+        chars = string.ascii_lowercase + string.digits
+        
+        if for_image:
+            first_part = ''.join(random.choices(chars, k=7))
+            second_part = ''.join(random.choices(chars, k=12))
+            return f"{first_part}_{second_part}"
+        else:
+            prefix = ''.join(random.choices(chars, k=3))
+            suffix = ''.join(random.choices(chars, k=15))
+            return f"{prefix}_{suffix}"
+
+    @classmethod
+    async def create_async_generator(
+        cls,
+        model: str,
+        messages: Messages,
+        prompt: str = None,
+        proxy: str = None,
+        aspect_ratio: str = "1:1",
+        project_id: str = None,
+        **kwargs
+    ) -> AsyncResult:
+        is_image_request = model in cls.image_models
+        
+        if project_id is None:
+            project_id = cls.generate_project_id(for_image=is_image_request)
+        
+        headers = {
+            'accept': '*/*',
+            'accept-language': 'en-US,en;q=0.9',
+            'content-type': 'text/plain;charset=UTF-8',
+            'origin': 'https://websim.ai',
+            'user-agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36',
+            'websim-flags;': ''
+        }
+        
+        if is_image_request:
+            headers['referer'] = 'https://websim.ai/@ISWEARIAMNOTADDICTEDTOPILLOW/ai-image-prompt-generator'
+            async for result in cls._handle_image_request(
+                project_id=project_id,
+                messages=messages,
+                prompt=prompt,
+                aspect_ratio=aspect_ratio,
+                headers=headers,
+                proxy=proxy,
+                **kwargs
+            ):
+                yield result
+        else:
+            headers['referer'] = 'https://websim.ai/@ISWEARIAMNOTADDICTEDTOPILLOW/zelos-ai-assistant'
+            async for result in cls._handle_chat_request(
+                project_id=project_id,
+                messages=messages,
+                headers=headers,
+                proxy=proxy,
+                **kwargs
+            ):
+                yield result
+
+    @classmethod
+    async def _handle_image_request(
+        cls,
+        project_id: str,
+        messages: Messages,
+        prompt: str,
+        aspect_ratio: str,
+        headers: dict,
+        proxy: str = None,
+        **kwargs
+    ) -> AsyncResult:
+        used_prompt = format_image_prompt(messages, prompt)
+        
+        async with ClientSession(headers=headers) as session:
+            data = {
+                "project_id": project_id,
+                "prompt": used_prompt,
+                "aspect_ratio": aspect_ratio
+            }
+            async with session.post(f"{cls.image_api_endpoint}", json=data, proxy=proxy) as response:
+                await raise_for_status(response)
+                response_text = await response.text()
+                response_json = json.loads(response_text)
+                image_url = response_json.get("url")
+                if image_url:
+                    yield ImageResponse(images=[image_url], alt=used_prompt)
+
+    @classmethod
+    async def _handle_chat_request(
+        cls,
+        project_id: str,
+        messages: Messages,
+        headers: dict,
+        proxy: str = None,
+        **kwargs
+    ) -> AsyncResult:
+        max_retries = 3
+        retry_count = 0
+        last_error = None
+        
+        while retry_count < max_retries:
+            try:
+                async with ClientSession(headers=headers) as session:
+                    data = {
+                        "project_id": project_id,
+                        "messages": messages
+                    }
+                    async with session.post(f"{cls.chat_api_endpoint}", json=data, proxy=proxy) as response:
+                        if response.status == 429:
+                            response_text = await response.text()
+                            last_error = ResponseStatusError(f"Response {response.status}: {response_text}")
+                            retry_count += 1
+                            if retry_count < max_retries:
+                                wait_time = 2 ** retry_count
+                                await asyncio.sleep(wait_time)
+                                continue
+                            else:
+                                raise last_error
+                        
+                        await raise_for_status(response)
+                        
+                        response_text = await response.text()
+                        try:
+                            response_json = json.loads(response_text)
+                            content = response_json.get("content", "")
+                            yield content.strip()
+                            break
+                        except json.JSONDecodeError:
+                            yield response_text
+                            break
+                            
+            except ResponseStatusError as e:
+                if "Rate limit exceeded" in str(e) and retry_count < max_retries:
+                    retry_count += 1
+                    wait_time = 2 ** retry_count
+                    await asyncio.sleep(wait_time)
+                else:
+                    if retry_count >= max_retries:
+                        raise e
+                    else:
+                        raise
+            except Exception as e:
+                raise

--- a/g4f/Provider/__init__.py
+++ b/g4f/Provider/__init__.py
@@ -29,6 +29,7 @@ from .Free2GPT             import Free2GPT
 from .FreeGpt              import FreeGpt
 from .GizAI                import GizAI
 from .Glider               import Glider
+from .Goabror              import Goabror
 from .ImageLabs            import ImageLabs
 from .Jmuz                 import Jmuz
 from .LambdaChat           import LambdaChat

--- a/g4f/Provider/__init__.py
+++ b/g4f/Provider/__init__.py
@@ -24,6 +24,7 @@ from .Cloudflare           import Cloudflare
 from .Copilot              import Copilot
 from .DDG                  import DDG
 from .DeepInfraChat        import DeepInfraChat
+from .Dynaspark            import Dynaspark
 from .Free2GPT             import Free2GPT
 from .FreeGpt              import FreeGpt
 from .GizAI                import GizAI
@@ -39,7 +40,9 @@ from .PollinationsAI       import PollinationsAI
 from .PollinationsImage    import PollinationsImage
 from .TeachAnything        import TeachAnything
 from .You                  import You
+from .Websim               import Websim
 from .Yqcloud              import Yqcloud
+
 
 import sys
 

--- a/g4f/Provider/__init__.py
+++ b/g4f/Provider/__init__.py
@@ -31,6 +31,7 @@ from .GizAI                import GizAI
 from .Glider               import Glider
 from .ImageLabs            import ImageLabs
 from .Jmuz                 import Jmuz
+from .LambdaChat           import LambdaChat
 from .Liaobots             import Liaobots
 from .OIVSCode             import OIVSCode
 from .PerplexityLabs       import PerplexityLabs

--- a/g4f/Provider/hf_space/BlackForestLabs_Flux1Dev.py
+++ b/g4f/Provider/hf_space/BlackForestLabs_Flux1Dev.py
@@ -9,10 +9,11 @@ from ...requests import StreamSession
 from ...errors import ResponseError
 from ..base_provider import AsyncGeneratorProvider, ProviderModelMixin
 from ..helper import format_image_prompt
-from .Janus_Pro_7B import get_zerogpu_token
+from .DeepseekAI_JanusPro7b import get_zerogpu_token
 from .raise_for_status import raise_for_status
 
-class BlackForestLabsFlux1Dev(AsyncGeneratorProvider, ProviderModelMixin):
+class BlackForestLabs_Flux1Dev(AsyncGeneratorProvider, ProviderModelMixin):
+    label = "BlackForestLabs Flux-1-Dev"
     url = "https://black-forest-labs-flux-1-dev.hf.space"
     space = "black-forest-labs/FLUX.1-dev"
     referer = f"{url}/?__theme=light"

--- a/g4f/Provider/hf_space/BlackForestLabs_Flux1Schnell.py
+++ b/g4f/Provider/hf_space/BlackForestLabs_Flux1Schnell.py
@@ -6,17 +6,18 @@ import json
 from ...typing import AsyncResult, Messages
 from ...providers.response import ImageResponse
 from ...errors import ResponseError
-from ...requests.raise_for_status import raise_for_status
-from ..helper import format_image_prompt
 from ..base_provider import AsyncGeneratorProvider, ProviderModelMixin
+from ..helper import format_image_prompt
+from .raise_for_status import raise_for_status
 
-class VoodoohopFlux1Schnell(AsyncGeneratorProvider, ProviderModelMixin):
-    url = "https://voodoohop-flux-1-schnell.hf.space"
-    api_endpoint = "https://voodoohop-flux-1-schnell.hf.space/call/infer"
-
+class BlackForestLabs_Flux1Schnell(AsyncGeneratorProvider, ProviderModelMixin):
+    label = "BlackForestLabs Flux-1-Schnell"
+    url = "https://black-forest-labs-flux-1-schnell.hf.space"
+    api_endpoint = "https://black-forest-labs-flux-1-schnell.hf.space/call/infer"
+    
     working = True
-
-    default_model = "voodoohop-flux-1-schnell"
+    
+    default_model = "black-forest-labs-flux-1-schnell"
     default_image_model = default_model
     model_aliases = {"flux-schnell": default_model, "flux": default_model}
     image_models = [default_image_model, *model_aliases.keys()]
@@ -36,6 +37,8 @@ class VoodoohopFlux1Schnell(AsyncGeneratorProvider, ProviderModelMixin):
         randomize_seed: bool = True,
         **kwargs
     ) -> AsyncResult:
+
+        model = cls.get_model(model)
         width = max(32, width - (width % 8))
         height = max(32, height - (height % 8))
         prompt = format_image_prompt(messages, prompt)
@@ -66,7 +69,7 @@ class VoodoohopFlux1Schnell(AsyncGeneratorProvider, ProviderModelMixin):
                                 event_type = event_parts[0].split(b': ')[1]
                                 data = event_parts[1]
                                 if event_type == b'error':
-                                    raise ResponseError(f"Error generating image: {data}")
+                                    raise ResponseError(f"Error generating image: {data.decode(errors='ignore')}")
                                 elif event_type == b'complete':
                                     json_data = json.loads(data)
                                     image_url = json_data[0]['url']

--- a/g4f/Provider/hf_space/CohereForAI_C4AI_Command.py
+++ b/g4f/Provider/hf_space/CohereForAI_C4AI_Command.py
@@ -9,7 +9,8 @@ from ..base_provider import AsyncGeneratorProvider, ProviderModelMixin
 from ..helper import format_prompt, get_last_user_message
 from ...providers.response import JsonConversation, TitleGeneration
 
-class CohereForAI(AsyncGeneratorProvider, ProviderModelMixin):
+class CohereForAI_C4AI_Command(AsyncGeneratorProvider, ProviderModelMixin):
+    label = "CohereForAI C4AI Command"
     url = "https://cohereforai-c4ai-command.hf.space"
     conversation_url = f"{url}/conversation"
 

--- a/g4f/Provider/hf_space/CohereForAI_C4AI_Command.py
+++ b/g4f/Provider/hf_space/CohereForAI_C4AI_Command.py
@@ -16,15 +16,18 @@ class CohereForAI_C4AI_Command(AsyncGeneratorProvider, ProviderModelMixin):
 
     working = True
 
-    default_model = "command-r-plus-08-2024"
+    default_model = "command-a-03-2025"
     models = [
         default_model,
+        "command-r-plus-08-2024",
         "command-r-08-2024",
         "command-r-plus",
         "command-r",
         "command-r7b-12-2024",
+        "command-r7b-arabic-02-2025",
     ]
     model_aliases = {
+        "command-a": "command-a-03-2025",
         "command-r-plus": "command-r-plus-08-2024",
         "command-r": "command-r-08-2024",
         "command-r7b": "command-r7b-12-2024",

--- a/g4f/Provider/hf_space/DeepseekAI_JanusPro7b.py
+++ b/g4f/Provider/hf_space/DeepseekAI_JanusPro7b.py
@@ -19,7 +19,8 @@ from ...errors import ResponseError
 from ... import debug
 from .raise_for_status import raise_for_status
 
-class Janus_Pro_7B(AsyncGeneratorProvider, ProviderModelMixin):
+class DeepseekAI_JanusPro7b(AsyncGeneratorProvider, ProviderModelMixin):
+    label = "DeepseekAI Janus-Pro-7B"
     space = "deepseek-ai/Janus-Pro-7B"
     url = f"https://huggingface.co/spaces/{space}"
     api_url = "https://deepseek-ai-janus-pro-7b.hf.space"

--- a/g4f/Provider/hf_space/G4F.py
+++ b/g4f/Provider/hf_space/G4F.py
@@ -8,16 +8,16 @@ import asyncio
 from ...typing import AsyncResult, Messages
 from ...providers.response import ImageResponse, Reasoning, JsonConversation
 from ..helper import format_image_prompt, get_random_string
-from .Janus_Pro_7B import Janus_Pro_7B, get_zerogpu_token
-from .BlackForestLabsFlux1Dev import BlackForestLabsFlux1Dev
+from .DeepseekAI_JanusPro7b import DeepseekAI_JanusPro7b, get_zerogpu_token
+from .BlackForestLabs_Flux1Dev import BlackForestLabs_Flux1Dev
 from .raise_for_status import raise_for_status
 
-class FluxDev(BlackForestLabsFlux1Dev):
+class FluxDev(BlackForestLabs_Flux1Dev):
     url = "https://roxky-flux-1-dev.hf.space"
     space = "roxky/FLUX.1-dev"
     referer = f"{url}/?__theme=light"
 
-class G4F(Janus_Pro_7B):
+class G4F(DeepseekAI_JanusPro7b):
     label = "G4F framework"
     space = "roxky/Janus-Pro-7B"
     url = f"https://huggingface.co/spaces/roxky/g4f-space"
@@ -27,8 +27,8 @@ class G4F(Janus_Pro_7B):
 
     default_model = "flux"
     model_aliases = {"flux-schnell": default_model}
-    image_models = [Janus_Pro_7B.default_image_model, default_model, "flux-dev", *model_aliases.keys()]
-    models = [Janus_Pro_7B.default_model, *image_models]
+    image_models = [DeepseekAI_JanusPro7b.default_image_model, default_model, "flux-dev", *model_aliases.keys()]
+    models = [DeepseekAI_JanusPro7b.default_model, *image_models]
 
     @classmethod
     async def create_async_generator(

--- a/g4f/Provider/hf_space/Microsoft_Phi_4.py
+++ b/g4f/Provider/hf_space/Microsoft_Phi_4.py
@@ -12,10 +12,11 @@ from ...requests.raise_for_status import raise_for_status
 from ...image import to_bytes, is_accepted_format, is_data_an_wav
 from ...errors import ResponseError
 from ... import debug
-from .Janus_Pro_7B import get_zerogpu_token
+from .DeepseekAI_JanusPro7b import get_zerogpu_token
 from .raise_for_status import raise_for_status
 
-class Phi_4(AsyncGeneratorProvider, ProviderModelMixin):
+class Microsoft_Phi_4(AsyncGeneratorProvider, ProviderModelMixin):
+    label = "Microsoft Phi-4"
     space = "microsoft/phi-4-multimodal"
     url = f"https://huggingface.co/spaces/{space}"
     api_url = "https://microsoft-phi-4-multimodal.hf.space"

--- a/g4f/Provider/hf_space/Qwen_QVQ_72B.py
+++ b/g4f/Provider/hf_space/Qwen_QVQ_72B.py
@@ -11,6 +11,7 @@ from ..helper import format_prompt, get_random_string
 from ...image import to_bytes, is_accepted_format
 
 class Qwen_QVQ_72B(AsyncGeneratorProvider, ProviderModelMixin):
+    label = "Qwen QVQ-72B"
     url = "https://qwen-qvq-72b-preview.hf.space"
     api_endpoint = "/gradio_api/call/generate"
 

--- a/g4f/Provider/hf_space/Qwen_Qwen_2_5M_Demo.py
+++ b/g4f/Provider/hf_space/Qwen_Qwen_2_5M_Demo.py
@@ -12,6 +12,7 @@ from ..helper import get_last_user_message
 from ... import debug
 
 class Qwen_Qwen_2_5M_Demo(AsyncGeneratorProvider, ProviderModelMixin):
+    label = "Qwen Qwen-2.5M-Demo"
     url = "https://qwen-qwen2-5-1m-demo.hf.space"
     api_endpoint = f"{url}/run/predict?__theme=light"
 

--- a/g4f/Provider/hf_space/Qwen_Qwen_2_72B_Instruct.py
+++ b/g4f/Provider/hf_space/Qwen_Qwen_2_72B_Instruct.py
@@ -11,6 +11,7 @@ from ..helper import format_prompt
 from ... import debug
 
 class Qwen_Qwen_2_72B_Instruct(AsyncGeneratorProvider, ProviderModelMixin):
+    label = "Qwen Qwen-2.72B-Instruct"
     url = "https://qwen-qwen2-72b-instruct.hf.space"
     api_endpoint = "https://qwen-qwen2-72b-instruct.hf.space/queue/join?"
     

--- a/g4f/Provider/hf_space/StabilityAI_SD35Large.py
+++ b/g4f/Provider/hf_space/StabilityAI_SD35Large.py
@@ -9,7 +9,8 @@ from ...errors import ResponseError
 from ..base_provider import AsyncGeneratorProvider, ProviderModelMixin
 from ..helper import format_image_prompt
 
-class StableDiffusion35Large(AsyncGeneratorProvider, ProviderModelMixin):
+class StabilityAI_SD35Large(AsyncGeneratorProvider, ProviderModelMixin):
+    label = "StabilityAI SD-3.5-Large"
     url = "https://stabilityai-stable-diffusion-3-5-large.hf.space"
     api_endpoint = "/gradio_api/call/infer"
 

--- a/g4f/Provider/hf_space/Voodoohop_Flux1Schnell.py
+++ b/g4f/Provider/hf_space/Voodoohop_Flux1Schnell.py
@@ -6,17 +6,18 @@ import json
 from ...typing import AsyncResult, Messages
 from ...providers.response import ImageResponse
 from ...errors import ResponseError
-from ..base_provider import AsyncGeneratorProvider, ProviderModelMixin
+from ...requests.raise_for_status import raise_for_status
 from ..helper import format_image_prompt
-from .raise_for_status import raise_for_status
+from ..base_provider import AsyncGeneratorProvider, ProviderModelMixin
 
-class BlackForestLabsFlux1Schnell(AsyncGeneratorProvider, ProviderModelMixin):
-    url = "https://black-forest-labs-flux-1-schnell.hf.space"
-    api_endpoint = "https://black-forest-labs-flux-1-schnell.hf.space/call/infer"
-    
+class Voodoohop_Flux1Schnell(AsyncGeneratorProvider, ProviderModelMixin):
+    label = "Voodoohop Flux-1-Schnell"
+    url = "https://voodoohop-flux-1-schnell.hf.space"
+    api_endpoint = "https://voodoohop-flux-1-schnell.hf.space/call/infer"
+
     working = True
-    
-    default_model = "black-forest-labs-flux-1-schnell"
+
+    default_model = "voodoohop-flux-1-schnell"
     default_image_model = default_model
     model_aliases = {"flux-schnell": default_model, "flux": default_model}
     image_models = [default_image_model, *model_aliases.keys()]
@@ -36,8 +37,6 @@ class BlackForestLabsFlux1Schnell(AsyncGeneratorProvider, ProviderModelMixin):
         randomize_seed: bool = True,
         **kwargs
     ) -> AsyncResult:
-
-        model = cls.get_model(model)
         width = max(32, width - (width % 8))
         height = max(32, height - (height % 8))
         prompt = format_image_prompt(messages, prompt)
@@ -68,7 +67,7 @@ class BlackForestLabsFlux1Schnell(AsyncGeneratorProvider, ProviderModelMixin):
                                 event_type = event_parts[0].split(b': ')[1]
                                 data = event_parts[1]
                                 if event_type == b'error':
-                                    raise ResponseError(f"Error generating image: {data.decode(errors='ignore')}")
+                                    raise ResponseError(f"Error generating image: {data}")
                                 elif event_type == b'complete':
                                     json_data = json.loads(data)
                                     image_url = json_data[0]['url']

--- a/g4f/Provider/hf_space/__init__.py
+++ b/g4f/Provider/hf_space/__init__.py
@@ -6,17 +6,17 @@ from ...typing import AsyncResult, Messages, ImagesType
 from ...errors import ResponseError
 from ..base_provider import AsyncGeneratorProvider, ProviderModelMixin
 
-from .BlackForestLabsFlux1Dev        import BlackForestLabsFlux1Dev
-from .BlackForestLabsFlux1Schnell    import BlackForestLabsFlux1Schnell
-from .VoodoohopFlux1Schnell          import VoodoohopFlux1Schnell
-from .CohereForAI                    import CohereForAI
-from .Janus_Pro_7B                   import Janus_Pro_7B
-from .Phi_4                          import Phi_4
+from .BlackForestLabs_Flux1Dev       import BlackForestLabs_Flux1Dev
+from .BlackForestLabs_Flux1Schnell   import BlackForestLabs_Flux1Schnell
+from .CohereForAI_C4AI_Command       import CohereForAI_C4AI_Command
+from .DeepseekAI_JanusPro7b          import DeepseekAI_JanusPro7b
+from .G4F                            import G4F
+from .Microsoft_Phi_4                import Microsoft_Phi_4
 from .Qwen_QVQ_72B                   import Qwen_QVQ_72B
 from .Qwen_Qwen_2_5M_Demo            import Qwen_Qwen_2_5M_Demo
 from .Qwen_Qwen_2_72B_Instruct       import Qwen_Qwen_2_72B_Instruct
-from .StableDiffusion35Large         import StableDiffusion35Large
-from .G4F                            import G4F
+from .StabilityAI_SD35Large          import StabilityAI_SD35Large
+from .Voodoohop_Flux1Schnell         import Voodoohop_Flux1Schnell
 
 class HuggingSpace(AsyncGeneratorProvider, ProviderModelMixin):
     url = "https://huggingface.co/spaces"
@@ -24,20 +24,20 @@ class HuggingSpace(AsyncGeneratorProvider, ProviderModelMixin):
     working = True
 
     default_model = Qwen_Qwen_2_72B_Instruct.default_model
-    default_image_model = BlackForestLabsFlux1Dev.default_model
+    default_image_model = BlackForestLabs_Flux1Dev.default_model
     default_vision_model = Qwen_QVQ_72B.default_model
     providers = [
-        BlackForestLabsFlux1Dev,
-        BlackForestLabsFlux1Schnell,
-        VoodoohopFlux1Schnell,
-        CohereForAI,
-        Janus_Pro_7B,
-        Phi_4,
+        BlackForestLabs_Flux1Dev,
+        BlackForestLabs_Flux1Schnell,
+        CohereForAI_C4AI_Command,
+        DeepseekAI_JanusPro7b,
+        G4F,
+        Microsoft_Phi_4,
         Qwen_QVQ_72B,
         Qwen_Qwen_2_5M_Demo,
         Qwen_Qwen_2_72B_Instruct,
-        StableDiffusion35Large,
-        G4F
+        StabilityAI_SD35Large,
+        Voodoohop_Flux1Schnell,
     ]
 
     @classmethod
@@ -98,3 +98,4 @@ class HuggingSpace(AsyncGeneratorProvider, ProviderModelMixin):
 
 for provider in HuggingSpace.providers:
     provider.parent = HuggingSpace.__name__
+    provider.hf_space = True

--- a/g4f/gui/client/static/js/chat.v1.js
+++ b/g4f/gui/client/static/js/chat.v1.js
@@ -2145,6 +2145,7 @@ async function on_api() {
                 + (provider.vision ? " (Image Upload)" : "")
                 + (provider.image ? " (Image Generation)" : "")
                 + (provider.nodriver ? " (Browser)" : "")
+                + (provider.hf_space ? " (HuggingSpace)" : "")
                 + (!provider.nodriver && provider.auth ? " (Auth)" : "");
             if (provider.parent)
                 option.dataset.parent = provider.parent;

--- a/g4f/gui/server/api.py
+++ b/g4f/gui/server/api.py
@@ -67,6 +67,7 @@ class Api:
             "image": bool(getattr(provider, "image_models", False)),
             "vision": getattr(provider, "default_vision_model", None) is not None,
             "nodriver": getattr(provider, "use_nodriver", False),
+            "hf_space": getattr(provider, "hf_space", False),
             "auth": provider.needs_auth,
             "login_url": getattr(provider, "login_url", None),
         } for provider in __providers__ if provider.working]

--- a/g4f/models.py
+++ b/g4f/models.py
@@ -139,7 +139,7 @@ gpt_4o = VisionModel(
 gpt_4o_mini = Model(
     name          = 'gpt-4o-mini',
     base_provider = 'OpenAI',
-    best_provider = IterListProvider([DDG, ChatGptEs, Jmuz, PollinationsAI, OIVSCode, Liaobots, OpenaiChat])
+    best_provider = IterListProvider([DDG, Blackbox, ChatGptEs, Jmuz, PollinationsAI, OIVSCode, Liaobots, OpenaiChat])
 )
 
 # o1
@@ -199,19 +199,19 @@ llama_3_70b = Model(
 llama_3_1_8b = Model(
     name          = "llama-3.1-8b",
     base_provider = "Meta Llama",
-    best_provider = IterListProvider([Blackbox, DeepInfraChat, Glider, PollinationsAI, AllenAI, Jmuz, Cloudflare])
+    best_provider = IterListProvider([DeepInfraChat, Glider, PollinationsAI, AllenAI, Jmuz, Cloudflare])
 )
 
 llama_3_1_70b = Model(
     name          = "llama-3.1-70b",
     base_provider = "Meta Llama",
-    best_provider = IterListProvider([Blackbox, Glider, AllenAI, Jmuz])
+    best_provider = IterListProvider([Glider, AllenAI, Jmuz])
 )
 
 llama_3_1_405b = Model(
     name          = "llama-3.1-405b",
     base_provider = "Meta Llama",
-    best_provider = IterListProvider([Blackbox, AllenAI, Jmuz])
+    best_provider = IterListProvider([AllenAI, Jmuz])
 )
 
 # llama 3.2
@@ -249,7 +249,7 @@ llama_3_2_90b = Model(
 llama_3_3_70b = Model(
     name          = "llama-3.3-70b",
     base_provider = "Meta Llama",
-    best_provider = IterListProvider([DDG, Blackbox, DeepInfraChat, LambdaChat, PollinationsAI, Jmuz, HuggingChat, HuggingFace])
+    best_provider = IterListProvider([DDG, DeepInfraChat, LambdaChat, PollinationsAI, Jmuz, HuggingChat, HuggingFace])
 )
 
 ### Mistral ###
@@ -273,16 +273,10 @@ mistral_nemo = Model(
 mixtral_small_24b = Model(
     name          = "mixtral-small-24b",
     base_provider = "Mistral",
-    best_provider = IterListProvider([DDG, Blackbox, DeepInfraChat])
+    best_provider = IterListProvider([DDG, DeepInfraChat])
 )
 
 ### NousResearch ###
-hermes_2_dpo = Model(
-    name          = "hermes-2-dpo",
-    base_provider = "NousResearch",
-    best_provider = Blackbox
-)
-
 hermes_3 = Model(
     name          = "hermes-3",
     base_provider = "NousResearch",
@@ -335,20 +329,20 @@ gemini_exp = Model(
 gemini_1_5_flash = Model(
     name          = 'gemini-1.5-flash',
     base_provider = 'Google DeepMind',
-    best_provider = IterListProvider([Blackbox, Free2GPT, FreeGpt, TeachAnything, Websim, Dynaspark, Jmuz, GeminiPro])
+    best_provider = IterListProvider([Free2GPT, FreeGpt, TeachAnything, Websim, Dynaspark, Jmuz, GeminiPro])
 )
 
 gemini_1_5_pro = Model(
     name          = 'gemini-1.5-pro',
     base_provider = 'Google DeepMind',
-    best_provider = IterListProvider([Blackbox, Free2GPT, FreeGpt, TeachAnything, Websim, Jmuz, GeminiPro])
+    best_provider = IterListProvider([Free2GPT, FreeGpt, TeachAnything, Websim, Jmuz, GeminiPro])
 )
 
 # gemini-2.0
 gemini_2_0_flash = Model(
     name          = 'gemini-2.0-flash',
     base_provider = 'Google DeepMind',
-    best_provider = IterListProvider([Blackbox, Dynaspark, GeminiPro, Liaobots])
+    best_provider = IterListProvider([Dynaspark, GeminiPro, Liaobots])
 )
 
 gemini_2_0_flash_thinking = Model(
@@ -418,12 +412,6 @@ blackboxai = Model(
     best_provider = Blackbox
 )
 
-blackboxai_pro = Model(
-    name = 'blackboxai-pro',
-    base_provider = 'Blackbox AI',
-    best_provider = Blackbox
-)
-
 ### CohereForAI ###
 command_r = Model(
     name = 'command-r',
@@ -485,7 +473,7 @@ qwen_2_5_1m = Model(
 qwq_32b = Model(
     name = 'qwq-32b',
     base_provider = 'Qwen',
-    best_provider = IterListProvider([Blackbox, Jmuz, HuggingChat])
+    best_provider = IterListProvider([Jmuz, HuggingChat])
 )
 qvq_72b = VisionModel(
     name = 'qvq-72b',
@@ -580,7 +568,7 @@ nemotron_70b = Model(
 dbrx_instruct = Model(
     name = 'dbrx-instruct',
     base_provider = 'Databricks',
-    best_provider = IterListProvider([Blackbox, DeepInfraChat])
+    best_provider = DeepInfraChat
 )
 
 ### THUDM ### 
@@ -798,7 +786,6 @@ class ModelUtils:
         mixtral_small_24b.name: mixtral_small_24b,
 
         ### NousResearch ###
-        hermes_2_dpo.name: hermes_2_dpo,
         hermes_3.name: hermes_3,
                 
         ### Microsoft ###
@@ -839,7 +826,6 @@ class ModelUtils:
 
         ### Blackbox AI ###
         blackboxai.name: blackboxai,
-        blackboxai_pro.name: blackboxai_pro,
 
         ### CohereForAI ###
         command_r.name: command_r,
@@ -880,19 +866,33 @@ class ModelUtils:
         deepseek_v3.name: deepseek_v3,
         deepseek_r1.name: deepseek_r1,
 
-        nemotron_70b.name: nemotron_70b, ### Nvidia ###
-        dbrx_instruct.name: dbrx_instruct, ### Databricks ###
-        glm_4.name: glm_4, ### THUDM ###
-        mini_max.name: mini_max, ## MiniMax ###
-        yi_34b.name: yi_34b, ## 01-ai ###
+        ### Nvidia ###
+        nemotron_70b.name: nemotron_70b,
+        
+        ### Databricks ###
+        dbrx_instruct.name: dbrx_instruct,
+        
+        ### THUDM ###
+        glm_4.name: glm_4,
+        
+        ## MiniMax ###
+        mini_max.name: mini_max, 
+        
+        ## 01-ai ###
+        yi_34b.name: yi_34b,
         
         ### Cognitive Computations ###
         dolphin_2_6.name: dolphin_2_6,
         dolphin_2_9.name: dolphin_2_9,
         
-        airoboros_70b.name: airoboros_70b, ### DeepInfra ###
-        lzlv_70b.name: lzlv_70b, ### Lizpreciatior ###
-        minicpm_2_5.name: minicpm_2_5, ### OpenBMB ###
+        ### DeepInfra ###
+        airoboros_70b.name: airoboros_70b,
+        
+        ### Lizpreciatior ###
+        lzlv_70b.name: lzlv_70b,
+        
+        ### OpenBMB ###
+        minicpm_2_5.name: minicpm_2_5,
         
         ### Ai2 ###
         tulu_3_405b.name: tulu_3_405b,
@@ -901,9 +901,11 @@ class ModelUtils:
         tulu_3_70b.name: tulu_3_70b,
         olmoe_0125.name: olmoe_0125,
         
-        lfm_40b.name: lfm_40b, ### Liquid AI ###
+        ### Liquid AI ###
+        lfm_40b.name: lfm_40b,
         
-        evil.name: evil, ### Uncensored AI ###
+        ### Uncensored AI ###
+        evil.name: evil,
         
         #############
         ### Image ###

--- a/g4f/models.py
+++ b/g4f/models.py
@@ -22,6 +22,7 @@ from .Provider import (
     Glider,
     ImageLabs,
     Jmuz,
+    LambdaChat,
     Liaobots,
     OIVSCode,
     PerplexityLabs,
@@ -247,7 +248,7 @@ llama_3_2_90b = Model(
 llama_3_3_70b = Model(
     name          = "llama-3.3-70b",
     base_provider = "Meta Llama",
-    best_provider = IterListProvider([DDG, Blackbox, DeepInfraChat, PollinationsAI, Jmuz, HuggingChat, HuggingFace])
+    best_provider = IterListProvider([DDG, Blackbox, DeepInfraChat, LambdaChat, PollinationsAI, Jmuz, HuggingChat, HuggingFace])
 )
 
 ### Mistral ###
@@ -279,6 +280,12 @@ hermes_2_dpo = Model(
     name          = "hermes-2-dpo",
     base_provider = "NousResearch",
     best_provider = Blackbox
+)
+
+hermes_3 = Model(
+    name          = "hermes-3",
+    base_provider = "NousResearch",
+    best_provider = LambdaChat
 )
 
 ### Microsoft ###
@@ -502,7 +509,7 @@ deepseek_chat = Model(
 deepseek_v3 = Model(
     name = 'deepseek-v3',
     base_provider = 'DeepSeek',
-    best_provider = IterListProvider([Blackbox, DeepInfraChat, OIVSCode, Liaobots])
+    best_provider = IterListProvider([Blackbox, DeepInfraChat, LambdaChat, OIVSCode, Liaobots])
 )
 
 deepseek_r1 = Model(
@@ -565,7 +572,7 @@ r1_1776 = Model(
 nemotron_70b = Model(
     name = 'nemotron-70b',
     base_provider = 'Nvidia',
-    best_provider = IterListProvider([HuggingChat, HuggingFace])
+    best_provider = IterListProvider([LambdaChat, HuggingChat, HuggingFace])
 )
 
 ### Databricks ### 
@@ -785,6 +792,7 @@ class ModelUtils:
 
         ### NousResearch ###
         hermes_2_dpo.name: hermes_2_dpo,
+        hermes_3.name: hermes_3,
                 
         ### Microsoft ###
         # phi

--- a/g4f/models.py
+++ b/g4f/models.py
@@ -441,6 +441,12 @@ command_r7b = Model(
     best_provider = HuggingSpace
 )
 
+command_a = Model(
+    name = 'command-a',
+    base_provider = 'CohereForAI',
+    best_provider = HuggingSpace
+)
+
 ### Qwen ###
 qwen_1_5_7b = Model(
     name = 'qwen-1.5-7b',
@@ -831,6 +837,7 @@ class ModelUtils:
         command_r.name: command_r,
         command_r_plus.name: command_r_plus,
         command_r7b.name: command_r7b,
+        command_a.name: command_a,
 
         ### GigaChat ###
         gigachat.name: gigachat,

--- a/g4f/models.py
+++ b/g4f/models.py
@@ -13,11 +13,12 @@ from .Provider import (
     Copilot,
     DDG,
     DeepInfraChat,
+    Dynaspark,
     Free2GPT,
     FreeGpt,
     HuggingSpace,
     G4F,
-    Janus_Pro_7B,
+    DeepseekAI_JanusPro7b,
     Glider,
     ImageLabs,
     Jmuz,
@@ -28,6 +29,7 @@ from .Provider import (
     PollinationsAI,
     PollinationsImage,
     TeachAnything,
+    Websim,
     Yqcloud,
     
     ### Needs Auth ###
@@ -88,6 +90,7 @@ default = Model(
         Free2GPT,
         FreeGpt,
         Glider,
+        Dynaspark,
         OpenaiChat,
         Jmuz,
         Cloudflare,
@@ -102,6 +105,7 @@ default_vision = Model(
         OIVSCode,
         DeepInfraChat,
         PollinationsAI,
+        Dynaspark,
         HuggingSpace,
         GeminiPro,
         HuggingFaceAPI,
@@ -193,19 +197,19 @@ llama_3_70b = Model(
 llama_3_1_8b = Model(
     name          = "llama-3.1-8b",
     base_provider = "Meta Llama",
-    best_provider = IterListProvider([Blackbox, DeepInfraChat, Glider, Jmuz, PollinationsAI, Cloudflare])
+    best_provider = IterListProvider([Blackbox, DeepInfraChat, Glider, PollinationsAI, AllenAI, Jmuz, Cloudflare])
 )
 
 llama_3_1_70b = Model(
     name          = "llama-3.1-70b",
     base_provider = "Meta Llama",
-    best_provider = IterListProvider([Blackbox, Glider, Jmuz])
+    best_provider = IterListProvider([Blackbox, Glider, AllenAI, Jmuz])
 )
 
 llama_3_1_405b = Model(
     name          = "llama-3.1-405b",
     base_provider = "Meta Llama",
-    best_provider = IterListProvider([Blackbox, Jmuz])
+    best_provider = IterListProvider([Blackbox, AllenAI, Jmuz])
 )
 
 # llama 3.2
@@ -329,20 +333,20 @@ gemini_exp = Model(
 gemini_1_5_flash = Model(
     name          = 'gemini-1.5-flash',
     base_provider = 'Google DeepMind',
-    best_provider = IterListProvider([Blackbox, Free2GPT, FreeGpt, TeachAnything, Jmuz, GeminiPro])
+    best_provider = IterListProvider([Blackbox, Free2GPT, FreeGpt, TeachAnything, Websim, Dynaspark, Jmuz, GeminiPro])
 )
 
 gemini_1_5_pro = Model(
     name          = 'gemini-1.5-pro',
     base_provider = 'Google DeepMind',
-    best_provider = IterListProvider([Blackbox, Free2GPT, FreeGpt, TeachAnything, Jmuz, GeminiPro])
+    best_provider = IterListProvider([Blackbox, Free2GPT, FreeGpt, TeachAnything, Websim, Jmuz, GeminiPro])
 )
 
 # gemini-2.0
 gemini_2_0_flash = Model(
     name          = 'gemini-2.0-flash',
     base_provider = 'Google DeepMind',
-    best_provider = IterListProvider([Blackbox, GeminiPro, Liaobots])
+    best_provider = IterListProvider([Blackbox, Dynaspark, GeminiPro, Liaobots])
 )
 
 gemini_2_0_flash_thinking = Model(
@@ -508,9 +512,9 @@ deepseek_r1 = Model(
 )
 
 janus_pro_7b = VisionModel(
-    name = Janus_Pro_7B.default_model,
+    name = DeepseekAI_JanusPro7b.default_model,
     base_provider = 'DeepSeek',
-    best_provider = IterListProvider([Janus_Pro_7B, G4F])
+    best_provider = IterListProvider([DeepseekAI_JanusPro7b, G4F])
 )
 
 ### x.ai ###
@@ -686,7 +690,7 @@ sd_3_5 = ImageModel(
 flux = ImageModel(
     name = 'flux',
     base_provider = 'Black Forest Labs',
-    best_provider = IterListProvider([Blackbox, PollinationsImage, HuggingSpace])
+    best_provider = IterListProvider([Blackbox, PollinationsImage, Websim, HuggingSpace])
 )
 
 flux_pro = ImageModel(

--- a/g4f/models.py
+++ b/g4f/models.py
@@ -20,6 +20,7 @@ from .Provider import (
     G4F,
     DeepseekAI_JanusPro7b,
     Glider,
+    Goabror,
     ImageLabs,
     Jmuz,
     LambdaChat,
@@ -125,7 +126,7 @@ default_vision = Model(
 gpt_4 = Model(
     name          = 'gpt-4',
     base_provider = 'OpenAI',
-    best_provider = IterListProvider([DDG, Jmuz, ChatGptEs, PollinationsAI, Yqcloud, Copilot, OpenaiChat, Liaobots])
+    best_provider = IterListProvider([DDG, Jmuz, ChatGptEs, PollinationsAI, Yqcloud, Goabror, Copilot, OpenaiChat, Liaobots])
 )
 
 # gpt-4o

--- a/g4f/models.py
+++ b/g4f/models.py
@@ -131,7 +131,7 @@ gpt_4 = Model(
 gpt_4o = VisionModel(
     name          = 'gpt-4o',
     base_provider = 'OpenAI',
-    best_provider = IterListProvider([Blackbox, Jmuz, ChatGptEs, PollinationsAI, Copilot, Liaobots, OpenaiChat])
+    best_provider = IterListProvider([Blackbox, Jmuz, ChatGptEs, PollinationsAI, Liaobots, OpenaiChat])
 )
 
 gpt_4o_mini = Model(
@@ -144,7 +144,7 @@ gpt_4o_mini = Model(
 o1 = Model(
     name          = 'o1',
     base_provider = 'OpenAI',
-    best_provider = IterListProvider([Blackbox, OpenaiAccount])
+    best_provider = IterListProvider([Blackbox, Copilot, OpenaiAccount])
 )
 
 o1_mini = Model(

--- a/g4f/models.py
+++ b/g4f/models.py
@@ -271,13 +271,13 @@ mistral_nemo = Model(
 mixtral_small_24b = Model(
     name          = "mixtral-small-24b",
     base_provider = "Mistral",
-    best_provider = DDG
+    best_provider = IterListProvider([DDG, Blackbox])
 )
 
 mixtral_small_28b = Model(
     name          = "mixtral-small-28b",
     base_provider = "Mistral",
-    best_provider = IterListProvider([Blackbox, DeepInfraChat])
+    best_provider = DeepInfraChat
 )
 
 ### NousResearch ###

--- a/g4f/models.py
+++ b/g4f/models.py
@@ -271,13 +271,7 @@ mistral_nemo = Model(
 mixtral_small_24b = Model(
     name          = "mixtral-small-24b",
     base_provider = "Mistral",
-    best_provider = IterListProvider([DDG, Blackbox])
-)
-
-mixtral_small_28b = Model(
-    name          = "mixtral-small-28b",
-    base_provider = "Mistral",
-    best_provider = DeepInfraChat
+    best_provider = IterListProvider([DDG, Blackbox, DeepInfraChat])
 )
 
 ### NousResearch ###
@@ -788,7 +782,6 @@ class ModelUtils:
         mixtral_8x22b.name: mixtral_8x22b,
         mistral_nemo.name: mistral_nemo,
         mixtral_small_24b.name: mixtral_small_24b,
-        mixtral_small_28b.name: mixtral_small_28b,
 
         ### NousResearch ###
         hermes_2_dpo.name: hermes_2_dpo,

--- a/g4f/models.py
+++ b/g4f/models.py
@@ -515,7 +515,7 @@ deepseek_v3 = Model(
 deepseek_r1 = Model(
     name = 'deepseek-r1',
     base_provider = 'DeepSeek',
-    best_provider = IterListProvider([Blackbox, DeepInfraChat, Glider, PollinationsAI, Jmuz, Liaobots, HuggingChat, HuggingFace])
+    best_provider = IterListProvider([Blackbox, DeepInfraChat, Glider, LambdaChat, PollinationsAI, Jmuz, Liaobots, HuggingChat, HuggingFace])
 )
 
 janus_pro_7b = VisionModel(
@@ -666,6 +666,12 @@ olmoe_0125 = Model(
     name = "olmoe-0125",
     base_provider = "Ai2",
     best_provider = AllenAI
+)
+
+lfm_40b = Model(
+    name = "lfm-40b",
+    base_provider = "Liquid AI",
+    best_provider = LambdaChat
 )
 
 ### Uncensored AI ### 
@@ -893,6 +899,8 @@ class ModelUtils:
         tulu_3_1_8b.name: tulu_3_1_8b,
         tulu_3_70b.name: tulu_3_70b,
         olmoe_0125.name: olmoe_0125,
+        
+        lfm_40b.name: lfm_40b, ### Liquid AI ###
         
         evil.name: evil, ### Uncensored AI ###
         


### PR DESCRIPTION
# Overview
This PR introduces new providers (Websim, Dynaspark, LambdaChat, Goabror) and updates existing provider configurations throughout the codebase. It enhances documentation with standardized terminology and adds audio generation indicators to provider tables. The PR also improves UI labeling for HuggingFace integrations and updates model configurations for various providers.

# Commits
## G4F-Docs (docs/)
### docs(docs/providers-and-models.md): update provider tables and model categorization
- Add "Audio generation" column to all provider tables with ❌ defaults
- Rename table headers: "Text Models" → "Text generation", "Image Models" → "Image generation", "Stream" → "Streaming"
- Add new providers: ARTA, Dynaspark, Websim with respective capabilities
- Update PollinationsAI row with audio generation support and additional vision models
- Rename HuggingSpace providers to use underscores (e.g. BlackForestLabsFlux1Dev → BlackForestLabs_Flux1Dev)
- Add Microsoft_Phi_4 provider with vision capabilities in HuggingSpace section
- Remove Prodia provider from "No auth required" section
- Update model categories from "Text Models"/"Image Models" to "Text generation models"/"Image generation models"
- Add audio generation capability indicators in Local providers section
- Standardize "Needs auth" section header capitalization

### fix(docs/providers-and-models.md): correct streaming status for GlhfChat provider
- Change GlhfChat streaming support status from checked (✔) to unchecked (❌)
- Align streaming capability documentation with actual provider functionality

### docs(docs/providers-and-models.md): update provider capabilities and model documentation
- Fix streaming status indicator for GlhfChat provider in "Needs auth" section (changed to ❌)
- Correct provider counts for Mistral models in text generation table:
  - mixtral-small-24b updated from 1+ to 2+ providers
  - mixtral-small-28b updated from 2+ to 1+ providers
- Standardize status badge formatting across provider tables

### fix(documentation): correct model names and provider counts 
- Correct "mixtral-small-28b" to "mixtral-small-24b" in text generation models table 
- Update provider count for mixtral-small-24b from 2+ to 3+ providers
- Remove incorrect "mixtral-small-28b" entry from Mistral models section 
- Fix model name consistency in DeepInfraChat provider description
> (https://github.com/xtekky/gpt4free/pull/2805#issuecomment-2727489835)

### docs(docs/providers-and-models.md): add LambdaChat provider and update model listings
- Add LambdaChat to "No auth required" providers with supported models
- Introduce new Hermes-3 model under NousResearch in text generation section
- Update llama-3.3-70b provider count from 7+ to 8+ 
- Increase nemotron-70b providers from 2+ to 3+ in text models
- Insert LambdaChat between Jmuz and Liaobots in providers table

### docs(docs/providers-and-models.md): update model listings and provider counts
- Add deepseek-r1 to LambdaChat provider's text generation models
- Increase deepseek-r1 provider count from 8+ to 9+ in models table
- Introduce new lfm-40b model from Liquid AI in text generation section

### docs(docs/providers-and-models.md): update model listings and provider counts
- Update Blackbox provider model list with revised visible models and increased count (29+ → 40+)
- Remove Hermes-2-DPO model from text generation section
- Adjust provider counts for mixtral-small-24b (3+ → 2+), dbrx-instruct (2+ → 1+), and qwq-32b (3+ → 2+)
- Increase GPT-4o-mini provider count from 7+ to 8+ in text models section
- Simplify Blackbox vision models description by removing explicit list in favor of count indicator

## G4F-ETC (etc/)
### fix(etc/examples/vision_images.py): update model and simplify client configuration
- Remove explicit Blackbox provider import and client provider specification
- Change model from `g4f.models.default` to `g4f.models.default_vision` for vision tasks
- Use default Client() initialization without provider parameter
- Maintain consistent image processing logic for both remote and local images


## G4F-GUI (g4f/gui)
### feat(g4f/gui/client/static/js/chat.v1.js): Enhance provider labeling for HuggingFace integrations
- Add "(HuggingSpace)" indicator to provider labels in UI elements
- Update provider selection options with HuggingSpace visibility markers

### feat(g4f/gui/server/api.py): add Hugging Face Space compatibility flag to provider data  
- Add `hf_space` boolean field to provider objects indicating Hugging Face Space association  
- Update `Api.get_providers()` method to include new compatibility flag in returned provider data  
- Implement attribute fallback with `getattr(provider, "hf_space", False)` for backward compatibility  

---

## G4F (g4f/)
### feat(g4f/models.py): add new providers and update model configurations
- Add Dynaspark and Websim as new providers in imports
- Integrate Dynaspark provider into default and default_vision model configurations
- Add AllenAI provider to llama_3.1 series models (8b, 70b, 405b)
- Include Websim and Dynaspark in Gemini 1.5/2.0 flash/pro model providers
- Add Websim provider to Flux image model configuration
- Rename Janus_Pro_7B provider to DeepseekAI_JanusPro7b with updated class references
- Update janus_pro_7b model to use DeepseekAI_JanusPro7b provider class

### chore(g4f/models.py): update provider configurations for OpenAI models
- Add Copilot provider to o1 model's best_provider list
- Remove Copilot from gpt-4o providers and add OpenaiChat
- Maintain existing provider relationships for other models

### fix(g4f/models.py): update provider configurations for Mistral models
- Update mixtral_small_24b.best_provider to use IterListProvider with DDG and Blackbox
- Change mixtral_small_28b.best_provider from IterListProvider to direct DeepInfraChat reference

### fix(g4f/models.py): correct mistral model configurations 
- Remove deprecated 'mixtral-small-28b' model definition 
- Add DeepInfraChat provider to mixtral-small-24b's best_provider list
- Update provider count for mixtral-small-24b from 2 to 3 providers
- Remove mixtral-small-28b entry from ModelUtils conversion dictionary
> (https://github.com/xtekky/gpt4free/pull/2805#issuecomment-2727489835)

### feat(g4f/models.py): add new providers and enhance model configurations
- Add LambdaChat provider import to no-auth required providers list
- Integrate LambdaChat provider into llama-3.3-70b model's best_provider list
- Introduce new hermes-3 model under NousResearch with LambdaChat provider
- Add LambdaChat to deepseek-v3 model's provider list
- Update nemotron-70b provider list to include LambdaChat

### feat(g4f/models.py): add new Liquid AI model and enhance providers
- Add new lfm-40b model with Liquid AI base provider and LambdaChat support
- Integrate LambdaChat provider into deepseek-r1's best_provider list
- Include lfm-40b in ModelUtils.convert registry under Liquid AI section

### refactor(g4f/models.py): update provider configurations and model entries
- Add Blackbox provider to gpt_4o_mini's best_provider list
- Remove Blackbox from llama_3_1_8b, llama_3_1_70b, gemini_1_5_flash, gemini_1_5_pro, and gemini_2_0_flash providers
- Add DeepInfraChat to llama_3_1_8b's best_provider list
- Remove blackboxai_pro model entry and related references
- Update qwq_32b provider list to remove Blackbox
- Reorganize ModelUtils.convert section headers for better structure

---

## G4F-Tools (g4f/tools)
### fix(g4f/tools/run_tools.py): handle combined thinking tags in single chunk
- Add special case handling for chunks containing both `<think>` and `</think>` markers
- Properly split and process thinking content when both tags appear together 
- Add whitespace checks to avoid adding empty reasoning elements
- Ensure text after closing thinking tag gets preserved in output
- Maintain existing timing calculations while processing combined tags
> (https://github.com/xtekky/gpt4free/pull/2805#issuecomment-2730876948)

---

## G4F (g4f/Provider)
### New provider added(g4f/Provider/Websim.py)
 - **Model support:**
    - **Text generation:** `gemini-1.5-pro, gemini-1.5-flash`
    - **Image generation:** `flux`

---

### New provider added(g4f/Provider/Dynaspark.py)
 - **Model support:**
    - **Text generation:** `gemini-1.5-flash, gemini-2.0-flash`

---

### New provider added(g4f/Provider/LambdaChat.py)
**Model support:**
 - **Text generation:** `deepseek-v3, deepseek-r1, hermes-3, nemotron-70b, llama-3.3-70b, lfm-40b`
> (close #2654)

### feat(g4f/Provider/LambdaChat.py): add conditional reasoning processing based on model
- Add new class variable `reasoning_model` set to "deepseek-r1"
- Replace hardcoded "deepseek-r1" in models list with `reasoning_model` reference
- Add model check to reasoning response processing (`model == cls.reasoning_model`)
- Ensure reasoning logic only executes for designated reasoning model

---

### New provider added(g4f/Provider/Goabror.py)
 - **Model support:**
    - **Text generation:** `gpt-4`
> (close #2808)

---

### Update g4f/Provider/__init__.py

---

### Update g4f/Provider/hf_space/*

---

### feat(g4f/Provider/AllenAI.py): expand model alias mappings for AllenAI provider
- Add "llama-3.1-405b" alias mapping to "Llama-3-1-Tulu-3-70B" in model_aliases
- Add "llama-3.1-8b" alias mapping to "tulu-3-1-8b" in model_aliases
- Update existing "tulu-3-70b" alias to point to "Llama-3-1-Tulu-3-70B"

---

### feat(g4f/Provider/Blackbox.py): restructure image model handling and response processing
- Change default_image_model from 'ImageGeneration' to 'flux' and update model_aliases
- Remove direct image generation endpoint call and move logic to main response processing
- Add conditional response streaming based on model type (image vs non-image)
- Implement unified image URL extraction from full response markdown
- Update imageGenerationMode flag to use model comparison instead of hardcoded False
- Add fallback text response for image models that don't produce images
- Remove obsolete "flux" alias from model_aliases dictionary

### fix(g4f/Provider/Blackbox.py): correct model alias key for Mistral variant
- Update model_aliases key from "mixtral-small-28b" to "mixtral-small-24b"
- Maintain correct mapping to "Mistral-Small-24B-Instruct-2501" model
> (close #2804)

### feat(g4f/Provider/Blackbox.py): implement dynamic session management and model access control
- Add dynamic session generation with expiry dates and improved user session validation
- Implement model access control with fallback_models for unauthorized users and _all_models for premium
- Add HAR file analysis in _check_premium_access to detect valid user sessions
- Restructure model configurations with standardized naming (GPT-4o, Gemini-PRO)
- Replace print statements with debug.log for better error tracking
- Remove hardcoded encrypted session data in favor of generated sessions
- Add 35+ fallback models for free tier access
- Simplify model aliases and update agentMode/trendingAgentMode configurations
- Implement get_models() method for dynamic model list selection based on auth status

---

### feat(g4f/Provider/PollinationsAI.py): add new model aliases and streamline headers
- Add "deepseek-r1": "deepseek-r1-llama" alias to text models
- Add "gpt-4o-audio": "openai-audio" alias for audio capabilities
- Remove redundant security headers (priority, sec-* headers) from DEFAULT_HEADERS
- Maintain core headers (user-agent, referer, origin) for essential request metadata

---

### refactor(g4f/Provider/Copilot.py): update model alias mapping
- Replace "gpt-4o" alias with "o1" in Copilot model_aliases
- Maintain same default model mapping for compatibility

---

### feat(g4f/Provider/hf_space/CohereForAI_C4AI_Command.py): update supported model versions and aliases 
- Change default_model from "command-r-plus-08-2024" to "command-a-03-2025"
- Add "command-a-03-2025" and "command-r7b-arabic-02-2025" to models list
- Introduce "command-a" alias mapping to "command-a-03-2025" in model_aliases
- Maintain backward compatibility with existing model aliases while adding new ones
> (close #2802)

---

### fix(g4f/Provider/DeepInfraChat.py): correct mixtral-small alias key 
- Fix typo in model alias key from "mixtral-small-28b" to "mixtral-small-24b"
- Update key to match actual model name "mistralai/Mistral-Small-24B-Instruct-2501"
> (https://github.com/xtekky/gpt4free/pull/2805#issuecomment-2727489835)

---

# Irrelevant issues that can be closed
 - close #2745
 - close #2607
 - close #2587
