### PR TITLE
refactor: update string conversion, provider aliases, and model mappings

### DIFF
--- a/g4f/Provider/Blackbox.py
+++ b/g4f/Provider/Blackbox.py
@@ -19,6 +19,7 @@ from ..cookies import get_cookies_dir
 from .helper import format_image_prompt
 from ..providers.response import JsonConversation, ImageResponse
 from ..tools.media import merge_media
+from ..errors import PaymentRequiredError
 from .. import debug
 
 class Conversation(JsonConversation):
@@ -689,6 +690,8 @@ class Blackbox(AsyncGeneratorProvider, ProviderModelMixin):
                 async for chunk in response.content.iter_any():
                     if chunk:
                         chunk_text = chunk.decode()
+                        if chunk_text == "You have reached your request limit for the hour":
+                            raise PaymentRequiredError(chunk_text)
                         full_response.append(chunk_text)
                         # Only yield chunks for non-image models
                         if model != cls.default_image_model:

--- a/g4f/Provider/Cloudflare.py
+++ b/g4f/Provider/Cloudflare.py
@@ -9,6 +9,7 @@ from ..requests import Session, StreamSession, get_args_from_nodriver, raise_for
 from ..requests import DEFAULT_HEADERS, has_nodriver, has_curl_cffi
 from ..providers.response import FinishReason, Usage
 from ..errors import ResponseStatusError, ModelNotFoundError
+from .helper import to_string
 
 class Cloudflare(AsyncGeneratorProvider, ProviderModelMixin, AuthFileMixin):
     label = "Cloudflare AI"
@@ -89,8 +90,8 @@ class Cloudflare(AsyncGeneratorProvider, ProviderModelMixin, AuthFileMixin):
         data = {
             "messages": [{
                 **message,
-                "content": message["content"] if isinstance(message["content"], str) else "",
-                "parts": [{"type":"text", "text":message["content"]}] if isinstance(message["content"], str) else message} for message in messages],
+                "content": to_string(message["content"]),
+                "parts": [{"type":"text", "text": to_string(message["content"])}]} for message in messages],
             "lora": None,
             "model": model,
             "max_tokens": max_tokens,

--- a/g4f/Provider/PollinationsAI.py
+++ b/g4f/Provider/PollinationsAI.py
@@ -51,7 +51,7 @@ class PollinationsAI(AsyncGeneratorProvider, ProviderModelMixin):
     image_models = [default_image_model]
     audio_models = [default_audio_model]
     extra_image_models = ["flux-pro", "flux-dev", "flux-schnell", "midjourney", "dall-e-3", "turbo"]
-    vision_models = [default_vision_model, "gpt-4o-mini", "o3-mini", "openai", "openai-large", "searchgpt"]
+    vision_models = [default_vision_model, "gpt-4o-mini", "openai", "openai-large", "searchgpt"]
     extra_text_models = vision_models
     _models_loaded = False
     model_aliases = {
@@ -59,22 +59,19 @@ class PollinationsAI(AsyncGeneratorProvider, ProviderModelMixin):
         "gpt-4o-mini": "openai",
         "gpt-4": "openai-large",
         "gpt-4o": "openai-large",
-        "o3-mini": "openai-reasoning",
         "qwen-2.5-coder-32b": "qwen-coder",
         "llama-3.3-70b": "llama",
+        "llama-4-scout": "llamascout",
         "mistral-nemo": "mistral",
-        "gpt-4o-mini": "searchgpt",
         "llama-3.1-8b": "llamalight",
         "llama-3.3-70b": "llama-scaleway",
         "phi-4": "phi",
         "gemini-2.0": "gemini",
         "gemini-2.0-flash": "gemini",
         "gemini-2.0-flash-thinking": "gemini-thinking",
-        "gemini-2.0-flash-thinking": "gemini-reasoning",
         "deepseek-r1": "deepseek-reasoning-large",
         "deepseek-r1": "deepseek-reasoning",
         "deepseek-v3": "deepseek",
-        "qwq-32b": "qwen-reasoning",
         "llama-3.2-11b": "llama-vision",
         "gpt-4o-audio": "openai-audio",
         

--- a/g4f/Provider/needs_auth/OpenaiChat.py
+++ b/g4f/Provider/needs_auth/OpenaiChat.py
@@ -605,7 +605,7 @@ class OpenaiChat(AsyncAuthedProvider, ProviderModelMixin):
                 elif event.request.url in (backend_url, backend_anon_url):
                     if "OpenAI-Sentinel-Proof-Token" in event.request.headers:
                             cls.request_config.proof_token = json.loads(base64.b64decode(
-                                event.request.headers["OpenAI-Sentinel-Proof-Token"].split("gAAAAAB", 1)[-1].encode()
+                                event.request.headers["OpenAI-Sentinel-Proof-Token"].split("gAAAAAB", 1)[-1].split("~")[0].encode()
                             ).decode())
                     if "OpenAI-Sentinel-Turnstile-Token" in event.request.headers:
                         cls.request_config.turnstile_token = event.request.headers["OpenAI-Sentinel-Turnstile-Token"]

--- a/g4f/gui/client/index.html
+++ b/g4f/gui/client/index.html
@@ -86,6 +86,10 @@
                     <i class="fa-regular fa-plus"></i>
                     <span>New Conversation</span>
                 </button>
+                <button class="new_convo" onclick="new_conversation(true)">
+                    <i class="fa-solid fa-user-secret"></i>
+                    <span>Private Conversation</span>
+                </button>
             </div>
             <div class="bottom_buttons">
                 <button onclick="open_settings();">

--- a/g4f/gui/client/static/css/style.css
+++ b/g4f/gui/client/static/css/style.css
@@ -432,7 +432,7 @@ body:not(.white) a:visited{
     padding: 8px 16px;
     margin-bottom: 16px;
     color: inherit;
-    border-left: .25em solid var(--colour-4);
+    border-left: .25em solid var(--media-select);
 }
 
 .media-player {

--- a/g4f/models.py
+++ b/g4f/models.py
@@ -183,7 +183,7 @@ o1_mini = Model(
 o3_mini = Model(
     name          = 'o3-mini',
     base_provider = 'OpenAI',
-    best_provider = IterListProvider([DDG, Blackbox, PollinationsAI, Liaobots])
+    best_provider = IterListProvider([DDG, Blackbox, Liaobots])
 )
 
 ### GigaChat ###
@@ -200,13 +200,13 @@ meta = Model(
     best_provider = MetaAI
 )
 
-# llama 2
+### llama 2-4 ###
 llama_2_7b = Model(
     name          = "llama-2-7b",
     base_provider = "Meta Llama",
     best_provider = Cloudflare
 )
-# llama 3
+
 llama_3_8b = Model(
     name          = "llama-3-8b",
     base_provider = "Meta Llama",
@@ -219,7 +219,6 @@ llama_3_70b = Model(
     best_provider = Jmuz
 )
 
-# llama 3.1
 llama_3_1_8b = Model(
     name          = "llama-3.1-8b",
     base_provider = "Meta Llama",
@@ -237,8 +236,6 @@ llama_3_1_405b = Model(
     base_provider = "Meta Llama",
     best_provider = IterListProvider([AllenAI, Jmuz])
 )
-
-# llama 3.2
 
 llama_3_2_1b = Model(
     name          = "llama-3.2-1b",
@@ -264,11 +261,16 @@ llama_3_2_90b = Model(
     best_provider = IterListProvider([DeepInfraChat, Jmuz])
 )
 
-# llama 3.3
 llama_3_3_70b = Model(
     name          = "llama-3.3-70b",
     base_provider = "Meta Llama",
     best_provider = IterListProvider([Blackbox, DDG, DeepInfraChat, LambdaChat, PollinationsAI, Jmuz, HuggingChat, HuggingFace])
+)
+
+llama_4_scout = Model(
+    name          = "llama-4-scout",
+    base_provider = "Meta Llama",
+    best_provider = IterListProvider([Cloudflare, PollinationsAI])
 )
 
 ### Mistral ###
@@ -496,7 +498,7 @@ qwen_2_5_max = Model(
 qwq_32b = Model(
     name = 'qwq-32b',
     base_provider = 'Qwen',
-    best_provider = IterListProvider([Blackbox, PollinationsAI, Jmuz, HuggingChat])
+    best_provider = IterListProvider([Blackbox, Jmuz, HuggingChat])
 )
 qvq_72b = VisionModel(
     name = 'qvq-72b',
@@ -818,6 +820,9 @@ class ModelUtils:
         
         # llama-3.3
         llama_3_3_70b.name: llama_3_3_70b,
+
+        # llama-4
+        llama_4_scout.name: llama_4_scout,
                 
         ### Mistral ###
         mixtral_8x7b.name: mixtral_8x7b,


### PR DESCRIPTION
- In **g4f/Provider/Cloudflare.py**:
  - Added `from .helper import to_string`.
  - Replaced conditional string checks with `to_string(message["content"])` for both `"content"` and elements in `"parts"`.

- In **g4f/Provider/PollinationsAI.py**:
  - Removed `"o3-mini"` from the `vision_models` list.
  - Updated the alias mapping dictionary by:
    - Removing the `"o3-mini": "openai-reasoning"` entry.
    - Removing the duplicate `"gpt-4o-mini": "searchgpt"` mapping.
    - Removing the duplicate `"gemini-2.0-flash-thinking": "gemini-reasoning"` entry.
    - Removing the `"qwq-32b": "qwen-reasoning"` mapping.
    - Adding a new alias `"llama-4-scout": "llamascout"`.

- In **g4f/gui/client/static/css/style.css**:
  - Changed the `border-left` property value from `var(--colour-4)` to `var(--media-select)`.

- In **g4f/models.py**:
  - For the `"o3-mini"` model, removed `PollinationsAI` from its `best_provider` list.
  - Changed the comment from `# llama 2` to `### llama 2-4 ###` and removed redundant comments for llama 3.1 and 3.2.
  - Added a new model `llama_4_scout` with `base_provider` set to `"Meta Llama"` and `best_provider` as `IterListProvider([Cloudflare, PollinationsAI])`.
  - For the `"qwq-32b"` model, removed `PollinationsAI` from its `best_provider` list.
  - Updated the `ModelUtils` mapping to include the new `llama_4_scout` model.