### PR TITLE
keep api_key for next provider when use retry_provider

### DIFF
--- a/g4f/providers/retry_provider.py
+++ b/g4f/providers/retry_provider.py
@@ -113,12 +113,13 @@ class IterListProvider(BaseRetryProvider):
             debug.log(f"Using {provider.__name__} provider with model {alias}")
             yield ProviderInfo(**provider.get_dict(), model=alias)
             extra_body = kwargs.copy()
+            current_provider_api_key = None
             if isinstance(api_key, dict):
-                api_key = api_key.get(provider.get_parent())
+                current_provider_api_key = api_key.get(provider.get_parent())
             if not api_key:
-                api_key = AuthManager.load_api_key(provider)
-            if api_key:
-                extra_body["api_key"] = api_key
+                current_provider_api_key = AuthManager.load_api_key(provider)
+            if current_provider_api_key:
+                extra_body["api_key"] = current_provider_api_key
             if conversation is not None and hasattr(conversation, provider.__name__):
                 extra_body["conversation"] = JsonConversation(**getattr(conversation, provider.__name__))
             try:


### PR DESCRIPTION
When using a model like `gemini-2.5-flash` and the provider `Gemini GeminiPro LegacyLMArena HarProvider`, the server will use `retry_provider`. Although the API key was sent in the format:

```
{'GeminiPro': 'AIzaSyBRjxgxSMBHVTwwMev4hs5QeDtgczzyb6s'}
```

when the `Gemini` provider failed, `GeminiPro` reported that it did not receive the API key.