### PR TITLE
fix(g4f/client/stubs.py): correct typo in object field

### DIFF
--- a/g4f/client/stubs.py
+++ b/g4f/client/stubs.py
@@ -84,7 +84,7 @@ class ChatCompletionChunk(BaseModel):
     ):
         return super().model_construct(
             id=f"chatcmpl-{completion_id}" if completion_id else None,
-            object="chat.completion.cunk",
+            object="chat.completion.chunk",
             created=created,
             model=None,
             provider=None,


### PR DESCRIPTION
Fix a typo in the `object` field from "chat.completion.cunk" to "chat.completion.chunk".