### PR TITLE
feat: Refactor extra_body handling and update model error handling

### DIFF
--- a/g4f/Provider/ARTA.py
+++ b/g4f/Provider/ARTA.py
@@ -13,7 +13,7 @@ from ..providers.response import ImageResponse, Reasoning
 from ..errors import ResponseError, ModelNotFoundError
 from ..cookies import get_cookies_dir
 from .base_provider import AsyncGeneratorProvider, ProviderModelMixin
-from .helper import format_image_prompt
+from .helper import format_media_prompt
 from .. import debug
 
 class ARTA(AsyncGeneratorProvider, ProviderModelMixin):
@@ -177,7 +177,7 @@ class ARTA(AsyncGeneratorProvider, ProviderModelMixin):
         **kwargs
     ) -> AsyncResult:
         model = cls.get_model(model)
-        prompt = format_image_prompt(messages, prompt)
+        prompt = format_media_prompt(messages, prompt)
 
         # Generate a random seed if not provided
         if seed is None:

--- a/g4f/Provider/ImageLabs.py
+++ b/g4f/Provider/ImageLabs.py
@@ -36,9 +36,11 @@ class ImageLabs(AsyncGeneratorProvider, ProviderModelMixin):
         aspect_ratio: str = "1:1",
         width: int = None,
         height: int = None,
-        extra_body: dict = {},
+        extra_body: dict = None,
         **kwargs
     ) -> AsyncResult:
+        if extra_body is None:
+            extra_body = {}
         extra_body = use_aspect_ratio({
             "width": width,
             "height": height,

--- a/g4f/Provider/LegacyLMArena.py
+++ b/g4f/Provider/LegacyLMArena.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import random
 import json
 import uuid
-import sys
 import asyncio
 
 
@@ -14,7 +13,7 @@ from ..tools.media import merge_media
 from ..image import to_bytes, is_accepted_format
 from .base_provider import AsyncGeneratorProvider, ProviderModelMixin
 from .helper import get_last_user_message
-from ..errors import ModelNotFoundError
+from ..errors import ModelNotFoundError, ResponseError
 from .. import debug
 
 class LegacyLMArena(AsyncGeneratorProvider, ProviderModelMixin):
@@ -460,6 +459,8 @@ class LegacyLMArena(AsyncGeneratorProvider, ProviderModelMixin):
                                 content = data
                             
                             if content:
+                                if "**NETWORK ERROR DUE TO HIGH TRAFFIC." in content:
+                                    raise ResponseError(data)
                                 # Clean up content
                                 if isinstance(content, str):
                                     if content.endswith("▌"):

--- a/g4f/Provider/PollinationsAI.py
+++ b/g4f/Provider/PollinationsAI.py
@@ -9,7 +9,7 @@ from urllib.parse import quote_plus
 from typing import Optional
 from aiohttp import ClientSession
 
-from .helper import filter_none, format_image_prompt
+from .helper import filter_none, format_media_prompt
 from .base_provider import AsyncGeneratorProvider, ProviderModelMixin
 from ..typing import AsyncResult, Messages, MediaListType
 from ..image import is_data_an_audio
@@ -132,6 +132,7 @@ class PollinationsAI(AsyncGeneratorProvider, ProviderModelMixin):
         ### Image Models ###
         "sdxl-turbo": "turbo",
         "gpt-image": "gptimage",
+        "dall-e-3": "gptimage",
         "flux-pro": "flux",
         "flux-dev": "flux",
         "flux-schnell": "flux"
@@ -292,7 +293,7 @@ class PollinationsAI(AsyncGeneratorProvider, ProviderModelMixin):
         if model in cls.image_models:
             async for chunk in cls._generate_image(
                 model=model,
-                prompt=format_image_prompt(messages, prompt),
+                prompt=format_media_prompt(messages, prompt),
                 proxy=proxy,
                 aspect_ratio=aspect_ratio,
                 width=width,
@@ -524,7 +525,7 @@ class PollinationsAI(AsyncGeneratorProvider, ProviderModelMixin):
                                 debug.error("Error generating title and followups")
                                 debug.error(e)
                 elif response.headers["content-type"].startswith("application/json"):
-                    prompt = format_image_prompt(messages)
+                    prompt = format_media_prompt(messages)
                     result = await response.json()
                     if result.get("model"):
                         yield ProviderInfo(**cls.get_dict(), model=result.get("model"))

--- a/g4f/Provider/PollinationsAI.py
+++ b/g4f/Provider/PollinationsAI.py
@@ -19,7 +19,7 @@ from ..requests.raise_for_status import raise_for_status
 from ..requests.aiohttp import get_connector
 from ..image.copy_images import save_response_media
 from ..image import use_aspect_ratio
-from ..providers.response import FinishReason, Usage, ToolCalls, ImageResponse, Reasoning, TitleGeneration, SuggestedFollowups
+from ..providers.response import FinishReason, Usage, ToolCalls, ImageResponse, Reasoning, TitleGeneration, SuggestedFollowups, ProviderInfo
 from ..tools.media import render_messages
 from ..constants import STATIC_URL
 from .. import debug
@@ -84,7 +84,6 @@ class PollinationsAI(AsyncGeneratorProvider, ProviderModelMixin):
     text_models = [default_model, "evil"]
     image_models = [default_image_model]
     audio_models = {default_audio_model: []}
-    extra_image_models = ["flux-pro", "flux-dev", "flux-schnell", "dall-e-3", "turbo"]
     vision_models = [default_vision_model, "gpt-4o-mini", "openai", "openai-large", "openai-reasoning", "searchgpt"]
     _models_loaded = False
     # https://github.com/pollinations/pollinations/blob/master/text.pollinations.ai/generateTextPortkey.js#L15
@@ -133,6 +132,9 @@ class PollinationsAI(AsyncGeneratorProvider, ProviderModelMixin):
         ### Image Models ###
         "sdxl-turbo": "turbo",
         "gpt-image": "gptimage",
+        "flux-pro": "flux",
+        "flux-dev": "flux",
+        "flux-schnell": "flux"
     }
 
     @classmethod
@@ -164,14 +166,14 @@ class PollinationsAI(AsyncGeneratorProvider, ProviderModelMixin):
                     new_image_models = []
 
                 # Combine image models without duplicates
-                all_image_models = [cls.default_image_model]  # Start with default model
+                image_models = [cls.default_image_model]  # Start with default model
                 
                 # Add extra image models if not already in the list
-                for model in cls.extra_image_models + new_image_models:
-                    if model not in all_image_models:
-                        all_image_models.append(model)
+                for model in new_image_models:
+                    if model not in image_models:
+                        image_models.append(model)
                 
-                cls.image_models = all_image_models
+                cls.image_models = image_models
 
                 text_response = requests.get("https://text.pollinations.ai/models")
                 text_response.raise_for_status()
@@ -194,19 +196,19 @@ class PollinationsAI(AsyncGeneratorProvider, ProviderModelMixin):
                         cls.vision_models.append(alias)
 
                 # Create a set of unique text models starting with default model
-                unique_text_models = cls.text_models.copy()
+                text_models = cls.text_models.copy()
 
                 # Add models from vision_models
-                unique_text_models.extend(cls.vision_models)
+                text_models.extend(cls.vision_models)
 
                 # Add models from the API response
                 for model in models:
                     model_name = model.get("name")
                     if model_name and "input_modalities" in model and "text" in model["input_modalities"]:
-                        unique_text_models.append(model_name)
+                        text_models.append(model_name)
 
                 # Convert to list and update text_models
-                cls.text_models = list(dict.fromkeys(unique_text_models))
+                cls.text_models = list(dict.fromkeys(text_models))
 
                 cls._models_loaded = True
 
@@ -243,10 +245,10 @@ class PollinationsAI(AsyncGeneratorProvider, ProviderModelMixin):
         messages: Messages,
         stream: bool = True,
         proxy: str = None,
-        cache: bool = False,
+        cache: bool = None,
         referrer: str = STATIC_URL,
         api_key: str = None,
-        extra_body: dict = {},
+        extra_body: dict = None,
         # Image generation parameters
         prompt: str = None,
         aspect_ratio: str = "1:1",
@@ -268,6 +270,10 @@ class PollinationsAI(AsyncGeneratorProvider, ProviderModelMixin):
         extra_parameters: list[str] = ["tools", "parallel_tool_calls", "tool_choice", "reasoning_effort", "logit_bias", "voice", "modalities", "audio"],
         **kwargs
     ) -> AsyncResult:
+        if cache is None:
+            cache = kwargs.get("action") == "next"
+        if extra_body is None:
+            extra_body = {}
         # Load model list
         cls.get_models()
         if not model:
@@ -363,8 +369,11 @@ class PollinationsAI(AsyncGeneratorProvider, ProviderModelMixin):
             "safe": str(safe).lower(),
         }, aspect_ratio)
         query = "&".join(f"{k}={quote_plus(str(v))}" for k, v in params.items() if v is not None)
-        prompt = quote_plus(prompt)[:2048-len(cls.image_api_endpoint)-len(query)-8]
-        url = f"{cls.image_api_endpoint}prompt/{prompt}?{query}"
+        encoded_prompt = prompt
+        if model == "gptimage" and aspect_ratio != "1:1":
+            encoded_prompt = f"{encoded_prompt} aspect-ratio: {aspect_ratio}"
+        encoded_prompt = quote_plus(encoded_prompt)[:2048-len(cls.image_api_endpoint)-len(query)-8]
+        url = f"{cls.image_api_endpoint}prompt/{encoded_prompt}?{query}"
         def get_image_url(i: int, seed: Optional[int] = None):
             if i == 0:
                 if not cache and seed is None:
@@ -374,10 +383,10 @@ class PollinationsAI(AsyncGeneratorProvider, ProviderModelMixin):
             return f"{url}&seed={seed}" if seed else url
         headers = {"referer": referrer}
         if api_key:
-            headers["Authorization"] = f"Bearer {api_key}"
+            headers["authorization"] = f"Bearer {api_key}"
         async with ClientSession(headers=DEFAULT_HEADERS, connector=get_connector(proxy=proxy)) as session:
             responses = set()
-            responses.add(Reasoning(status=f"Generating {n} {'image' if n == 1 else 'images'}..."))
+            responses.add(Reasoning(status=f"Generate {n} {'image' if n == 1 else 'images'}..."))
             finished = 0
             start = time.time()
             async def get_image(responses: set, i: int, seed: Optional[int] = None):
@@ -386,8 +395,11 @@ class PollinationsAI(AsyncGeneratorProvider, ProviderModelMixin):
                     try:
                         await raise_for_status(response)
                     except Exception as e:
+                        if response.status == 500:
+                            responses.add(e)
+                            return
                         debug.error(f"Error fetching image: {e}")
-                    responses.add(ImageResponse(str(response.url), prompt))
+                    responses.add(ImageResponse(str(response.url), prompt, {"headers": headers}))
                     finished += 1
                     responses.add(Reasoning(status=f"Image {finished}/{n} generated in {time.time() - start:.2f}s"))
             tasks = []
@@ -395,7 +407,12 @@ class PollinationsAI(AsyncGeneratorProvider, ProviderModelMixin):
                 tasks.append(asyncio.create_task(get_image(responses, i, seed)))
             while finished < n or len(responses) > 0:
                 while len(responses) > 0:
-                    yield responses.pop()
+                    item = responses.pop()
+                    if isinstance(item, Exception):
+                        for task in tasks:
+                            task.cancel()
+                        raise item
+                    yield item
                 await asyncio.sleep(0.1)
             await asyncio.gather(*tasks)
 
@@ -424,14 +441,17 @@ class PollinationsAI(AsyncGeneratorProvider, ProviderModelMixin):
             seed = random.randint(0, 2**32)
 
         async with ClientSession(headers=DEFAULT_HEADERS, connector=get_connector(proxy=proxy)) as session:
-            if model in cls.audio_models:
-                if "audio" in kwargs and kwargs.get("audio", {}).get("voice") is None:
-                    kwargs["audio"]["voice"] = cls.audio_models[model][0]
-                url = cls.text_api_endpoint
-                stream = False
-            else:
-                url = cls.openai_endpoint
             extra_body.update({param: kwargs[param] for param in extra_parameters if param in kwargs})
+            if model in cls.audio_models:
+                if "audio" in extra_body and extra_body.get("audio", {}).get("voice") is None:
+                    kwargs["audio"]["voice"] = cls.audio_models[model][0]
+                elif "audio" not in extra_body:
+                    extra_body["audio"] = {"voice": cls.audio_models[model][0]}
+                if extra_body.get("audio", {}).get("format") is None:
+                    extra_body["audio"]["format"] = "mp3"
+                if "modalities" not in extra_body:
+                    extra_body["modalities"] = ["text", "audio"]
+                stream = False
             data = filter_none(
                 messages=list(render_messages(messages, media)),
                 model=model,
@@ -447,19 +467,23 @@ class PollinationsAI(AsyncGeneratorProvider, ProviderModelMixin):
             )
             headers = {"referer": referrer}
             if api_key:
-                headers["Authorization"] = f"Bearer {api_key}"
-            async with session.post(url, json=data, headers=headers) as response:
-                if response.status == 400:
-                    debug.error(f"Error: 400 - Bad Request: {data}")
+                headers["authorization"] = f"Bearer {api_key}"
+            async with session.post(cls.openai_endpoint, json=data, headers=headers) as response:
+                if response.status in (400, 500):
+                    debug.error(f"Error: {response.status} - Bad Request: {data}")
                 await raise_for_status(response)
                 if response.headers["content-type"].startswith("text/plain"):
                     yield await response.text()
                     return
                 elif response.headers["content-type"].startswith("text/event-stream"):
                     reasoning = False
+                    model_returned = False
                     async for result in see_stream(response.content):
                         if "error" in result:
                             raise ResponseError(result["error"].get("message", result["error"]))
+                        if not model_returned and result.get("model"):
+                            yield ProviderInfo(**cls.get_dict(), model=result.get("model"))
+                            model_returned = True
                         if result.get("usage") is not None:
                             yield Usage(**result["usage"])
                         choices = result.get("choices", [{}])
@@ -478,15 +502,15 @@ class PollinationsAI(AsyncGeneratorProvider, ProviderModelMixin):
                         if finish_reason:
                             yield FinishReason(finish_reason)
                     if reasoning:
-                        yield Reasoning(status="Done")
+                        yield Reasoning(status="")
                     if kwargs.get("action") == "next":
                         data = {
                             "model": "openai",
-                            "messages": messages + FOLLOWUPS_DEVELOPER_MESSAGE,
+                            "messages": [m for m in messages if m.get("role") == "user"] + FOLLOWUPS_DEVELOPER_MESSAGE,
                             "tool_choice": "required",
                             "tools": FOLLOWUPS_TOOLS
                         }
-                        async with session.post(url, json=data, headers=headers) as response:
+                        async with session.post(cls.openai_endpoint, json=data, headers=headers) as response:
                             try:
                                 await raise_for_status(response)
                                 tool_calls = (await response.json()).get("choices", [{}])[0].get("message", {}).get("tool_calls", [])
@@ -500,7 +524,10 @@ class PollinationsAI(AsyncGeneratorProvider, ProviderModelMixin):
                                 debug.error("Error generating title and followups")
                                 debug.error(e)
                 elif response.headers["content-type"].startswith("application/json"):
+                    prompt = format_image_prompt(messages)
                     result = await response.json()
+                    if result.get("model"):
+                        yield ProviderInfo(**cls.get_dict(), model=result.get("model"))
                     if "choices" in result:
                         choice = result["choices"][0]
                         message = choice.get("message", {})
@@ -509,6 +536,13 @@ class PollinationsAI(AsyncGeneratorProvider, ProviderModelMixin):
                             yield content
                         if "tool_calls" in message:
                             yield ToolCalls(message["tool_calls"])
+                        audio = message.get("audio", {})
+                        if "data" in audio:
+                            async for chunk in save_response_media(audio["data"], prompt, [model, extra_body.get("audio", {}).get("voice")]):
+                                yield chunk
+                        if "transcript" in audio:
+                            yield "\n\n"
+                            yield audio["transcript"]
                     else:
                         raise ResponseError(result)
                     if result.get("usage") is not None:
@@ -517,6 +551,5 @@ class PollinationsAI(AsyncGeneratorProvider, ProviderModelMixin):
                     if finish_reason:
                         yield FinishReason(finish_reason)
                 else:
-                    async for chunk in save_response_media(response, format_image_prompt(messages), [model, extra_body.get("audio", {}).get("voice")]):
+                    async for chunk in save_response_media(response, prompt, [model, extra_body.get("audio", {}).get("voice")]):
                         yield chunk
-                        return

--- a/g4f/Provider/PollinationsImage.py
+++ b/g4f/Provider/PollinationsImage.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Optional
 
-from .helper import format_image_prompt
+from .helper import format_media_prompt
 from ..typing import AsyncResult, Messages
 from ..constants import STATIC_URL
 from .PollinationsAI import PollinationsAI
@@ -54,7 +54,7 @@ class PollinationsImage(PollinationsAI):
         cls.get_models()
         async for chunk in cls._generate_image(
             model=model,
-            prompt=format_image_prompt(messages, prompt),
+            prompt=format_media_prompt(messages, prompt),
             proxy=proxy,
             aspect_ratio=aspect_ratio,
             width=width,

--- a/g4f/Provider/PollinationsImage.py
+++ b/g4f/Provider/PollinationsImage.py
@@ -14,23 +14,20 @@ class PollinationsImage(PollinationsAI):
     default_vision_model = None
     default_image_model = default_model
     audio_models = {}
-    image_models = [default_image_model]  # Default models
-    _models_loaded = False  # Add a checkbox for synchronization
 
     @classmethod
     def get_models(cls, **kwargs):
-        if not cls._models_loaded:
-            # Calling the parent method to load models
-            super().get_models()
-            # Combine models from the parent class and additional ones
-            all_image_models = list(dict.fromkeys(
-                cls.image_models +
-                PollinationsAI.image_models +
-                cls.extra_image_models
-            ))
-            cls.image_models = all_image_models
-            cls._models_loaded = True
-        return cls.image_models
+        PollinationsAI.get_models()
+        cls.image_models = PollinationsAI.image_models
+        cls.models = cls.image_models
+        return cls.models
+
+    @classmethod
+    def get_grouped_models(cls) -> dict[str, list[str]]:
+        PollinationsAI.get_models()
+        return [
+            {"group": "Image Generation", "models": PollinationsAI.image_models},
+        ]
 
     @classmethod
     async def create_async_generator(

--- a/g4f/Provider/Websim.py
+++ b/g4f/Provider/Websim.py
@@ -11,7 +11,7 @@ from .base_provider import AsyncGeneratorProvider, ProviderModelMixin
 from ..requests.raise_for_status import raise_for_status
 from ..errors import ResponseStatusError
 from ..providers.response import ImageResponse
-from .helper import format_prompt, format_image_prompt
+from .helper import format_prompt, format_media_prompt
 
 
 class Websim(AsyncGeneratorProvider, ProviderModelMixin):
@@ -110,7 +110,7 @@ class Websim(AsyncGeneratorProvider, ProviderModelMixin):
         proxy: str = None,
         **kwargs
     ) -> AsyncResult:
-        used_prompt = format_image_prompt(messages, prompt)
+        used_prompt = format_media_prompt(messages, prompt)
         
         async with ClientSession(headers=headers) as session:
             data = {

--- a/g4f/Provider/hf_space/BlackForestLabs_Flux1Dev.py
+++ b/g4f/Provider/hf_space/BlackForestLabs_Flux1Dev.py
@@ -9,7 +9,7 @@ from ...requests import StreamSession
 from ...image import use_aspect_ratio
 from ...errors import ResponseError
 from ..base_provider import AsyncGeneratorProvider, ProviderModelMixin
-from ..helper import format_image_prompt
+from ..helper import format_media_prompt
 from .DeepseekAI_JanusPro7b import get_zerogpu_token
 from .raise_for_status import raise_for_status
 
@@ -70,7 +70,7 @@ class BlackForestLabs_Flux1Dev(AsyncGeneratorProvider, ProviderModelMixin):
         **kwargs
     ) -> AsyncResult:
         async with StreamSession(impersonate="chrome", proxy=proxy) as session:
-            prompt = format_image_prompt(messages, prompt)
+            prompt = format_media_prompt(messages, prompt)
             data = use_aspect_ratio({"width": width, "height": height}, aspect_ratio)
             data = [prompt, seed, randomize_seed, data.get("width"), data.get("height"), guidance_scale, num_inference_steps]
             conversation = JsonConversation(zerogpu_token=api_key, zerogpu_uuid=zerogpu_uuid, session_hash=uuid.uuid4().hex)

--- a/g4f/Provider/hf_space/DeepseekAI_JanusPro7b.py
+++ b/g4f/Provider/hf_space/DeepseekAI_JanusPro7b.py
@@ -9,7 +9,7 @@ import urllib.parse
 
 from ...typing import AsyncResult, Messages, Cookies, MediaListType
 from ..base_provider import AsyncGeneratorProvider, ProviderModelMixin
-from ..helper import format_prompt, format_image_prompt
+from ..helper import format_prompt, format_media_prompt
 from ...providers.response import JsonConversation, ImageResponse, Reasoning
 from ...requests.aiohttp import StreamSession, StreamResponse, FormData
 from ...requests.raise_for_status import raise_for_status
@@ -85,7 +85,7 @@ class DeepseekAI_JanusPro7b(AsyncGeneratorProvider, ProviderModelMixin):
         if model == cls.default_image_model or prompt is not None:
             method = "image"
         prompt = format_prompt(messages) if prompt is None and conversation is None else prompt
-        prompt = format_image_prompt(messages, prompt)
+        prompt = format_media_prompt(messages, prompt)
         if seed is None:
             seed = random.randint(1000, 999999)
 

--- a/g4f/Provider/hf_space/G4F.py
+++ b/g4f/Provider/hf_space/G4F.py
@@ -7,7 +7,7 @@ import asyncio
 
 from ...typing import AsyncResult, Messages
 from ...providers.response import ImageResponse, Reasoning, JsonConversation
-from ..helper import format_image_prompt, get_random_string
+from ..helper import format_media_prompt, get_random_string
 from .DeepseekAI_JanusPro7b import DeepseekAI_JanusPro7b, get_zerogpu_token
 from .BlackForestLabs_Flux1Dev import BlackForestLabs_Flux1Dev
 from .raise_for_status import raise_for_status
@@ -80,7 +80,7 @@ class G4F(DeepseekAI_JanusPro7b):
         width = max(32, width - (width % 8))
         height = max(32, height - (height % 8))
         if prompt is None:
-            prompt = format_image_prompt(messages)
+            prompt = format_media_prompt(messages)
         if seed is None:
             seed = random.randint(9999, 2**32 - 1)
 

--- a/g4f/Provider/hf_space/Microsoft_Phi_4_Multimodal.py
+++ b/g4f/Provider/hf_space/Microsoft_Phi_4_Multimodal.py
@@ -5,7 +5,7 @@ import uuid
 
 from ...typing import AsyncResult, Messages, Cookies, MediaListType
 from ..base_provider import AsyncGeneratorProvider, ProviderModelMixin
-from ..helper import format_prompt, format_image_prompt
+from ..helper import format_prompt, format_media_prompt
 from ...providers.response import JsonConversation
 from ...requests.aiohttp import StreamSession, StreamResponse, FormData
 from ...requests.raise_for_status import raise_for_status
@@ -104,7 +104,7 @@ class Microsoft_Phi_4_Multimodal(AsyncGeneratorProvider, ProviderModelMixin):
         **kwargs
     ) -> AsyncResult:
         prompt = format_prompt(messages) if prompt is None and conversation is None else prompt
-        prompt = format_image_prompt(messages, prompt)
+        prompt = format_media_prompt(messages, prompt)
 
         session_hash = uuid.uuid4().hex if conversation is None else getattr(conversation, "session_hash", uuid.uuid4().hex)
         async with StreamSession(proxy=proxy, impersonate="chrome") as session:

--- a/g4f/Provider/hf_space/Qwen_Qwen_3.py
+++ b/g4f/Provider/hf_space/Qwen_Qwen_3.py
@@ -7,7 +7,7 @@ import uuid
 from ...typing import AsyncResult, Messages
 from ...providers.response import Reasoning, JsonConversation
 from ...requests.raise_for_status import raise_for_status
-from ...errors import ModelNotSupportedError
+from ...errors import ModelNotFoundError
 from ..base_provider import AsyncGeneratorProvider, ProviderModelMixin
 from ..helper import get_last_user_message
 from ... import debug
@@ -55,7 +55,7 @@ class Qwen_Qwen_3(AsyncGeneratorProvider, ProviderModelMixin):
     ) -> AsyncResult:
         try:
             model = cls.get_model(model)
-        except ModelNotSupportedError:
+        except ModelNotFoundError:
             pass
         if conversation is None:
             conversation = JsonConversation(session_hash=str(uuid.uuid4()).replace('-', ''))

--- a/g4f/Provider/hf_space/StabilityAI_SD35Large.py
+++ b/g4f/Provider/hf_space/StabilityAI_SD35Large.py
@@ -8,7 +8,7 @@ from ...providers.response import ImageResponse, ImagePreview
 from ...image import use_aspect_ratio
 from ...errors import ResponseError
 from ..base_provider import AsyncGeneratorProvider, ProviderModelMixin
-from ..helper import format_image_prompt
+from ..helper import format_media_prompt
 
 class StabilityAI_SD35Large(AsyncGeneratorProvider, ProviderModelMixin):
     label = "StabilityAI SD-3.5-Large"
@@ -46,7 +46,7 @@ class StabilityAI_SD35Large(AsyncGeneratorProvider, ProviderModelMixin):
         if api_key is not None:
             headers["Authorization"] = f"Bearer {api_key}"
         async with ClientSession(headers=headers) as session:
-            prompt = format_image_prompt(messages, prompt)
+            prompt = format_media_prompt(messages, prompt)
             data = use_aspect_ratio({"width": width, "height": height}, aspect_ratio)
             data = {
                 "data": [prompt, negative_prompt, seed, randomize_seed, data.get("width"), data.get("height"), guidance_scale, num_inference_steps]

--- a/g4f/Provider/needs_auth/BingCreateImages.py
+++ b/g4f/Provider/needs_auth/BingCreateImages.py
@@ -6,7 +6,7 @@ from ...errors import MissingAuthError
 from ...typing import AsyncResult, Messages, Cookies
 from ..base_provider import AsyncGeneratorProvider, ProviderModelMixin
 from .bing.create_images import create_images, create_session
-from ..helper import format_image_prompt
+from ..helper import format_media_prompt
 
 class BingCreateImages(AsyncGeneratorProvider, ProviderModelMixin):
     label = "Microsoft Designer in Bing"
@@ -36,7 +36,7 @@ class BingCreateImages(AsyncGeneratorProvider, ProviderModelMixin):
         **kwargs
     ) -> AsyncResult:
         session = BingCreateImages(cookies, proxy, api_key)
-        yield await session.generate(format_image_prompt(messages, prompt))
+        yield await session.generate(format_media_prompt(messages, prompt))
 
     async def generate(self, prompt: str) -> ImageResponse:
         """

--- a/g4f/Provider/needs_auth/BlackboxPro.py
+++ b/g4f/Provider/needs_auth/BlackboxPro.py
@@ -16,7 +16,7 @@ from ..base_provider import AsyncGeneratorProvider, ProviderModelMixin
 from ..openai.har_file import get_har_files
 from ...image import to_data_uri
 from ...cookies import get_cookies_dir
-from ..helper import format_image_prompt, render_messages
+from ..helper import format_media_prompt, render_messages
 from ...providers.response import JsonConversation, ImageResponse
 from ...tools.media import merge_media
 from ...errors import RateLimitError, NoValidHarFileError
@@ -1343,7 +1343,7 @@ class BlackboxPro(AsyncGeneratorProvider, ProviderModelMixin):
                     image_url_match = re.search(r'!\[.*?\]\((.*?)\)', full_response_text)
                     if image_url_match:
                         image_url = image_url_match.group(1)
-                        yield ImageResponse(urls=[image_url], alt=format_image_prompt(messages, prompt))
+                        yield ImageResponse(urls=[image_url], alt=format_media_prompt(messages, prompt))
                         return
                 
                 # Handle conversation history once, in one place

--- a/g4f/Provider/needs_auth/DeepInfra.py
+++ b/g4f/Provider/needs_auth/DeepInfra.py
@@ -5,7 +5,7 @@ from ...typing import AsyncResult, Messages
 from ...requests import StreamSession, raise_for_status
 from ...providers.response import ImageResponse
 from ..template import OpenaiTemplate
-from ..helper import format_image_prompt
+from ..helper import format_media_prompt
 
 class DeepInfra(OpenaiTemplate):
     url = "https://deepinfra.com"
@@ -56,7 +56,7 @@ class DeepInfra(OpenaiTemplate):
     ) -> AsyncResult:
         if model in cls.get_image_models():
             yield cls.create_async_image(
-                format_image_prompt(messages, prompt),
+                format_media_prompt(messages, prompt),
                 model,
                 **kwargs
             )

--- a/g4f/Provider/needs_auth/Gemini.py
+++ b/g4f/Provider/needs_auth/Gemini.py
@@ -30,7 +30,7 @@ from ...image import to_bytes
 from ...cookies import get_cookies_dir
 from ...tools.media import merge_media
 from ..base_provider import AsyncGeneratorProvider, ProviderModelMixin
-from ..helper import format_prompt, get_cookies, get_last_user_message, format_image_prompt
+from ..helper import format_prompt, get_cookies, get_last_user_message, format_media_prompt
 from ... import debug
 
 REQUEST_HEADERS = {
@@ -187,7 +187,7 @@ class Gemini(AsyncGeneratorProvider, ProviderModelMixin):
         if model in cls.model_aliases:
             model = cls.model_aliases[model]
         if audio is not None or model == "gemini-audio":
-            prompt = format_image_prompt(messages, prompt)
+            prompt = format_media_prompt(messages, prompt)
             filename = get_filename(["gemini"], prompt, ".ogx", prompt)
             ensure_media_dir()
             path = os.path.join(get_media_dir(), filename)

--- a/g4f/Provider/needs_auth/MicrosoftDesigner.py
+++ b/g4f/Provider/needs_auth/MicrosoftDesigner.py
@@ -14,7 +14,7 @@ from ...requests.aiohttp import get_connector
 from ...requests import get_nodriver
 from ..Copilot import get_headers, get_har_files
 from ..base_provider import AsyncGeneratorProvider, ProviderModelMixin
-from ..helper import get_random_hex, format_image_prompt
+from ..helper import get_random_hex, format_media_prompt
 from ... import debug
 
 class MicrosoftDesigner(AsyncGeneratorProvider, ProviderModelMixin):
@@ -39,7 +39,7 @@ class MicrosoftDesigner(AsyncGeneratorProvider, ProviderModelMixin):
         image_size = "1024x1024"
         if model != cls.default_image_model and model in cls.image_models:
             image_size = model
-        yield await cls.generate(format_image_prompt(messages, prompt), image_size, proxy)
+        yield await cls.generate(format_media_prompt(messages, prompt), image_size, proxy)
 
     @classmethod
     async def generate(cls, prompt: str, image_size: str, proxy: str = None) -> ImageResponse:

--- a/g4f/Provider/needs_auth/OpenaiChat.py
+++ b/g4f/Provider/needs_auth/OpenaiChat.py
@@ -23,7 +23,7 @@ from ...requests.raise_for_status import raise_for_status
 from ...requests import StreamSession
 from ...requests import get_nodriver
 from ...image import ImageRequest, to_image, to_bytes, is_accepted_format
-from ...errors import MissingAuthError, NoValidHarFileError, ModelNotSupportedError
+from ...errors import MissingAuthError, NoValidHarFileError, ModelNotFoundError
 from ...providers.response import JsonConversation, FinishReason, SynthesizeData, AuthResult, ImageResponse, ImagePreview
 from ...providers.response import Sources, TitleGeneration, RequestLogin, Reasoning
 from ...tools.media import merge_media
@@ -358,7 +358,7 @@ class OpenaiChat(AsyncAuthedProvider, ProviderModelMixin):
                     debug.error(e)
             try:
                 model = cls.get_model(model)
-            except ModelNotSupportedError:
+            except ModelNotFoundError:
                 pass
             if conversation is None:
                 conversation = Conversation(None, str(uuid.uuid4()), getattr(auth_result, "cookies", {}).get("oai-did"))

--- a/g4f/Provider/needs_auth/OpenaiChat.py
+++ b/g4f/Provider/needs_auth/OpenaiChat.py
@@ -27,7 +27,7 @@ from ...errors import MissingAuthError, NoValidHarFileError, ModelNotFoundError
 from ...providers.response import JsonConversation, FinishReason, SynthesizeData, AuthResult, ImageResponse, ImagePreview
 from ...providers.response import Sources, TitleGeneration, RequestLogin, Reasoning
 from ...tools.media import merge_media
-from ..helper import format_cookies, format_image_prompt, to_string
+from ..helper import format_cookies, format_media_prompt, to_string
 from ..openai.models import default_model, default_image_model, models, image_models, text_models
 from ..openai.har_file import get_request_config
 from ..openai.har_file import RequestConfig, arkReq, arkose_url, start_url, conversation_url, backend_url, backend_anon_url
@@ -426,7 +426,7 @@ class OpenaiChat(AsyncAuthedProvider, ProviderModelMixin):
                 if conversation.conversation_id is not None:
                     data["conversation_id"] = conversation.conversation_id
                     debug.log(f"OpenaiChat: Use conversation: {conversation.conversation_id}")
-                prompt = conversation.prompt = format_image_prompt(messages, prompt)
+                prompt = conversation.prompt = format_media_prompt(messages, prompt)
                 if action != "continue":
                     data["parent_message_id"] = getattr(conversation, "parent_message_id", conversation.message_id)
                     conversation.parent_message_id = None

--- a/g4f/Provider/needs_auth/hf/HuggingChat.py
+++ b/g4f/Provider/needs_auth/hf/HuggingChat.py
@@ -16,7 +16,7 @@ except ImportError:
     has_curl_cffi = False
 
 from ...base_provider import ProviderModelMixin, AsyncAuthedProvider, AuthResult
-from ...helper import format_prompt, format_image_prompt, get_last_user_message
+from ...helper import format_prompt, format_media_prompt, get_last_user_message
 from ....typing import AsyncResult, Messages, Cookies, MediaListType
 from ....errors import MissingRequirementsError, MissingAuthError, ResponseError
 from ....image import to_bytes
@@ -184,7 +184,7 @@ class HuggingChat(AsyncAuthedProvider, ProviderModelMixin):
                 break
             elif line["type"] == "file":
                 url = f"{cls.url}/conversation/{conversationId}/output/{line['sha']}"
-                yield ImageResponse(url, format_image_prompt(messages, prompt), options={"cookies": auth_result.cookies})
+                yield ImageResponse(url, format_media_prompt(messages, prompt), options={"cookies": auth_result.cookies})
             elif line["type"] == "webSearch" and "sources" in line:
                 sources = Sources(line["sources"])
             elif line["type"] == "title":

--- a/g4f/Provider/needs_auth/hf/HuggingFaceInference.py
+++ b/g4f/Provider/needs_auth/hf/HuggingFaceInference.py
@@ -7,7 +7,7 @@ import requests
 
 from ....typing import AsyncResult, Messages
 from ...base_provider import AsyncGeneratorProvider, ProviderModelMixin, format_prompt
-from ....errors import ModelNotSupportedError, ResponseError
+from ....errors import ModelNotFoundError, ResponseError
 from ....requests import StreamSession, raise_for_status
 from ....providers.response import FinishReason, ImageResponse
 from ....image.copy_images import save_response_media
@@ -58,7 +58,7 @@ class HuggingFaceInference(AsyncGeneratorProvider, ProviderModelMixin):
             return cls.model_data[model]
         async with session.get(f"https://huggingface.co/api/models/{model}") as response:
             if response.status == 404:
-                raise ModelNotSupportedError(f"Model is not supported: {model} in: {cls.__name__}")
+                raise ModelNotFoundError(f"Model not found: {model} in: {cls.__name__}")
             await raise_for_status(response)
             cls.model_data[model] = await response.json()
         return cls.model_data[model]
@@ -77,7 +77,7 @@ class HuggingFaceInference(AsyncGeneratorProvider, ProviderModelMixin):
         temperature: float = None,
         prompt: str = None,
         action: str = None,
-        extra_body: dict = {},
+        extra_body: dict = None,
         seed: int = None,
         aspect_ratio: str = None,
         width: int = None,
@@ -86,7 +86,7 @@ class HuggingFaceInference(AsyncGeneratorProvider, ProviderModelMixin):
     ) -> AsyncResult:
         try:
             model = cls.get_model(model)
-        except ModelNotSupportedError:
+        except ModelNotFoundError:
             pass
         headers = {
             'Accept-Encoding': 'gzip, deflate',
@@ -94,6 +94,8 @@ class HuggingFaceInference(AsyncGeneratorProvider, ProviderModelMixin):
         }
         if api_key is not None:
             headers["Authorization"] = f"Bearer {api_key}"
+        if extra_body is None:
+            extra_body = {}
         image_extra_body = use_aspect_ratio({
             "width": width,
             "height": height,
@@ -114,12 +116,12 @@ class HuggingFaceInference(AsyncGeneratorProvider, ProviderModelMixin):
                     }
                     async with session.post(provider_together_urls[model], json=data) as response:
                         if response.status == 404:
-                            raise ModelNotSupportedError(f"Model is not supported: {model}")
+                            raise ModelNotFoundError(f"Model not found: {model}")
                         await raise_for_status(response)
                         result = await response.json()
                         yield ImageResponse([item["url"] for item in result["data"]], data["prompt"])
                     return
-            except ModelNotSupportedError:
+            except ModelNotFoundError:
                 pass
             payload = None
             params = {
@@ -156,11 +158,11 @@ class HuggingFaceInference(AsyncGeneratorProvider, ProviderModelMixin):
                         params["seed"] = seed
                     payload = {"inputs": inputs, "parameters": params, "stream": stream}
                 else:
-                    raise ModelNotSupportedError(f"Model is not supported: {model} in: {cls.__name__} pipeline_tag: {pipeline_tag}")
+                    raise ModelNotFoundError(f"Model is not supported: {model} in: {cls.__name__} pipeline_tag: {pipeline_tag}")
 
             async with session.post(f"{api_base.rstrip('/')}/models/{model}", json=payload) as response:
                 if response.status == 404:
-                    raise ModelNotSupportedError(f"Model is not supported: {model}")
+                    raise ModelNotFoundError(f"Model not found: {model}")
                 await raise_for_status(response)
                 if stream:
                     first = True

--- a/g4f/Provider/needs_auth/hf/HuggingFaceInference.py
+++ b/g4f/Provider/needs_auth/hf/HuggingFaceInference.py
@@ -12,7 +12,7 @@ from ....requests import StreamSession, raise_for_status
 from ....providers.response import FinishReason, ImageResponse
 from ....image.copy_images import save_response_media
 from ....image import use_aspect_ratio
-from ...helper import format_image_prompt, get_last_user_message
+from ...helper import format_media_prompt, get_last_user_message
 from .models import default_model, default_image_model, model_aliases, text_models, image_models, vision_models
 from .... import debug
 
@@ -110,7 +110,7 @@ class HuggingFaceInference(AsyncGeneratorProvider, ProviderModelMixin):
                 if model in provider_together_urls:
                     data = {
                         "response_format": "url",
-                        "prompt": format_image_prompt(messages, prompt),
+                        "prompt": format_media_prompt(messages, prompt),
                         "model": model,
                         **image_extra_body
                     }
@@ -136,7 +136,7 @@ class HuggingFaceInference(AsyncGeneratorProvider, ProviderModelMixin):
                 pipeline_tag = model_data.get("pipeline_tag")
                 if pipeline_tag == "text-to-image":
                     stream = False
-                    inputs = format_image_prompt(messages, prompt)
+                    inputs = format_media_prompt(messages, prompt)
                     payload = {"inputs": inputs, "parameters": {"seed": random.randint(0, 2**32) if seed is None else seed, **image_extra_body}}
                 elif pipeline_tag in ("text-generation", "image-text-to-text"):
                     model_type = None

--- a/g4f/Provider/needs_auth/hf/HuggingFaceMedia.py
+++ b/g4f/Provider/needs_auth/hf/HuggingFaceMedia.py
@@ -8,7 +8,7 @@ import requests
 from ....providers.types import Messages
 from ....requests import StreamSession, raise_for_status
 from ....errors import ModelNotFoundError
-from ....providers.helper import format_image_prompt
+from ....providers.helper import format_media_prompt
 from ....providers.base_provider import AsyncGeneratorProvider, ProviderModelMixin
 from ....providers.response import ProviderInfo, ImageResponse, VideoResponse, Reasoning
 from ....image.copy_images import save_response_media
@@ -119,7 +119,7 @@ class HuggingFaceMedia(AsyncGeneratorProvider, ProviderModelMixin):
             model, selected_provider = model.split(":", 1)
         elif not model:
             model = cls.get_models()[0]
-        prompt = format_image_prompt(messages, prompt)
+        prompt = format_media_prompt(messages, prompt)
         provider_mapping = await cls.get_mapping(model, api_key)
         headers = {
             'Accept-Encoding': 'gzip, deflate',

--- a/g4f/Provider/needs_auth/hf/__init__.py
+++ b/g4f/Provider/needs_auth/hf/__init__.py
@@ -4,7 +4,7 @@ import random
 
 from ....typing import AsyncResult, Messages
 from ....providers.response import ImageResponse
-from ....errors import ModelNotSupportedError, MissingAuthError
+from ....errors import ModelNotFoundError, MissingAuthError
 from ...base_provider import AsyncGeneratorProvider, ProviderModelMixin
 from .HuggingChat import HuggingChat
 from .HuggingFaceAPI import HuggingFaceAPI
@@ -58,7 +58,7 @@ class HuggingFace(AsyncGeneratorProvider, ProviderModelMixin):
             async for chunk in HuggingFaceMedia.create_async_generator(model, messages, **kwargs):
                 yield chunk
             return
-        except ModelNotSupportedError:
+        except ModelNotFoundError:
             pass
         if model in cls.image_models:
             if "api_key" not in kwargs:
@@ -71,6 +71,6 @@ class HuggingFace(AsyncGeneratorProvider, ProviderModelMixin):
         try:
             async for chunk in HuggingFaceAPI.create_async_generator(model, messages, **kwargs):
                 yield chunk
-        except (ModelNotSupportedError, MissingAuthError):
+        except (ModelNotFoundError, MissingAuthError):
             async for chunk in HuggingFaceInference.create_async_generator(model, messages, **kwargs):
                 yield chunk

--- a/g4f/Provider/not_working/AllenAI.py
+++ b/g4f/Provider/not_working/AllenAI.py
@@ -7,7 +7,7 @@ from ...image import to_bytes, is_accepted_format, to_data_uri
 from ..base_provider import AsyncGeneratorProvider, ProviderModelMixin
 from ...requests.raise_for_status import raise_for_status
 from ...providers.response import FinishReason, JsonConversation
-from ..helper import format_prompt, get_last_user_message, format_image_prompt
+from ..helper import format_prompt, get_last_user_message, format_media_prompt
 from ...tools.media import merge_media
 
 

--- a/g4f/Provider/template/OpenaiTemplate.py
+++ b/g4f/Provider/template/OpenaiTemplate.py
@@ -66,7 +66,7 @@ class OpenaiTemplate(AsyncGeneratorProvider, ProviderModelMixin, RaiseErrorMixin
         headers: dict = None,
         impersonate: str = None,
         extra_parameters: list[str] = ["tools", "parallel_tool_calls", "tool_choice", "reasoning_effort", "logit_bias", "modalities", "audio"],
-        extra_body: dict = {},
+        extra_body: dict = None,
         **kwargs
     ) -> AsyncResult:
         if api_key is None and cls.api_key is not None:
@@ -98,6 +98,8 @@ class OpenaiTemplate(AsyncGeneratorProvider, ProviderModelMixin, RaiseErrorMixin
                 return
 
             extra_parameters = {key: kwargs[key] for key in extra_parameters if key in kwargs}
+            if extra_body is None:
+                extra_body = {}
             data = filter_none(
                 messages=list(render_messages(messages, media)),
                 model=model,

--- a/g4f/Provider/template/OpenaiTemplate.py
+++ b/g4f/Provider/template/OpenaiTemplate.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import requests
 
-from ..helper import filter_none, format_image_prompt
+from ..helper import filter_none, format_media_prompt
 from ..base_provider import AsyncGeneratorProvider, ProviderModelMixin, RaiseErrorMixin
 from ...typing import Union, AsyncResult, Messages, MediaListType
 from ...requests import StreamSession, raise_for_status
@@ -85,7 +85,7 @@ class OpenaiTemplate(AsyncGeneratorProvider, ProviderModelMixin, RaiseErrorMixin
 
             # Proxy for image generation feature
             if model and model in cls.image_models:
-                prompt = format_image_prompt(messages, prompt)
+                prompt = format_media_prompt(messages, prompt)
                 data = {
                     "prompt": prompt,
                     "model": model,

--- a/g4f/constants.py
+++ b/g4f/constants.py
@@ -1,5 +1,6 @@
 PACKAGE_NAME = "g4f"
-GITHUB_REPOSITORY = "xtekky/gpt4free"
-STATIC_DOMAIN = "gpt4free.github.io"
+ORGANIZATION = "gpt4free"
+GITHUB_REPOSITORY = f"xtekky/{ORGANIZATION}"
+STATIC_DOMAIN = f"{ORGANIZATION}.github.io"
 STATIC_URL = f"https://{STATIC_DOMAIN}/"
 DIST_DIR = f"./{STATIC_DOMAIN}/dist"

--- a/g4f/errors.py
+++ b/g4f/errors.py
@@ -22,9 +22,6 @@ class RetryNoProviderError(Exception):
 class VersionNotFoundError(Exception):
     ...
 
-class ModelNotSupportedError(Exception):
-    ...
-
 class MissingRequirementsError(Exception):
     ...
 

--- a/g4f/gui/server/api.py
+++ b/g4f/gui/server/api.py
@@ -257,7 +257,7 @@ class Api:
         }
 
     def handle_provider(self, provider_handler, model):
-        if model:
+        if not getattr(provider_handler, "model", False):
             return self._format_json("provider", {**provider_handler.get_dict(), "model": model})
         return self._format_json("provider", provider_handler.get_dict())
 

--- a/g4f/gui/server/api.py
+++ b/g4f/gui/server/api.py
@@ -13,7 +13,7 @@ from ...tools.run_tools import iter_run_tools
 from ... import Provider
 from ...providers.base_provider import ProviderModelMixin
 from ...providers.retry_provider import BaseRetryProvider
-from ...providers.helper import format_image_prompt
+from ...providers.helper import format_media_prompt
 from ...providers.response import *
 from ... import version, models
 from ... import ChatCompletion, get_model_and_provider
@@ -194,7 +194,7 @@ class Api:
                 elif isinstance(chunk, MediaResponse):
                     media = chunk
                     if download_media or chunk.get("cookies"):
-                        chunk.alt = format_image_prompt(kwargs.get("messages"), chunk.alt)
+                        chunk.alt = format_media_prompt(kwargs.get("messages"), chunk.alt)
                         tags = [model, kwargs.get("aspect_ratio"), kwargs.get("resolution"), kwargs.get("width"), kwargs.get("height")]
                         media = asyncio.run(copy_media(chunk.get_list(), chunk.get("cookies"), chunk.get("headers"), proxy=proxy, alt=chunk.alt, tags=tags))
                         media = ImageResponse(media, chunk.alt) if isinstance(chunk, ImageResponse) else VideoResponse(media, chunk.alt)

--- a/g4f/image/__init__.py
+++ b/g4f/image/__init__.py
@@ -25,7 +25,7 @@ EXTENSIONS_MAP: dict[str, str] = {
     "gif": "image/gif",
     "webp": "image/webp",
     # Audio
-    "wav": "audio/x-wav",
+    "wav": "audio/wav",
     "mp3": "audio/mpeg",
     "flac": "audio/flac",
     "opus": "audio/opus",

--- a/g4f/providers/base_provider.py
+++ b/g4f/providers/base_provider.py
@@ -20,7 +20,7 @@ from .asyncio import get_running_loop, to_sync_generator, to_async_iterator
 from .response import BaseConversation, AuthResult
 from .helper import concat_chunks
 from ..cookies import get_cookies_dir
-from ..errors import ModelNotSupportedError, ResponseError, MissingAuthError, NoValidHarFileError, PaymentRequiredError
+from ..errors import ModelNotFoundError, ResponseError, MissingAuthError, NoValidHarFileError, PaymentRequiredError
 from .. import debug
 
 SAFE_PARAMETERS = [
@@ -363,7 +363,7 @@ class ProviderModelMixin:
             model = cls.model_aliases[model]
         else:
             if model not in cls.get_models(**kwargs) and cls.models:
-                raise ModelNotSupportedError(f"Model is not supported: {model} in: {cls.__name__} Valid models: {cls.models}")
+                raise ModelNotFoundError(f"Model is not supported: {model} in: {cls.__name__} Valid models: {cls.models}")
         cls.last_model = model
         debug.last_model = model
         return model

--- a/g4f/providers/helper.py
+++ b/g4f/providers/helper.py
@@ -88,7 +88,7 @@ def get_last_message(messages: Messages, prompt: str = None) -> str:
                 prompt = content
     return prompt
 
-def format_image_prompt(messages, prompt: str = None) -> str:
+def format_media_prompt(messages, prompt: str = None) -> str:
     if prompt is None:
         return get_last_user_message(messages)
     return prompt

--- a/g4f/requests/raise_for_status.py
+++ b/g4f/requests/raise_for_status.py
@@ -28,9 +28,12 @@ async def raise_for_status_async(response: Union[StreamResponse, ClientResponse]
         content_type = response.headers.get("content-type", "")
         if content_type.startswith("application/json"):
             message = await response.json()
-            message = message.get("error", message)
-            if isinstance(message, dict):
-                message = message.get("message", message)
+            error = message.get("error")
+            if isinstance(error, dict):
+                message = error.get("message")
+            message = message.get("message", message)
+            if isinstance(error, str):
+                message = f"{error}: {message}"
         else:
             message = (await response.text()).strip()
             is_html = content_type.startswith("text/html") or message.startswith("<!DOCTYPE")

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,13 @@
-import codecs
 import os
 
 from setuptools import find_packages, setup
 
-STATIC_HOST = "gpt4free.github.io"
+current_dir = os.path.abspath(os.path.dirname(__file__))
 
-here = os.path.abspath(os.path.dirname(__file__))
-
-with codecs.open(os.path.join(here, 'README.md'), encoding='utf-8') as fh:
-    long_description = '\n' + fh.read()
+with open(os.path.join(current_dir, 'README.md')) as f:
+    long_description = f.read()
 
 long_description = long_description.replace("[!NOTE]", "")
-long_description = long_description.replace("(docs/images/", f"(https://{STATIC_HOST}/docs/images/")
-long_description = long_description.replace("(docs/", f"(https://github.com/gpt4free/{STATIC_HOST}/blob/main/docs/")
 
 INSTALL_REQUIRE = [
     "requests",
@@ -41,9 +36,6 @@ EXTRA_REQUIRE = {
         "pywebview",
         "plyer",
         "setuptools",
-        "odfpy", # files
-        "ebooklib",
-        "openpyxl",
         "markitdown[all]"
     ],
     'slim': [
@@ -58,7 +50,7 @@ EXTRA_REQUIRE = {
         "fastapi",                 # api
         "uvicorn",                 # api
         "python-multipart",
-        "markitdown[pdf, docx, pptx]"
+        "markitdown[all]"
     ],
     "image": [
         "pillow",
@@ -91,9 +83,6 @@ EXTRA_REQUIRE = {
     ],
     "files": [
         "beautifulsoup4",
-        "odfpy",
-        "ebooklib",
-        "openpyxl",
         "markitdown[all]"
     ]
 }


### PR DESCRIPTION
- Changed the default value of `extra_body` from an empty dictionary to `None` in `ImageLabs` and `PollinationsAI` classes.
- Added a check to initialize `extra_body` to an empty dictionary if it is `None` in the `ImageLabs` class.
- Removed the `extra_image_models` list from the `PollinationsAI` class.
- Updated the way image models are combined in the `PollinationsAI` class to avoid duplicates.
- Changed the error handling for unsupported models from `ModelNotSupportedError` to `ModelNotFoundError` in multiple classes including `OpenaiChat`, `HuggingFaceAPI`, and `HuggingFaceInference`.
- Updated the `save_response_media` function to handle both string and bytes responses.
- Adjusted the handling of audio data in the `PollinationsAI` class to ensure proper processing of audio responses.