### PR TITLE
fix(image): support additional video formats in upload

### DIFF
--- a/g4f/image/__init__.py
+++ b/g4f/image/__init__.py
@@ -46,6 +46,11 @@ EXTENSIONS_MAP: dict[str, str] = {
     "mkv": "video/x-matroska",
     "webm": "video/webm",
     "mp4": "video/mp4",
+    "mov": "video/quicktime",
+    "avi": "video/x-msvideo",
+    "ogv": "video/ogg",
+    "mpg": "video/mpeg",
+    "mpeg": "video/mpeg",
 }
 
 MEDIA_TYPE_MAP: dict[str, str] = {value: key for key, value in EXTENSIONS_MAP.items()}
@@ -284,6 +289,8 @@ def detect_file_type(binary_data: bytes) -> tuple[str, str] | None:
             return ".heic", "image/heif"
         elif brand in [b"avif"]:
             return ".avif", "image/avif"
+        else:
+            return ".mp4", "video/mp4"
     elif binary_data.lstrip().startswith((b"<?xml", b"<svg")):
         return ".svg", "image/svg+xml"
 


### PR DESCRIPTION
## Summary
- Add support for additional video formats (mov, avi, ogv, mpg, mpeg) in `EXTENSIONS_MAP`
- Fix `detect_file_type()` to properly recognize MP4 video files with non-HEIC/AVIF ftyp brands

## Root Cause
MP4 files with video container brands (dash, iso6, avc1, etc.) were failing to upload because `detect_file_type()` only recognized HEIC/AVIF brands from the `ftyp` atom. When an MP4 file had any other brand, the function fell through and raised "Unknown or unsupported file type".

## Changes
1. **`EXTENSIONS_MAP`**: Added `mov`, `avi`, `ogv`, `mpg`, `mpeg` video format mappings
2. **`detect_file_type()`**: Added fallback to return `.mp4` / `video/mp4` for any ftyp brand that isn't HEIC/AVIF

## Testing
Verified all video formats are now recognized:

**Extension-based detection:**
- `.mp4`: ✓
- `.webm`: ✓
- `.mkv`: ✓
- `.mov`: ✓
- `.avi`: ✓
- `.ogv`: ✓
- `.mpg`: ✓
- `.mpeg`: ✓

**Content-based detection (magic number):**
- MP4 (ftyp=dash): ✓ video/mp4
- MP4 (ftyp=iso5): ✓ video/mp4
- HEIC: ✓ image/heif (not affected)
- AVIF: ✓ image/avif (not affected)
- WebM/MKV: ✓ video/webm

Fixes video upload errors in Qwen and other providers that use `detect_file_type()` to validate media files.