### PR TITLE
feat: enhance HAR provider, image handling, markdown upload & cache

### DIFF
--- a/etc/tool/commit.py
+++ b/etc/tool/commit.py
@@ -31,8 +31,8 @@ from g4f import debug
 debug.logging = True
 
 # Constants
-DEFAULT_MODEL = "o1"
-FALLBACK_MODELS = ["o1", "o3-mini", "gpt-4o"]
+DEFAULT_MODEL = "gpt-4o"
+FALLBACK_MODELS = []
 MAX_DIFF_SIZE = None  # Set to None to disable truncation, or a number for character limit
 MAX_RETRIES = 3
 RETRY_DELAY = 2  # Seconds
@@ -193,15 +193,15 @@ def generate_commit_message(diff_text: str, model: str = DEFAULT_MODEL) -> Optio
             )
             content = []
             for chunk in response:
-                # Stop spinner and clear line
-                if spinner:
-                    spinner.set()
-                    print(" " * 50 + "\n", flush=True)
-                    spinner = None
                 if isinstance(chunk.choices[0].delta.content, str):
+                    # Stop spinner and clear line
+                    if spinner:
+                        spinner.set()
+                        print(" " * 50 + "\n", flush=True)
+                        spinner = None
                     content.append(chunk.choices[0].delta.content)
                     print(chunk.choices[0].delta.content, end="", flush=True)
-            return "".join(content).strip()
+            return "".join(content).strip().strip("`")
         except Exception as e:
             # Stop spinner if it's running
             if 'spinner' in locals() and spinner:

--- a/g4f/Provider/Cloudflare.py
+++ b/g4f/Provider/Cloudflare.py
@@ -66,6 +66,11 @@ class Cloudflare(AsyncGeneratorProvider, ProviderModelMixin, AuthFileMixin):
                 cls.model_aliases = {**cls.model_aliases, **model_map}
         if not cls.models:
             try:
+                cache_file = cls.get_cache_file()
+                if cls._args is None:
+                    if cache_file.exists():
+                        with cache_file.open("r") as f:
+                            cls._args = json.load(f)
                 if cls._args is None:
                     cls._args = {"headers": DEFAULT_HEADERS, "cookies": {}}
                 read_models()

--- a/g4f/Provider/audio/EdgeTTS.py
+++ b/g4f/Provider/audio/EdgeTTS.py
@@ -31,6 +31,7 @@ class EdgeTTS(AsyncGeneratorProvider, ProviderModelMixin):
             voices = asyncio.run(VoicesManager.create())
             cls.default_model = voices.find(Locale=cls.default_locale)[0]["Name"]
             cls.models = [voice["Name"] for voice in voices.voices]
+            cls.audio_models = cls.models
         return cls.models
 
     @classmethod

--- a/g4f/Provider/audio/gTTS.py
+++ b/g4f/Provider/audio/gTTS.py
@@ -43,7 +43,10 @@ class gTTS(AsyncGeneratorProvider, ProviderModelMixin):
     default_language = "en"
     default_tld = "com"
     default_format = "mp3"
+
+    default_model = "en-US"
     models = list(models.keys())
+    audio_models = models
 
     @classmethod
     async def create_async_generator(

--- a/g4f/Provider/har/__init__.py
+++ b/g4f/Provider/har/__init__.py
@@ -17,10 +17,10 @@ class HarProvider(AsyncGeneratorProvider, ProviderModelMixin):
 
     @classmethod
     def get_models(cls):
-        for harFile in read_har_files():
+        for domain, harFile in read_har_files():
             for v in harFile['log']['entries']:
                 request_url = v['request']['url']
-                if not request_url.startswith(cls.url) or "." in urlparse(request_url).path or "heartbeat" in request_url:
+                if domain not in request_url or "." in urlparse(request_url).path or "heartbeat" in request_url:
                     continue
                 if "\n\ndata: " not in v['response']['content']['text']:
                     continue
@@ -41,11 +41,11 @@ class HarProvider(AsyncGeneratorProvider, ProviderModelMixin):
         session_hash = str(uuid.uuid4()).replace("-", "")
         prompt = get_last_user_message(messages)
 
-        for harFile in read_har_files():
+        for domain, harFile in read_har_files():
             async with StreamSession(impersonate="chrome") as session:
                 for v in harFile['log']['entries']:
                     request_url = v['request']['url']
-                    if not request_url.startswith(cls.url) or "." in urlparse(request_url).path or "heartbeat" in request_url:
+                    if domain not in request_url or "." in urlparse(request_url).path or "heartbeat" in request_url:
                         continue
                     postData = None
                     if "postData" in v['request']:
@@ -59,8 +59,6 @@ class HarProvider(AsyncGeneratorProvider, ProviderModelMixin):
 
                     async with getattr(session, method)(request_url, data=postData, headers=get_headers(v), proxy=proxy) as response:
                         await raise_for_status(response)
-                        if "heartbeat" in request_url:
-                            continue
                         returned_data = ""
                         async for line in response.iter_lines():
                             if not line.startswith(b"data: "):
@@ -83,9 +81,9 @@ def read_har_files():
         for file in files:
             if not file.endswith(".har"):
                 continue
-            with open(os.path.join(root, file), 'rb') as file:
+            with open(os.path.join(root, file), 'rb') as f:
                 try:
-                    yield json.loads(file.read())
+                    yield os.path.splitext(file)[0], json.load(f)
                 except json.JSONDecodeError:
                     raise RuntimeError(f"Failed to read HAR file: {file}")
 
@@ -98,7 +96,7 @@ def read_str_recusive(data):
         elif isinstance(item, str):
             yield item
 
-def find_str(data, skip=0):
+def find_str(data, skip: int = 0):
     for item in read_str_recusive(data):
         if skip > 0:
             skip -= 1
@@ -110,7 +108,6 @@ def read_list_recusive(data, key):
     if isinstance(data, dict):
         for k, v in data.items():
             if k == key:
-                print(k, v)
                 yield v
             else:
                 yield from read_list_recusive(v, key)
@@ -123,8 +120,7 @@ def find_list(data, key):
         if isinstance(item, str):
             yield item
         elif isinstance(item, list):
-            for sub_item in item:
-                yield sub_item
+            yield from item
 
 def get_str_list(data):
     for item in data:

--- a/g4f/Provider/har/__init__.py
+++ b/g4f/Provider/har/__init__.py
@@ -14,6 +14,7 @@ from ..openai.har_file import get_headers
 class HarProvider(AsyncGeneratorProvider, ProviderModelMixin):
     url = "https://lmarena.ai"
     working = True
+    default_model = "chatgpt-4o-latest-20250326"
 
     @classmethod
     def get_models(cls):
@@ -26,6 +27,7 @@ class HarProvider(AsyncGeneratorProvider, ProviderModelMixin):
                     continue
                 chunk = v['response']['content']['text'].split("\n\ndata: ")[2]
                 cls.models = list(dict.fromkeys(get_str_list(find_list(json.loads(chunk), 'choices'))).keys())
+                cls.models[0] = cls.default_model
                 if cls.models:
                     break
         return cls.models

--- a/g4f/Provider/hf/HuggingFaceMedia.py
+++ b/g4f/Provider/hf/HuggingFaceMedia.py
@@ -16,7 +16,7 @@ from ...image import use_aspect_ratio
 from ... import debug
 
 class HuggingFaceMedia(AsyncGeneratorProvider, ProviderModelMixin):
-    label = "HuggingFace (Image/Video Generation)"
+    label = "HuggingFace"
     parent = "HuggingFace"
     url = "https://huggingface.co"
     working = True

--- a/g4f/Provider/hf_space/CohereForAI_C4AI_Command.py
+++ b/g4f/Provider/hf_space/CohereForAI_C4AI_Command.py
@@ -11,7 +11,7 @@ from ...providers.response import JsonConversation, TitleGeneration
 
 class CohereForAI_C4AI_Command(AsyncGeneratorProvider, ProviderModelMixin):
     label = "CohereForAI C4AI Command"
-    url = "	https://coherelabs-c4ai-command.hf.space"
+    url = "https://coherelabs-c4ai-command.hf.space"
     conversation_url = f"{url}/conversation"
 
     working = True

--- a/g4f/Provider/needs_auth/Grok.py
+++ b/g4f/Provider/needs_auth/Grok.py
@@ -111,7 +111,7 @@ class Grok(AsyncAuthedProvider, ProviderModelMixin):
                             response_data = result.get("response", {})
                             image = response_data.get("streamingImageGenerationResponse", None)
                             if image is not None:
-                                yield ImagePreview(f'{cls.assets_url}/{image["imageUrl"]}', "", {"cookies": cookies, "headers": headers})
+                                yield ImagePreview(f'{cls.assets_url}/{image["imageUrl"]}', "", {"cookies": auth_result.cookies, "headers": auth_result.headers})
                             token = response_data.get("token", result.get("token"))
                             is_thinking = response_data.get("isThinking", result.get("isThinking"))
                             if token:

--- a/g4f/client/__init__.py
+++ b/g4f/client/__init__.py
@@ -291,16 +291,18 @@ class Completions:
         max_tokens: Optional[int] = None,
         stop: Optional[Union[list[str], str]] = None,
         api_key: Optional[str] = None,
-        ignore_working: Optional[bool] = False,
         ignore_stream: Optional[bool] = False,
         **kwargs
     ) -> ChatCompletion:
         if isinstance(messages, str):
             messages = [{"role": "user", "content": messages}]
         if image is not None:
-            kwargs["media"] = [(image, image_name)]
+            kwargs["media"] = (image, image_name)
         elif "images" in kwargs:
             kwargs["media"] = kwargs.pop("images")
+        for idx, media in kwargs.get("media", []):
+            if not isinstance(media, (list, tuple)):
+                kwargs["media"][idx] = (media[0], media[1] if media[1] is not None else getattr(image, "name", None))
         if provider is None:
             provider = self.provider
             if provider is None:
@@ -493,7 +495,10 @@ class Images:
             proxy = self.client.proxy
         prompt = "create a variation of this image"
         if image is not None:
-            kwargs["media"] = [(image, None)]
+            kwargs["media"] = image
+        for idx, media in kwargs.get("media", []):
+            if not isinstance(media, (list, tuple)):
+                kwargs["media"][idx] = (media[0], media[1] if media[1] is not None else getattr(image, "name", None))
 
         error = None
         response = None
@@ -591,7 +596,6 @@ class AsyncCompletions:
         max_tokens: Optional[int] = None,
         stop: Optional[Union[list[str], str]] = None,
         api_key: Optional[str] = None,
-        ignore_working: Optional[bool] = False,
         ignore_stream: Optional[bool] = False,
         **kwargs
     ) -> Awaitable[ChatCompletion]:
@@ -601,6 +605,10 @@ class AsyncCompletions:
             kwargs["media"] = [(image, image_name)]
         elif "images" in kwargs:
             kwargs["media"] = kwargs.pop("images")
+        for idx, media in kwargs.get("media", []):
+            if not isinstance(media, (list, tuple)):
+                kwargs["media"][idx] = (media[0], media[1] if media[1] is not None else getattr(image, "name", None))
+
         if provider is None:
             provider = self.provider
             if provider is None:

--- a/g4f/client/__init__.py
+++ b/g4f/client/__init__.py
@@ -297,7 +297,7 @@ class Completions:
         if isinstance(messages, str):
             messages = [{"role": "user", "content": messages}]
         if image is not None:
-            kwargs["media"] = (image, image_name)
+            kwargs["media"] = [(image, image_name)]
         elif "images" in kwargs:
             kwargs["media"] = kwargs.pop("images")
         for idx, media in kwargs.get("media", []):
@@ -608,7 +608,6 @@ class AsyncCompletions:
         for idx, media in kwargs.get("media", []):
             if not isinstance(media, (list, tuple)):
                 kwargs["media"][idx] = (media[0], media[1] if media[1] is not None else getattr(image, "name", None))
-
         if provider is None:
             provider = self.provider
             if provider is None:

--- a/g4f/gui/server/api.py
+++ b/g4f/gui/server/api.py
@@ -107,12 +107,6 @@ class Api:
         model = json_data.get('model')
         provider = json_data.get('provider')
         messages = json_data.get('messages')
-        kwargs["tool_calls"] = [{
-            "function": {
-                "name": "bucket_tool"
-            },
-            "type": "function"
-        }]
         action = json_data.get('action')
         if action == "continue":
             kwargs["tool_calls"].append({
@@ -186,7 +180,6 @@ class Api:
                             yield self._format_json("conversation_id", conversation_id)
                 elif isinstance(chunk, Exception):
                     logger.exception(chunk)
-                    debug.error(chunk)
                     yield self._format_json('message', get_error_message(chunk), error=type(chunk).__name__)
                 elif isinstance(chunk, RequestLogin):
                     yield self._format_json("preview", chunk.to_string())
@@ -232,7 +225,6 @@ class Api:
             yield self._format_json('auth', type(e).__name__, message=get_error_message(e))
         except Exception as e:
             logger.exception(e)
-            debug.error(e)
             yield self._format_json('error', type(e).__name__, message=get_error_message(e))
         finally:
             yield from self._yield_logs()

--- a/g4f/gui/server/api.py
+++ b/g4f/gui/server/api.py
@@ -4,7 +4,7 @@ import logging
 import os
 import asyncio
 from typing import Iterator
-from flask import send_from_directory
+from flask import send_from_directory, request
 from inspect import signature
 
 from ...errors import VersionNotFoundError, MissingAuthError
@@ -87,7 +87,10 @@ class Api:
         latest_version = None
         try:
             current_version = version.utils.current_version
-            latest_version = version.utils.latest_version
+            if request.args.get("cache"):
+                latest_version = version.utils.latest_version_cached
+            else:
+                latest_version = version.utils.latest_version
         except VersionNotFoundError:
             pass
         return {

--- a/g4f/gui/server/api.py
+++ b/g4f/gui/server/api.py
@@ -87,9 +87,12 @@ class Api:
         latest_version = None
         try:
             current_version = version.utils.current_version
-            if request.args.get("cache"):
-                latest_version = version.utils.latest_version_cached
-            else:
+            try:
+                if request.args.get("cache"):
+                    latest_version = version.utils.latest_version_cached
+            except RuntimeError:
+                pass
+            if latest_version is None:
                 latest_version = version.utils.latest_version
         except VersionNotFoundError:
             pass

--- a/g4f/gui/server/backend_api.py
+++ b/g4f/gui/server/backend_api.py
@@ -318,7 +318,7 @@ class Backend_Api(Api):
                         md = MarkItDown()
                         result = md.convert(copyfile.name).text_content
                         with open(os.path.join(bucket_dir, f"{filename}.md"), 'w') as f:
-                            f.write(f"{result.text_content}\n")
+                            f.write(f"{result}\n")
                         filenames.append(f"{filename}.md")
                     except Exception as e:
                         logger.exception(e)
@@ -333,8 +333,11 @@ class Backend_Api(Api):
                     else:
                         os.remove(copyfile.name)
                         continue
-                    shutil.copyfile(copyfile.name, newfile)
-                    os.remove(copyfile.name)
+                    try:
+                        os.rename(copyfile.name, newfile)
+                    except OSError:
+                        shutil.copyfile(copyfile.name, newfile)
+                        os.remove(copyfile.name)
             with open(os.path.join(bucket_dir, "files.txt"), 'w') as f:
                 [f.write(f"{filename}\n") for filename in filenames]
             return {"bucket_id": bucket_id, "files": filenames, "media": media}

--- a/g4f/gui/server/backend_api.py
+++ b/g4f/gui/server/backend_api.py
@@ -16,6 +16,12 @@ from pathlib import Path
 from urllib.parse import quote_plus
 from hashlib import sha256
 
+try:
+    from markitdown import MarkItDown
+    has_markitdown = True
+except ImportError:
+    has_markitdown = False
+
 from ...client.service import convert_to_provider
 from ...providers.asyncio import to_sync_generator
 from ...providers.response import FinishReason
@@ -299,8 +305,24 @@ class Backend_Api(Api):
             filenames = []
             media = []
             for file in request.files.getlist('files'):
-                try:
-                    filename = secure_filename(file.filename)
+                # Copy the file to a temporary location
+                filename = secure_filename(file.filename)
+                copyfile = tempfile.NamedTemporaryFile(suffix=filename, delete=False)
+                shutil.copyfileobj(file.stream, copyfile)
+                copyfile.close()
+                file.stream.close()
+
+                result = None
+                if has_markitdown:
+                    try:
+                        md = MarkItDown()
+                        result = md.convert(copyfile.name).text_content
+                        with open(os.path.join(bucket_dir, f"{filename}.md"), 'w') as f:
+                            f.write(f"{result.text_content}\n")
+                        filenames.append(f"{filename}.md")
+                    except Exception as e:
+                        logger.exception(e)
+                if not result:
                     if is_allowed_extension(filename):
                         os.makedirs(media_dir, exist_ok=True)
                         newfile = os.path.join(media_dir, filename)
@@ -309,11 +331,10 @@ class Backend_Api(Api):
                         newfile = os.path.join(bucket_dir, filename)
                         filenames.append(filename)
                     else:
+                        os.remove(copyfile.name)
                         continue
-                    with open(newfile, 'wb') as f:
-                        shutil.copyfileobj(file.stream, f)
-                finally:
-                    file.stream.close()
+                    shutil.copyfile(copyfile.name, newfile)
+                    os.remove(copyfile.name)
             with open(os.path.join(bucket_dir, "files.txt"), 'w') as f:
                 [f.write(f"{filename}\n") for filename in filenames]
             return {"bucket_id": bucket_id, "files": filenames, "media": media}

--- a/g4f/providers/base_provider.py
+++ b/g4f/providers/base_provider.py
@@ -465,9 +465,11 @@ class AsyncAuthedProvider(AsyncGeneratorProvider, AuthFileMixin):
                     auth_result = chunk
                 else:
                     yield chunk
-            yield from to_sync_generator(cls.create_authed(model, messages, auth_result, **kwargs))
-        finally:
-            cls.write_cache_file(cache_file, auth_result)
+            for chunk in to_sync_generator(cls.create_authed(model, messages, auth_result, **kwargs)):
+                if cache_file is not None:
+                    cls.write_cache_file(cache_file, auth_result)
+                    cache_file = None
+                yield chunk
 
     @classmethod
     async def create_async_generator(
@@ -506,5 +508,3 @@ class AsyncAuthedProvider(AsyncGeneratorProvider, AuthFileMixin):
                     cls.write_cache_file(cache_file, auth_result)
                     cache_file = None
                 yield chunk
-        finally:
-            cls.write_cache_file(cache_file, auth_result)

--- a/g4f/tools/files.py
+++ b/g4f/tools/files.py
@@ -187,7 +187,7 @@ def stream_read_files(bucket_dir: Path, filenames: list, delete_files: bool = Fa
                                 else:
                                     os.unlink(filepath)
             continue
-        yield f"```{filename}\n"        
+        yield f"```{filename}\n"
         if has_pypdf2 and filename.endswith(".pdf"):
             try:
                 reader = PyPDF2.PdfReader(file_path)

--- a/g4f/version.py
+++ b/g4f/version.py
@@ -104,6 +104,10 @@ class VersionUtils:
             return get_github_version(GITHUB_REPOSITORY)
         return get_pypi_version(PACKAGE_NAME)
 
+    @cached_property
+    def latest_version_cached(self) -> str:
+        return self.latest_version
+
     def check_version(self) -> None:
         """
         Checks if the current version of 'g4f' is up to date with the latest version.


### PR DESCRIPTION
- **g4f/Provider/har/__init__.py**
  - `get_models`/`create_async`: iterate over `(domain, harFile)` and filter with `domain in request_url`
  - `read_har_files` now yields `(domain, har_data)`; fixes file variable shadowing and uses `json.load`
  - remove stray `print`, add type hint for `find_str`, replace manual loops with `yield from`
  - small whitespace clean-up

- **g4f/Provider/needs_auth/Grok.py**
  - `ImagePreview` now passes `auth_result.cookies` and `auth_result.headers`

- **g4f/Provider/needs_auth/OpenaiChat.py**
  - add `Union` import; rename/refactor `get_generated_images` → `get_generated_image`
  - support `file-service://` and `sediment://` pointers; choose correct download URL
  - return `ImagePreview` or `ImageResponse` accordingly and stream each image part
  - propagate 422 errors, update prompt assignment and image handling paths

- **g4f/client/__init__.py**
  - drop unused `ignore_working` parameter in sync/async `Completions`
  - normalise `media` argument: accept single tuple, infer filename when missing, fix index loop
  - `Images.create_variation` updated to use the new media logic

- **g4f/gui/server/api.py**
  - expose `latest_version_cached` via `?cache=` query parameter

- **g4f/gui/server/backend_api.py**
  - optional Markdown extraction via `MarkItDown`; save rendered text as `<file>.md`
  - upload flow rewrites: copy to temp file, move to bucket/media dir, clean temp, store filenames
  - introduce `has_markitdown` guard and improved logging/exception handling

- **g4f/tools/files.py**
  - remove trailing spaces in HAR code-block header string

- **g4f/version.py**
  - add `latest_version_cached` `@cached_property` for memoised version lookup