### PR TITLE
Fix: publish main Docker image as multi-arch (amd64 + arm64)

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -290,7 +290,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}


### PR DESCRIPTION
The main Docker image (hlohaus789/g4f:latest) is currently published as amd64-only due to the CI configuration.

Although the Dockerfile and base image already support arm64, the build workflow explicitly restricts the platform to linux/amd64.

This PR enables multi-arch builds (amd64 + arm64) for the main image, fixing Docker pulls on Apple Silicon and ARM machines.