### PR TITLE
feat: upgrade MiniMax default model to M2.7

### DIFF
--- a/etc/unittest/test_minimax.py
+++ b/etc/unittest/test_minimax.py
@@ -1,0 +1,34 @@
+import unittest
+
+from g4f.Provider.needs_auth.mini_max.MiniMax import MiniMax
+
+
+class TestMiniMaxProvider(unittest.TestCase):
+    def test_default_model_is_m27(self):
+        self.assertEqual(MiniMax.default_model, "MiniMax-M2.7")
+
+    def test_m27_highspeed_in_models(self):
+        self.assertIn("MiniMax-M2.7-highspeed", MiniMax.models)
+
+    def test_m27_is_first_in_models(self):
+        self.assertEqual(MiniMax.models[0], "MiniMax-M2.7")
+
+    def test_m27_highspeed_is_second(self):
+        self.assertEqual(MiniMax.models[1], "MiniMax-M2.7-highspeed")
+
+    def test_old_models_still_available(self):
+        self.assertIn("MiniMax-Text-01", MiniMax.models)
+        self.assertIn("abab6.5s-chat", MiniMax.models)
+
+    def test_model_alias_points_to_m27(self):
+        self.assertEqual(MiniMax.model_aliases["MiniMax"], "MiniMax-M2.7")
+
+    def test_provider_is_working(self):
+        self.assertTrue(MiniMax.working)
+
+    def test_needs_auth(self):
+        self.assertTrue(MiniMax.needs_auth)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/g4f/Provider/needs_auth/mini_max/MiniMax.py
+++ b/g4f/Provider/needs_auth/mini_max/MiniMax.py
@@ -10,7 +10,7 @@ class MiniMax(OpenaiTemplate):
     working = True
     needs_auth = True
 
-    default_model = "MiniMax-Text-01"
+    default_model = "MiniMax-M2.7"
     default_vision_model = default_model
-    models = [default_model, "abab6.5s-chat"]
+    models = [default_model, "MiniMax-M2.7-highspeed", "MiniMax-Text-01", "abab6.5s-chat"]
     model_aliases = {"MiniMax": default_model}

--- a/g4f/providers/any_model_map.py
+++ b/g4f/providers/any_model_map.py
@@ -1093,6 +1093,12 @@ model_map = {
     "HuggingChat": "zai-org/GLM-4.7-FP8",
     "OpenRouter": "z-ai/glm-4.7"
   },
+  "minimax-m2.7": {
+    "MiniMax": "MiniMax-M2.7"
+  },
+  "minimax-m2.7-highspeed": {
+    "MiniMax": "MiniMax-M2.7-highspeed"
+  },
   "minimax-m2.1": {
     "PollinationsAI": "minimax",
     "HuggingFace": "MiniMaxAI/MiniMax-M2.1",
@@ -4153,6 +4159,8 @@ models_count = {
   "claude-opus-4.5": 3,
   "gemini-3-pro": 8,
   "glm-4.7": 9,
+  "minimax-m2.7": 9,
+  "minimax-m2.7-highspeed": 9,
   "minimax-m2.1": 9,
   "turbo": 2,
   "gpt-image-1.5": 3,
@@ -5399,6 +5407,10 @@ model_aliases = {
   "openrouter:z-ai/glm-4.7": "glm-4.7",
   "zai-org/GLM-4.7-FP8": "glm-4.7",
   "z-ai/glm-4.7": "glm-4.7",
+  "MiniMax-M2.7": "minimax-m2.7",
+  "minimax/minimax-m2.7": "minimax-m2.7",
+  "MiniMax-M2.7-highspeed": "minimax-m2.7-highspeed",
+  "minimax/minimax-m2.7-highspeed": "minimax-m2.7-highspeed",
   "MiniMaxAI/MiniMax-M2.1": "minimax-m2.1",
   "minimax-m2.1-preview": "minimax-m2.1",
   "openrouter:minimax/minimax-m2.1": "minimax-m2.1",


### PR DESCRIPTION
## Summary
- Add MiniMax-M2.7 and MiniMax-M2.7-highspeed to the model selection list
- Set MiniMax-M2.7 as the new default model
- Retain all previous models (MiniMax-Text-01, abab6.5s-chat) as available alternatives
- Add model routing entries in any_model_map for cross-provider support
- Add unit tests for MiniMax provider configuration

## Why
MiniMax-M2.7 is the latest flagship model with enhanced reasoning and coding capabilities.

## Changes
- `g4f/Provider/needs_auth/mini_max/MiniMax.py`: Updated default model and models list
- `g4f/providers/any_model_map.py`: Added M2.7 model routing, scores, and aliases
- `etc/unittest/test_minimax.py`: New unit tests verifying model configuration

## Testing
- Unit tests verify M2.7 is default, both new models are in the list, and old models are preserved
