### PR TITLE
Fix get_models ,Update Qwen provider models and thinking mode

### DIFF
--- a/g4f/Provider/Qwen.py
+++ b/g4f/Provider/Qwen.py
@@ -88,28 +88,26 @@ def get_oss_headers(method: str, date_str: str, sts_data: dict, content_type: st
 
 
 text_models = [
-    'qwen3-max-preview', 'qwen-plus-2025-09-11', 'qwen3-235b-a22b', 'qwen3-coder-plus', 'qwen3-30b-a3b',
-    'qwen3-coder-30b-a3b-instruct', 'qwen-max-latest', 'qwen-plus-2025-01-25', 'qwq-32b', 'qwen-turbo-2025-02-11',
-    'qwen2.5-omni-7b', 'qvq-72b-preview-0310', 'qwen2.5-vl-32b-instruct', 'qwen2.5-14b-instruct-1m',
-    'qwen2.5-coder-32b-instruct', 'qwen2.5-72b-instruct']
+    'qwen3.6-plus', 'qwen3.6-max-preview', 'qwen3.5-plus', 'qwen3.5-omni-plus', 'qwen3.6-35b-a3b', 'qwen3.5-flash',
+    'qwen3.5-max-2026-03-08', 'qwen3.6-plus-preview', 'qwen3.5-397b-a17b', 'qwen3.5-122b-a10b', 'qwen3.5-omni-flash',
+    'qwen3.5-27b', 'qwen3.5-35b-a3b', 'qwen3-max-2026-01-23', 'qwen-plus-2025-07-28', 'qwen3-coder-plus',
+    'qwen3-vl-plus', 'qwen3-omni-flash-2025-12-01', 'qwen-max-latest']
 
 image_models = [
-    'qwen3-max-preview', 'qwen-plus-2025-09-11', 'qwen3-235b-a22b', 'qwen3-coder-plus', 'qwen3-30b-a3b',
-    'qwen3-coder-30b-a3b-instruct', 'qwen-max-latest', 'qwen-plus-2025-01-25', 'qwen-turbo-2025-02-11',
-    'qwen2.5-omni-7b', 'qwen2.5-vl-32b-instruct', 'qwen2.5-14b-instruct-1m', 'qwen2.5-coder-32b-instruct',
-    'qwen2.5-72b-instruct']
+    'qwen3.6-plus', 'qwen3.5-plus', 'qwen3.5-omni-plus', 'qwen3.6-35b-a3b', 'qwen3.5-flash', 'qwen3.5-397b-a17b',
+    'qwen3.5-122b-a10b', 'qwen3.5-omni-flash', 'qwen3.5-27b', 'qwen3.5-35b-a3b', 'qwen3-max-2026-01-23',
+    'qwen-plus-2025-07-28', 'qwen3-coder-plus', 'qwen3-vl-plus', 'qwen3-omni-flash-2025-12-01', 'qwen-max-latest']
 
 vision_models = [
-    'qwen3-max-preview', 'qwen-plus-2025-09-11', 'qwen3-235b-a22b', 'qwen3-coder-plus', 'qwen3-30b-a3b',
-    'qwen3-coder-30b-a3b-instruct', 'qwen-max-latest', 'qwen-plus-2025-01-25', 'qwen-turbo-2025-02-11',
-    'qwen2.5-omni-7b', 'qvq-72b-preview-0310', 'qwen2.5-vl-32b-instruct', 'qwen2.5-14b-instruct-1m',
-    'qwen2.5-coder-32b-instruct', 'qwen2.5-72b-instruct']
+    'qwen3.6-plus', 'qwen3.5-plus', 'qwen3.5-omni-plus', 'qwen3.6-35b-a3b', 'qwen3.5-flash', 'qwen3.5-397b-a17b',
+    'qwen3.5-122b-a10b', 'qwen3.5-omni-flash', 'qwen3.5-27b', 'qwen3.5-35b-a3b', 'qwen3-max-2026-01-23',
+    'qwen-plus-2025-07-28', 'qwen3-coder-plus', 'qwen3-vl-plus', 'qwen3-omni-flash-2025-12-01', 'qwen-max-latest']
 
 models = [
-    'qwen3-max-preview', 'qwen-plus-2025-09-11', 'qwen3-235b-a22b', 'qwen3-coder-plus', 'qwen3-30b-a3b',
-    'qwen3-coder-30b-a3b-instruct', 'qwen-max-latest', 'qwen-plus-2025-01-25', 'qwq-32b', 'qwen-turbo-2025-02-11',
-    'qwen2.5-omni-7b', 'qvq-72b-preview-0310', 'qwen2.5-vl-32b-instruct', 'qwen2.5-14b-instruct-1m',
-    'qwen2.5-coder-32b-instruct', 'qwen2.5-72b-instruct']
+    'qwen3.6-plus', 'qwen3.6-max-preview', 'qwen3.5-plus', 'qwen3.5-omni-plus', 'qwen3.6-35b-a3b', 'qwen3.5-flash',
+    'qwen3.5-max-2026-03-08', 'qwen3.6-plus-preview', 'qwen3.5-397b-a17b', 'qwen3.5-122b-a10b', 'qwen3.5-omni-flash',
+    'qwen3.5-27b', 'qwen3.5-35b-a3b', 'qwen3-max-2026-01-23', 'qwen-plus-2025-07-28', 'qwen3-coder-plus',
+    'qwen3-vl-plus', 'qwen3-omni-flash-2025-12-01', 'qwen-max-latest']
 
 
 class Qwen(AsyncGeneratorProvider, ProviderModelMixin):
@@ -136,17 +134,22 @@ class Qwen(AsyncGeneratorProvider, ProviderModelMixin):
     @classmethod
     def get_models(cls, **kwargs) -> list[str]:
         if not cls._models_loaded and has_curl_cffi:
-            response = curl_cffi.get(f"{cls.url}/api/models")
+            _token = kwargs.get("token")
+            headers = cls._get_headers(_token) if _token else {}
+            response = curl_cffi.get(f"{cls.url}/api/models", headers=headers)
             if response.ok:
                 models = response.json().get("data", [])
-                cls.text_models = [model["id"] for model in models if "t2t" in model["info"]["meta"]["chat_type"]]
+                cls.text_models = [model["id"] for model in models
+                                   if "t2t" in model.get("info", {}).get("meta", {}).get("chat_type")]
 
                 cls.image_models = [
-                    model["id"] for model in models if
-                    "image_edit" in model["info"]["meta"]["chat_type"] or "t2i" in model["info"]["meta"]["chat_type"]
+                    model["id"] for model in models
+                    if "image_edit" in model.get("info", {}).get("meta", {}).get("chat_type") or
+                       "t2i" in model.get("info", {}).get("meta", {}).get("chat_type")
                 ]
 
-                cls.vision_models = [model["id"] for model in models if model["info"]["meta"]["capabilities"]["vision"]]
+                cls.vision_models = [model["id"] for model in models
+                                     if model.get("info", {}).get("meta", {}).get("capabilities", {}).get("vision")]
 
                 cls.models = [model["id"] for model in models]
                 cls.default_model = cls.models[0]
@@ -384,7 +387,9 @@ class Qwen(AsyncGeneratorProvider, ProviderModelMixin):
         model_name = cls.get_model(model)
         prompt = get_last_user_message(messages)
         enable_thinking = reasoning_effort in ("medium", "high")
-        thinking_mode: Literal["Auto", "Thinking", "Fast"] = kwargs.get("thinking_mode", "Auto")
+        thinking_mode: Literal["Auto", "Thinking", "Fast"] = kwargs.get("thinking_mode",
+                                                                        "Auto" if enable_thinking else "Fast")
+        auto_thinking = thinking_mode == "Auto"
         timeout = kwargs.get("timeout") or 5 * 60
         token = kwargs.get("token")
         async with StreamSession(headers=cls._get_headers(token)) as session:
@@ -427,7 +432,7 @@ class Qwen(AsyncGeneratorProvider, ProviderModelMixin):
                                                         headers=req_headers)
 
                     feature_config = {
-                        "auto_thinking": "Auto" == thinking_mode,
+                        "auto_thinking": auto_thinking,
                         "thinking_mode": thinking_mode,
                         # "thinking_format": "summary",
                         "thinking_enabled": enable_thinking,


### PR DESCRIPTION
Fix get_models
Refresh static model lists and improve dynamic model discovery/parsing. get_models now accepts an optional token, sends headers, and uses safe dict access (model.get(...)) to build text/image/vision/models lists and set default_model. Adjust generation logic so thinking_mode defaults to "Auto" when reasoning is enabled (otherwise "Fast"), introduce an auto_thinking variable, and propagate token headers into the StreamSession.