### PR TITLE
fix(OperaAria): real streaming, text+image coexistence, visible upload errors

### DIFF
--- a/g4f/Provider/OperaAria.py
+++ b/g4f/Provider/OperaAria.py
@@ -9,6 +9,7 @@ import base64
 import asyncio
 from aiohttp import ClientSession, FormData
 
+from .. import debug
 from ..typing import AsyncResult, Messages, MediaListType
 from .base_provider import AsyncGeneratorProvider, ProviderModelMixin
 from .helper import format_prompt
@@ -245,7 +246,8 @@ class OperaAria(AsyncGeneratorProvider, ProviderModelMixin):
                         
                         image_id = await cls.upload_media(session, access_token, media_bytes, media_name)
                         media_attachments.append(image_id)
-                    except Exception:
+                    except Exception as e:
+                        debug.log(f"OperaAria: failed to upload media '{media_name}': {e}")
                         continue
             
             headers = {
@@ -271,16 +273,16 @@ class OperaAria(AsyncGeneratorProvider, ProviderModelMixin):
                 response.raise_for_status()
                 
                 if stream:
-                    text_buffer, image_urls, finish_reason = [], [], None
-                    
+                    image_urls, finish_reason = [], None
+
                     async for line in response.content:
                         if not line: continue
                         decoded = line.decode('utf-8').strip()
                         if not decoded.startswith('data: '): continue
-                        
+
                         content = decoded[6:]
                         if content == '[DONE]': break
-                        
+
                         try:
                             json_data = json.loads(content)
                             if 'message' in json_data:
@@ -289,22 +291,20 @@ class OperaAria(AsyncGeneratorProvider, ProviderModelMixin):
                                 if found_urls:
                                     image_urls.extend(found_urls)
                                 else:
-                                    text_buffer.append(message_chunk)
-                            
+                                    yield message_chunk
+
                             if 'conversation_id' in json_data and json_data['conversation_id']:
                                 conversation.conversation_id = json_data['conversation_id']
-                            
+
                             if 'finish_reason' in json_data and json_data.get('finish_reason'):
                                 finish_reason = json_data['finish_reason']
 
                         except json.JSONDecodeError:
                             continue
-                    
+
                     if image_urls:
                         yield ImageResponse(image_urls, format_prompt(messages))
-                    elif text_buffer:
-                        yield "".join(text_buffer)
-                    
+
                     if finish_reason:
                         yield FinishReason(finish_reason)
 


### PR DESCRIPTION
## What

Three bugs fixed in `g4f/Provider/OperaAria.py`:

**1. Streaming was not actually streaming**
Text chunks were appended to a buffer and yielded as one string after `[DONE]`. Now each chunk is yielded immediately as it arrives.

**2. Text was silently discarded when images were present**
The `elif text_buffer` check meant any text in a response containing images was thrown away. Text is now streamed inline and image responses are yielded independently after the loop.

**3. Media upload failures were swallowed silently**
`except Exception: continue` gave no indication when an image failed to upload. Now logs via `debug.log()` consistent with other providers.

## Why

- `supports_stream = True` was misleading — the provider was buffering the full response before yielding
- Mixed text+image responses lost all text content
- Silent upload failures made debugging impossible