### PR TITLE
fix: update error handling, URL, and media name logic across providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ docker pull hlohaus789/g4f
   Reach out for help in our [Support Group: discord.gg/qXA4Wf4Fsm](https://discord.gg/qXA4Wf4Fsm).
 
 - **Read our Documentation** 📖  
-  Find detailed guidance and resources at [gpt4free.github.io/docs](https://github.com/gpt4free/gpt4free.github.io/blob/main/docs/main.md).
+  Find detailed guidance and resources at [gpt4free.github.io/docs](https://github.com/gpt4free/gpt4free.github.io).
 
 ## 🔻 Site Takedown
 

--- a/g4f/Provider/Cloudflare.py
+++ b/g4f/Provider/Cloudflare.py
@@ -80,7 +80,7 @@ class Cloudflare(AsyncGeneratorProvider, ProviderModelMixin, AuthFileMixin):
                         try:
                             cls._args = await get_args_from_nodriver(cls.url)
                             read_models()
-                        except (RuntimeError, FileNotFoundError) as e:
+                        except Exception as e:
                             debug.log(f"Nodriver is not available: {type(e).__name__}: {e}")
                             cls.models = cls.fallback_models
                     get_running_loop(check_nested=True)
@@ -107,7 +107,11 @@ class Cloudflare(AsyncGeneratorProvider, ProviderModelMixin, AuthFileMixin):
                 with cache_file.open("r") as f:
                     cls._args = json.load(f)
             elif has_nodriver:
-                cls._args = await get_args_from_nodriver(cls.url, proxy, timeout, cookies)
+                try:
+                    cls._args = await get_args_from_nodriver(cls.url)
+                except (RuntimeError, FileNotFoundError) as e:
+                    debug.log(f"Nodriver is not available: {type(e).__name__}: {e}")
+                    cls._args = {"headers": DEFAULT_HEADERS, "cookies": {}, "impersonate": "chrome"}
             else:
                 cls._args = {"headers": DEFAULT_HEADERS, "cookies": {}, "impersonate": "chrome"}
         try:

--- a/g4f/Provider/PollinationsAI.py
+++ b/g4f/Provider/PollinationsAI.py
@@ -194,8 +194,7 @@ class PollinationsAI(AsyncGeneratorProvider, ProviderModelMixin):
         try:
             model = cls.get_model(model)
         except ModelNotFoundError:
-            if model not in cls.image_models:
-                raise
+            pass
 
         if model in cls.image_models:
             async for chunk in cls._generate_image(

--- a/g4f/client/__init__.py
+++ b/g4f/client/__init__.py
@@ -54,7 +54,7 @@ def resolve_media(kwargs: dict, image = None, image_name: str = None) -> None:
         kwargs["media"] = [kwargs["media"]]
     for idx, media in enumerate(kwargs.get("media", [])):
         if not isinstance(media, (list, tuple)):
-            kwargs["media"][idx] = (media, getattr(media, "name", None))
+            kwargs["media"][idx] = (media, os.path.basename(getattr(media, "name", "")))
 
 # Synchronous iter_response function
 def iter_response(


### PR DESCRIPTION
- Changed documentation URL in README.md for detailed guidance link
- In g4f/Provider/Cloudflare.py, broadened exception handling in async argument fetching to catch all exceptions in one place and only specific exceptions in another
- In g4f/Provider/PollinationsAI.py, removed raising of exception for unknown model not in image_models and replaced it with pass
- In g4f/Provider/needs_auth/OpenaiChat.py, modified session post call to always use cls._headers
- Changed if-chain in OpenaiChat.py to use elif for checking element prefix "sediment://"
- Added logic to extract and yield generated images for unique "file-service://" matches in streamed responses within OpenaiChat.py
- Commented out multimodal_text image asset pointer handling in OpenaiChat.py
- In g4f/client/__init__.py resolve_media(), set media name to basename of file path using os.path.basename