### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/etc/unittest/test_minimax.py
+++ b/etc/unittest/test_minimax.py
@@ -19,9 +19,13 @@ class TestMiniMaxProvider(unittest.TestCase):
     def test_m27_highspeed_still_available(self):
         self.assertIn("MiniMax-M2.7-highspeed", MiniMax.models)
 
-    def test_old_models_still_available(self):
-        self.assertIn("MiniMax-Text-01", MiniMax.models)
-        self.assertIn("abab6.5s-chat", MiniMax.models)
+    def test_old_models_removed(self):
+        self.assertNotIn("MiniMax-Text-01", MiniMax.models)
+        self.assertNotIn("abab6.5s-chat", MiniMax.models)
+        self.assertNotIn("MiniMax-M2.5", MiniMax.models)
+        self.assertNotIn("MiniMax-M2.1", MiniMax.models)
+        self.assertNotIn("MiniMax-M2", MiniMax.models)
+        self.assertNotIn("MiniMax-M1", MiniMax.models)
 
     def test_model_alias_points_to_m3(self):
         self.assertEqual(MiniMax.model_aliases["MiniMax"], "MiniMax-M3")

--- a/etc/unittest/test_minimax.py
+++ b/etc/unittest/test_minimax.py
@@ -4,24 +4,27 @@ from g4f.Provider.needs_auth.mini_max.MiniMax import MiniMax
 
 
 class TestMiniMaxProvider(unittest.TestCase):
-    def test_default_model_is_m27(self):
-        self.assertEqual(MiniMax.default_model, "MiniMax-M2.7")
+    def test_default_model_is_m3(self):
+        self.assertEqual(MiniMax.default_model, "MiniMax-M3")
 
-    def test_m27_highspeed_in_models(self):
+    def test_m3_in_models(self):
+        self.assertIn("MiniMax-M3", MiniMax.models)
+
+    def test_m3_is_first_in_models(self):
+        self.assertEqual(MiniMax.models[0], "MiniMax-M3")
+
+    def test_m27_still_available(self):
+        self.assertIn("MiniMax-M2.7", MiniMax.models)
+
+    def test_m27_highspeed_still_available(self):
         self.assertIn("MiniMax-M2.7-highspeed", MiniMax.models)
-
-    def test_m27_is_first_in_models(self):
-        self.assertEqual(MiniMax.models[0], "MiniMax-M2.7")
-
-    def test_m27_highspeed_is_second(self):
-        self.assertEqual(MiniMax.models[1], "MiniMax-M2.7-highspeed")
 
     def test_old_models_still_available(self):
         self.assertIn("MiniMax-Text-01", MiniMax.models)
         self.assertIn("abab6.5s-chat", MiniMax.models)
 
-    def test_model_alias_points_to_m27(self):
-        self.assertEqual(MiniMax.model_aliases["MiniMax"], "MiniMax-M2.7")
+    def test_model_alias_points_to_m3(self):
+        self.assertEqual(MiniMax.model_aliases["MiniMax"], "MiniMax-M3")
 
     def test_provider_is_working(self):
         self.assertTrue(MiniMax.working)

--- a/g4f/Provider/needs_auth/mini_max/MiniMax.py
+++ b/g4f/Provider/needs_auth/mini_max/MiniMax.py
@@ -12,5 +12,5 @@ class MiniMax(OpenaiTemplate):
 
     default_model = "MiniMax-M3"
     default_vision_model = default_model
-    models = [default_model, "MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-Text-01", "abab6.5s-chat"]
+    models = [default_model, "MiniMax-M2.7", "MiniMax-M2.7-highspeed"]
     model_aliases = {"MiniMax": default_model}

--- a/g4f/Provider/needs_auth/mini_max/MiniMax.py
+++ b/g4f/Provider/needs_auth/mini_max/MiniMax.py
@@ -10,7 +10,7 @@ class MiniMax(OpenaiTemplate):
     working = True
     needs_auth = True
 
-    default_model = "MiniMax-M2.7"
+    default_model = "MiniMax-M3"
     default_vision_model = default_model
-    models = [default_model, "MiniMax-M2.7-highspeed", "MiniMax-Text-01", "abab6.5s-chat"]
+    models = [default_model, "MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-Text-01", "abab6.5s-chat"]
     model_aliases = {"MiniMax": default_model}

--- a/g4f/providers/any_model_map.py
+++ b/g4f/providers/any_model_map.py
@@ -1093,6 +1093,9 @@ model_map = {
     "HuggingChat": "zai-org/GLM-4.7-FP8",
     "OpenRouter": "z-ai/glm-4.7"
   },
+  "minimax-m3": {
+    "MiniMax": "MiniMax-M3"
+  },
   "minimax-m2.7": {
     "MiniMax": "MiniMax-M2.7"
   },
@@ -5407,6 +5410,8 @@ model_aliases = {
   "openrouter:z-ai/glm-4.7": "glm-4.7",
   "zai-org/GLM-4.7-FP8": "glm-4.7",
   "z-ai/glm-4.7": "glm-4.7",
+  "MiniMax-M3": "minimax-m3",
+  "minimax/minimax-m3": "minimax-m3",
   "MiniMax-M2.7": "minimax-m2.7",
   "minimax/minimax-m2.7": "minimax-m2.7",
   "MiniMax-M2.7-highspeed": "minimax-m2.7-highspeed",


### PR DESCRIPTION
## Summary
Upgrade the MiniMax provider's model configuration to include the latest M3 model as the new default, and prune the legacy model list.

## Changes
- Add `MiniMax-M3` to the model selection list (placed first)
- Set `MiniMax-M3` as the new `default_model` and `default_vision_model`
- Retain `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as available alternatives
- Remove legacy models `MiniMax-Text-01` and `abab6.5s-chat` from the provider model list
- Update `model_aliases["MiniMax"]` to point at M3
- Add M3 entries to `g4f/providers/any_model_map.py` (forward + reverse mappings)
- Update unit tests to assert M3 is the default, M2.7 is retained, and the legacy models are removed

## Why
MiniMax-M3 is the new flagship model from MiniMax, offering a 512K context window, 128K max output tokens, and image input support across both the OpenAI-compatible and Anthropic-compatible interfaces. Adopting it as the default keeps users on the most capable model by default while leaving M2.7 and M2.7-highspeed available for callers that need the older behavior. Removing the long-deprecated `MiniMax-Text-01` and `abab6.5s-chat` IDs keeps the model list in line with the SKILL guidance to drop anything older than M2.7.

## Testing
- `python3 -m unittest etc.unittest.test_minimax -v` — all 9 tests pass
- Provider class loads cleanly and exposes the expected attributes
- `g4f/providers/any_model_map.py` imports without syntax errors