### PR TITLE
feat(qwen): add support for qwen3-max-preview model

### DIFF
--- a/g4f/Provider/Qwen.py
+++ b/g4f/Provider/Qwen.py
@@ -28,6 +28,7 @@ class Qwen(AsyncGeneratorProvider, ProviderModelMixin):
 
     # Complete list of models, extracted from the API
     models = [
+        "qwen3-max-preview",
         "qwen3-235b-a22b",
         "qwen3-coder-plus",
         "qwen3-30b-a3b",
@@ -206,3 +207,4 @@ class Qwen(AsyncGeneratorProvider, ProviderModelMixin):
                         raise e
 
             raise RateLimitError("The Qwen provider reached the request limit after 5 attempts.")
+


### PR DESCRIPTION
This adds the 'qwen3-max-preview' model to the list of supported models for the chat.qwen.ai provider.

Partially addresses #3172.