### PR TITLE
Fix conditional check for API key prefix

### DIFF
--- a/g4f/Provider/PollinationsAI.py
+++ b/g4f/Provider/PollinationsAI.py
@@ -378,7 +378,7 @@ class PollinationsAI(AsyncGeneratorProvider, ProviderModelMixin):
             return f"{url}&seed={seed}" if seed else url
 
         headers = None
-        if api_key and api_key.startswith("g4f_") or api_key.startswith("gfs_"):
+        if api_key and (api_key.startswith("g4f_") or api_key.startswith("gfs_")):
             headers = {"authorization": f"Bearer {api_key}"}
         async with ClientSession(
             headers=DEFAULT_HEADERS,


### PR DESCRIPTION
```
from g4f.client import Client
from g4f.Provider import PollinationsImage

client = Client()
response = client.images.generate(
    provider=PollinationsImage(),
    model="flux",
    prompt="a white siamese cat",
    response_format="url"
)
print(f"Generated image URL: {response.data[0].url}")
```

it errors with
```
if api_key and api_key.startswith("g4f_") or api_key.startswith("gfs_"):
                                          ^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'startswith'
```

after adding parentheses it works