### PR TITLE
fix: ignore /message/metadata/refresh_key_info

### DIFF
--- a/g4f/Provider/needs_auth/OpenaiChat.py
+++ b/g4f/Provider/needs_auth/OpenaiChat.py
@@ -541,7 +541,9 @@ class OpenaiChat(AsyncAuthedProvider, ProviderModelMixin):
         if "v" in line:
             v = line.get("v")
             if isinstance(v, str) and fields.recipient == "all":
-                if "p" not in line or line.get("p") == "/message/content/parts/0":
+                if fields.p == "/message/metadata/refresh_key_info":
+                    yield ""
+                elif "p" not in line or line.get("p") == "/message/content/parts/0":
                     yield Reasoning(token=v) if fields.is_thinking else v
             elif isinstance(v, list):
                 for m in v:


### PR DESCRIPTION
OpenaiAccount Completions API adds ids from /message/metadata/refresh_key_info event to the response if image generation is used

![Screenshot 2025-06-06 at 14 57 59](https://github.com/user-attachments/assets/e01faa2f-4b2d-4ed8-8628-704aafd9a0e1)
