### PR TITLE
fix: serialize None as empty string

### DIFF
--- a/g4f/client/stubs.py
+++ b/g4f/client/stubs.py
@@ -185,14 +185,17 @@ class ChatCompletion(BaseModel):
 
 class ChatCompletionDelta(BaseModel):
     role: str
-    content: str
+    content: Optional[str]
 
     @classmethod
     def model_construct(cls, content: Optional[str]):
         return super().model_construct(role="assistant", content=content)
 
     @field_serializer('content')
-    def serialize_content(self, content: str):
+    def serialize_content(self, content: Optional[str]):
+        if content is None:
+            return ""
+
         return str(content)
 
 class ChatCompletionDeltaChoice(BaseModel):


### PR DESCRIPTION
**Problem**:

content with value None is serialized as `"None"` string in response when using stream mode:
![image](https://github.com/user-attachments/assets/c92e561f-d46a-4c0a-9a30-c2f805d49dd1)
