### PR TITLE
feat(provider/GLM): Enable reasoning/thinking stream

### DIFF
--- a/g4f/Provider/GLM.py
+++ b/g4f/Provider/GLM.py
@@ -45,6 +45,9 @@ class GLM(AsyncGeneratorProvider, ProviderModelMixin):
             "messages": messages,
             "params": {},
             "tool_servers": [],
+            "features": {
+                "enable_thinking": True
+            }
         }
         async with StreamSession(
             impersonate="chrome",


### PR DESCRIPTION
## Description

This PR enables the "thinking" (reasoning) stream for the GLM provider (`chat.z.ai`). 

The provider's code was already set up to handle `thinking` events, but the API requires the `"enable_thinking": True` flag to be explicitly sent in the request payload to start sending these events. This flag was previously missing, causing the feature to not work.

### Changes Made

- Modified the `data` payload in the `create_async_generator` method within the `GLM` provider class.
- Added the `"features": {"enable_thinking": True}` dictionary to the JSON request body.

### Why is this change necessary?

Without this change, the GLM provider could not stream the model's reasoning process, negatively impacting the user experience as it would appear the model was idle. This fix activates the intended functionality and aligns the provider with its full capabilities.

### How to Test

1. Run a query using the GLM provider (e.g., `GLM-4.5`).
2. Observe the streamed output.
3. You should now see the `Reasoning` output being streamed before the final message content is delivered.