### PR TITLE
fix: replace 34 bare except clauses with except Exception

### DIFF
--- a/etc/testing/test_all.py
+++ b/etc/testing/test_all.py
@@ -18,7 +18,7 @@ async def test(model: g4f.Model):
                 print(response, end="")
 
             print()
-        except:
+        except Exception:
             for response in await g4f.ChatCompletion.create_async(
                     model=model,
                     messages=[{"role": "user", "content": "write a poem about a tree"}],

--- a/etc/tool/commit.py
+++ b/etc/tool/commit.py
@@ -201,7 +201,7 @@ def get_repository_info(repo_path: Path) -> dict:
         )
         if branch_process.returncode == 0:
             info["branch"] = branch_process.stdout.strip()
-    except:
+    except Exception:
         pass
     
     try:
@@ -214,7 +214,7 @@ def get_repository_info(repo_path: Path) -> dict:
         )
         if remote_process.returncode == 0:
             info["remote"] = remote_process.stdout.strip()
-    except:
+    except Exception:
         pass
     
     return info
@@ -287,7 +287,7 @@ def show_spinner(duration: int = None):
             time.sleep(duration)
             stop_spinner.set()
         return stop_spinner
-    except:
+    except Exception:
         stop_spinner.set()
         raise
 
@@ -383,7 +383,7 @@ def edit_commit_message(message: str) -> str:
             ["git", "config", "--get", "core.editor"],
             capture_output=True, text=True
         ).stdout.strip()
-    except:
+    except Exception:
         editor = os.environ.get('EDITOR', 'vim')
     
     if not editor:

--- a/etc/tool/readme_table.py
+++ b/etc/tool/readme_table.py
@@ -99,7 +99,7 @@ def print_providers():
                         lines.append(f"| **Image Models (Image Generation)** | {', '.join(image_models)} |")
                     if hasattr(_provider, "vision_models"):
                         lines.append(f"| **Vision (Image Upload)** | ✔️ |")
-                except:
+                except Exception:
                     pass
 
             lines.append(f"| **Authentication** | {auth} | \n| **Streaming** | {stream} |")

--- a/etc/unittest/asyncio.py
+++ b/etc/unittest/asyncio.py
@@ -2,7 +2,7 @@ import asyncio
 try:
     import nest_asyncio2 as nest_asyncio
     has_nest_asyncio = True
-except:
+except Exception:
     has_nest_asyncio = False 
 import unittest
 

--- a/etc/unittest/backend.py
+++ b/etc/unittest/backend.py
@@ -7,12 +7,12 @@ from g4f.errors import MissingRequirementsError
 try:
     from g4f.gui.server.backend_api import Backend_Api
     has_requirements = True
-except:
+except Exception:
     has_requirements = False
 try:
     from g4f.tools.web_search import search
     has_search = True
-except:
+except Exception:
     has_search = False
 try:
     from ddgs.exceptions import DDGSException

--- a/g4f/Provider/Copilot.py
+++ b/g4f/Provider/Copilot.py
@@ -286,7 +286,7 @@ class Copilot(AsyncAuthedProvider, ProviderModelMixin):
                 try:
                     msg_txt, _ = await asyncio.wait_for(wss.recv(), 1 if done else timeout)
                     msg = json.loads(msg_txt)
-                except:
+                except Exception:
                     break
                 last_msg = msg
                 if msg.get("event") == "appendText":

--- a/g4f/Provider/CopilotSession.py
+++ b/g4f/Provider/CopilotSession.py
@@ -168,7 +168,7 @@ class CopilotSession(AsyncAuthedProvider, ProviderModelMixin):
             try:
                 request_id, msg_txt = await asyncio.wait_for(queue.get(), 1 if done else timeout)
                 msg = json.loads(msg_txt)
-            except:
+            except Exception:
                 break
             last_msg = msg
             if msg.get("event") == "startMessage":

--- a/g4f/Provider/needs_auth/LMArena.py
+++ b/g4f/Provider/needs_auth/LMArena.py
@@ -614,7 +614,7 @@ class LMArena(AsyncGeneratorProvider, ProviderModelMixin, AuthFileMixin):
                 force = True
                 debug.error(error)
                 continue
-            except:
+            except Exception:
                 raise
         if args and os.getenv("G4F_SHARE_AUTH") and not kwargs.get("action"):
             yield "\n" * 10

--- a/g4f/Provider/needs_auth/OpenaiChat.py
+++ b/g4f/Provider/needs_auth/OpenaiChat.py
@@ -648,7 +648,7 @@ class OpenaiChat(AsyncAuthedProvider, ProviderModelMixin):
                                                         products_str += f"{name} - {tags}\n\n"
 
                                                     return products_str
-                                                except:
+                                                except Exception:
                                                     return ""
 
                                             sequence_content = match.group(1)
@@ -747,7 +747,7 @@ class OpenaiChat(AsyncAuthedProvider, ProviderModelMixin):
             while not wss.closed:
                 try:
                     last_msg = await wss.recv_json(timeout=60 if not started else timeout)
-                except:
+                except Exception:
                     break
                 conversation_id = conversation.task.get("conversation_id")
                 message_id = conversation.task.get("message", {}).get("id")
@@ -871,7 +871,7 @@ class OpenaiChat(AsyncAuthedProvider, ProviderModelMixin):
             return
         try:
             line = json.loads(line[6:])
-        except:
+        except Exception:
             return
         if not isinstance(line, dict):
             return

--- a/g4f/Provider/needs_auth/Video.py
+++ b/g4f/Provider/needs_auth/Video.py
@@ -12,7 +12,7 @@ try:
     import zendriver as nodriver
     from zendriver.core.connection import ProtocolException
     has_nodriver = True
-except:
+except Exception:
     has_nodriver = False
 
 from ...typing import Messages, AsyncResult

--- a/g4f/Provider/needs_auth/bing/create_images.py
+++ b/g4f/Provider/needs_auth/bing/create_images.py
@@ -118,7 +118,7 @@ async def create_images(session: ClientSession, prompt: str, timeout: int = TIME
     error = None
     try:
         error = json.loads(text).get("errorMessage")
-    except:
+    except Exception:
         pass
     if error == "Pending":
         raise RuntimeError("Prompt is been blocked")

--- a/g4f/Provider/needs_auth/hf/HuggingFaceMedia.py
+++ b/g4f/Provider/needs_auth/hf/HuggingFaceMedia.py
@@ -227,7 +227,7 @@ class HuggingFaceMedia(AsyncGeneratorProvider, ProviderModelMixin):
                                         item["url"] if isinstance(item, dict) else item
                                         for item in result.get("images", result.get("data", result.get("output")))
                                     ], prompt)
-                                except:
+                                except Exception:
                                     raise ValueError(f"Unexpected response: {result}")
                             elif task == "text-to-video" and result.get("output") is not None:
                                 return provider_info, VideoResponse(result["output"], prompt)

--- a/g4f/Provider/qwen/QwenCode.py
+++ b/g4f/Provider/qwen/QwenCode.py
@@ -77,7 +77,7 @@ class QwenCode(OpenaiTemplate):
                     last_chunk = chunk
                 else:
                     yield chunk
-        except:
+        except Exception:
             raise
 
     @classmethod

--- a/g4f/Provider/qwen/oauthFlow.py
+++ b/g4f/Provider/qwen/oauthFlow.py
@@ -40,7 +40,7 @@ async def launch_browser_for_oauth():
     url_to_open = device_auth.get("verification_uri_complete") or device_auth["verification_uri"]
     try:
         webbrowser.open(url_to_open)
-    except:
+    except Exception:
         print(f"Open the URL manually in your browser: {url_to_open}")
 
     # Start polling for token

--- a/g4f/Provider/qwen/sharedTokenManager.py
+++ b/g4f/Provider/qwen/sharedTokenManager.py
@@ -80,7 +80,7 @@ class SharedTokenManager(AuthFileMixin):
             try:
                 lock_path = self.getLockFilePath()
                 lock_path.unlink()
-            except:
+            except Exception:
                 pass
 
         atexit.register(cleanup)
@@ -214,16 +214,16 @@ class SharedTokenManager(AuthFileMixin):
                 with open(lock_path, "w") as f:
                     f.write(lock_id)
                 return
-            except:
+            except Exception:
                 try:
                     stat = os.stat(str(lock_path))
                     lock_age = int(time.time() * 1000) - int(stat.st_mtime * 1000)
                     if lock_age > LOCK_TIMEOUT_MS:
                         try:
                             await os.unlink(str(lock_path))
-                        except:
+                        except Exception:
                             pass
-                except:
+                except Exception:
                     pass
                 await asyncio.sleep(attempt_interval / 1000)
         raise TokenManagerError(TokenError.LOCK_TIMEOUT, "Failed to acquire lock")
@@ -231,7 +231,7 @@ class SharedTokenManager(AuthFileMixin):
     async def releaseLock(self, lock_path: Path):
         try:
             await os.unlink(str(lock_path))
-        except:
+        except Exception:
             pass
 
     async def saveCredentialsToFile(self, credentials: dict):

--- a/g4f/api/__init__.py
+++ b/g4f/api/__init__.py
@@ -239,7 +239,7 @@ class Api:
                     if has_crypto and user_g4f_api_key:
                         try:
                             expires, user = decrypt_data(private_key, user_g4f_api_key[0]).split(":", 1)
-                        except:
+                        except Exception:
                             try:
                                 data = json.loads(decrypt_data(session_key, user_g4f_api_key[0]))
                                 debug.log(f"Decrypted G4F API key data: {data}")
@@ -247,7 +247,7 @@ class Api:
                                 user = data.get("user", user)
                                 if not user or "referrer" not in data:
                                     raise ValueError("User not found")
-                            except:
+                            except Exception:
                                 return ErrorResponse.from_message(f"Invalid G4F API key", HTTP_401_UNAUTHORIZED)
                         user = f"{country}:{user}" if country else user
                         expires = int(expires) - int(time.time())
@@ -621,7 +621,7 @@ class Api:
             def safe_get_models(provider: ProviderType) -> list[str]:
                 try:
                     return provider.get_models() if hasattr(provider, "get_models") else []
-                except:
+                except Exception:
                     return []
             return {
                 'id': provider.__name__,

--- a/g4f/requests/__init__.py
+++ b/g4f/requests/__init__.py
@@ -67,7 +67,7 @@ async def get_args_from_webview(url: str) -> dict:
         try:
             await asyncio.sleep(1)
             body = window.dom.get_element("body:not(.no-js)")
-        except:
+        except Exception:
             ...
     headers = {
         **WEBVIEW_HAEDERS,
@@ -134,7 +134,7 @@ async def get_args_from_nodriver(
             },
             "proxy": proxy,
         }
-    except:
+    except Exception:
         await stop_browser()
         raise
 
@@ -232,7 +232,7 @@ async def get_nodriver(
         try:
             if BrowserConfig.port is None and browser.connection:
                 await browser.stop()
-        except:
+        except Exception:
             pass
         finally:
             if user_data_dir:

--- a/g4f/tools/files.py
+++ b/g4f/tools/files.py
@@ -60,7 +60,7 @@ except ImportError:
 try:
     import spacy
     has_spacy = True
-except:
+except Exception:
     has_spacy = False
 try:
     from bs4 import BeautifulSoup

--- a/g4f/tools/run_tools.py
+++ b/g4f/tools/run_tools.py
@@ -342,7 +342,7 @@ async def async_iter_run_tools(
                 f.write(f"{json.dumps(usage)}\n")
         if completion_tokens > 0:
             provider.live += 1
-    except:
+    except Exception:
         provider.live -= 1
         raise
 
@@ -514,7 +514,7 @@ def iter_run_tools(
             f.write(f"{json.dumps(usage)}\n")
         if completion_tokens > 0:
             provider.live += 1
-    except:
+    except Exception:
         provider.live -= 1
         raise
 


### PR DESCRIPTION
## What
Replace 34 bare `except:` clauses with `except Exception:`.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can prevent clean process shutdown and mask critical errors. Using `except Exception:` catches all application-level errors while allowing system-level exceptions to propagate correctly.