### PR TITLE
fix(OpenaiChat): use gizmo_interaction conversation_mode for custom GPTs

### DIFF
--- a/g4f/Provider/needs_auth/OpenaiChat.py
+++ b/g4f/Provider/needs_auth/OpenaiChat.py
@@ -451,7 +451,11 @@ class OpenaiChat(AsyncAuthedProvider, ProviderModelMixin):
                 conversation = copy(conversation)
 
             if conversation_mode is None:
-                conversation_mode = {"kind": "primary_assistant"}
+                _gizmo_id = kwargs.get("gizmo_id")
+                if _gizmo_id:
+                    conversation_mode = {"kind": "gizmo_interaction", "gizmo_id": _gizmo_id}
+                else:
+                    conversation_mode = {"kind": "primary_assistant"}
 
             if getattr(auth_result, "cookies", {}).get("oai-did") != getattr(conversation, "user_id", None):
                 conversation = Conversation(None, str(uuid.uuid4()))
@@ -475,7 +479,7 @@ class OpenaiChat(AsyncAuthedProvider, ProviderModelMixin):
                         "model": model,
                         "timezone_offset_min": -120,
                         "timezone": "Europe/Berlin",
-                        "conversation_mode": {"kind": "primary_assistant"},
+                        "conversation_mode": conversation_mode,
                         "system_hints": system_hints,
                         "supports_buffering": True,
                         "supported_encodings": ["v1"]
@@ -536,7 +540,7 @@ class OpenaiChat(AsyncAuthedProvider, ProviderModelMixin):
                     "model": model,
                     "timezone_offset_min": -120,
                     "timezone": "Europe/Berlin",
-                    "conversation_mode": {"kind": "primary_assistant"},
+                    "conversation_mode": conversation_mode,
                     "enable_message_followups": True,
                     "system_hints": system_hints,
                     "supports_buffering": True,


### PR DESCRIPTION
## Summary

Fixes #3427

When `gizmo_id` is passed to `OpenaiChat`, the `conversation_mode` parameter in `create_authed` was never propagated to the HTTP request payload — both `data` dicts hardcoded `{"kind": "primary_assistant"}`, causing the custom GPT's system instructions to be ignored and the base model to respond instead.

## Changes

- In `create_authed`, when `conversation_mode` is `None` and `gizmo_id` is present in `kwargs`, default to `{"kind": "gizmo_interaction", "gizmo_id": gizmo_id}` instead of `primary_assistant`
- Replace the two hardcoded `conversation_mode` literals in the request payload `data` dicts with the `conversation_mode` variable

## Test

```python
import g4f
from g4f.Provider import OpenaiChat

for chunk in g4f.ChatCompletion.create(
    model="gpt-4o",
    provider=OpenaiChat,
    messages=[{"role": "user", "content": "Hello, follow your instructions"}],
    gizmo_id="g-XXXXXXXX",  # replace with a real custom GPT id
    stream=True,
):
    print(chunk, end="")
# Now responds using the custom GPT's system instructions
```