### PR TITLE
feat: update MiniMax provider with M2.5 models

### DIFF
--- a/g4f/Provider/needs_auth/mini_max/MiniMax.py
+++ b/g4f/Provider/needs_auth/mini_max/MiniMax.py
@@ -4,13 +4,13 @@ from ...template import OpenaiTemplate
 
 class MiniMax(OpenaiTemplate):
     label = "MiniMax API"
-    url = "https://www.hailuo.ai/chat"
-    login_url = "https://intl.minimaxi.com/user-center/basic-information/interface-key"
-    base_url = "https://api.minimaxi.chat/v1"
+    url = "https://www.minimax.io"
+    login_url = "https://platform.minimax.io/user-center/basic-information/interface-key"
+    base_url = "https://api.minimax.io/v1"
     working = True
     needs_auth = True
 
-    default_model = "MiniMax-Text-01"
+    default_model = "MiniMax-M2.5"
     default_vision_model = default_model
-    models = [default_model, "abab6.5s-chat"]
-    model_aliases = {"MiniMax": default_model}
+    models = [default_model, "MiniMax-M2.5-highspeed", "MiniMax-Text-01", "abab6.5s-chat"]
+    model_aliases = {"MiniMax": default_model, "minimax": default_model}

--- a/g4f/models.py
+++ b/g4f/models.py
@@ -43,6 +43,7 @@ from .Provider import (
     Groq,
     MetaAI,
     MicrosoftDesigner,
+    MiniMax,
     OpenaiAccount,
     OpenaiChat,
     OpenRouter,
@@ -836,6 +837,19 @@ grok_3_r1 = Model(
     name = 'grok-3-r1',
     base_provider = 'x.ai',
     best_provider = Grok
+)
+
+### MiniMax ###
+minimax_m2_5 = Model(
+    name = 'MiniMax-M2.5',
+    base_provider = 'MiniMax',
+    best_provider = IterListProvider([MiniMax, DeepInfra]),
+)
+
+minimax_m2_5_highspeed = Model(
+    name = 'MiniMax-M2.5-highspeed',
+    base_provider = 'MiniMax',
+    best_provider = MiniMax,
 )
 
 kimi = Model(


### PR DESCRIPTION
## Summary
Update the MiniMax API provider to support the latest MiniMax-M2.5 and MiniMax-M2.5-highspeed models, and fix the API base URL.

## Changes
- **Fix API endpoint**: Update `base_url` from deprecated `api.minimaxi.chat` to the official `api.minimax.io/v1`
- **Add M2.5 models**: Add `MiniMax-M2.5` (default) and `MiniMax-M2.5-highspeed` to the provider
- **Register models**: Add MiniMax-M2.5 models to the central model registry in `models.py` with `DeepInfra` as fallback provider
- **Update URLs**: Update provider website and API key management URLs to current MiniMax platform
- **Backward compatible**: Legacy models (`MiniMax-Text-01`, `abab6.5s-chat`) are preserved

## Model Details

| Model | Context Window | Description |
|-------|---------------|-------------|
| MiniMax-M2.5 | 204,800 tokens | Peak performance, ultimate value (default) |
| MiniMax-M2.5-highspeed | 204,800 tokens | Same performance, faster and more agile |

## API Documentation
- OpenAI Compatible API: https://platform.minimax.io/docs/api-reference/text-openai-api

## Testing
- Verified provider loads correctly with updated configuration
- Tested both models via direct API calls with streaming
- Tested via g4f client interface