### PR TITLE
fix: include conversation_id in prepare request for conversation continuity

### DIFF
--- a/g4f/Provider/needs_auth/OpenaiChat.py
+++ b/g4f/Provider/needs_auth/OpenaiChat.py
@@ -464,6 +464,8 @@ class OpenaiChat(AsyncAuthedProvider, ProviderModelMixin):
                     }
                     if temporary:
                         data["history_and_training_disabled"] = True
+                    if conversation.conversation_id is not None and not temporary:
+                        data["conversation_id"] = conversation.conversation_id
                     async with session.post(
                             prepare_url,
                             json=data,


### PR DESCRIPTION
## Summary

- The prepare request to `/backend-api/f/conversation/prepare` was missing `conversation_id` from its payload, causing ChatGPT to always allocate a new conversation even when continuing an existing one.
- The main conversation request (to `backend_url`) correctly includes `conversation_id`, but by then a new conduit has already been created by the prepare step.
- This adds `conversation_id` to the prepare payload when available, matching the main request behavior.

## Reproduction

1. Create a conversation using `AsyncClient(provider=OpenaiChat)`
2. Save `response.conversation` and pass it to a subsequent request
3. **Before fix:** ChatGPT creates a new conversation each time (visible in ChatGPT UI sidebar as separate chats, model has no context of prior messages)
4. **After fix:** Same `conversation_id` is reused, model recalls prior context

## Test

```python
async def test():
    client = AsyncClient(provider=OpenaiChat)
    r1 = await client.chat.completions.create(
        model='gpt-4o',
        messages=[{'role': 'user', 'content': 'The secret code is PINEAPPLE99. Remember it.'}],
    )
    r2 = await client.chat.completions.create(
        model='gpt-4o',
        messages=[{'role': 'user', 'content': 'What is the secret code I told you?'}],
        conversation=r1.conversation,
    )
    print(r2.choices[0].message.content)
    # Before fix: "I don't know your secret code"
    # After fix: "The secret code is PINEAPPLE99"
```

## Related issues

Fixes #2897, #3102