### PR TITLE
fix: intercept module access for lazy loading, resolve string attribute error, and fix offline GUI crash (#3469)

### DIFF
--- a/etc/unittest/models.py
+++ b/etc/unittest/models.py
@@ -13,7 +13,8 @@ class TestProviderHasModel(unittest.TestCase):
     def test_provider_has_model(self):
         for model, providers in __models__.values():
             for provider in providers:
-                provider = __getattr__(provider)
+                if isinstance(provider, str):
+                    provider = __getattr__(provider)
                 if getattr(provider, "needs_auth", False):
                     continue
                 if issubclass(provider, ProviderModelMixin):
@@ -40,5 +41,6 @@ class TestProviderHasModel(unittest.TestCase):
     def test_all_providers_working(self):
         for model, providers in __models__.values():
             for provider in providers:
-                provider = __getattr__(provider)
+                if isinstance(provider, str):
+                    provider = __getattr__(provider)
                 self.assertTrue(provider.working, f"{provider.__name__} in {model.name}")

--- a/g4f/Provider/CopilotApp.py
+++ b/g4f/Provider/CopilotApp.py
@@ -18,7 +18,7 @@ class CopilotApp(AsyncGeneratorProvider, ProviderModelMixin):
     default_model = "smart"
     models = ["smart", "reasoning", "chat", "study", "search", "gpt-4", "gpt-4o"]
     model_aliases = {
-        "Copilot": default_model,
+        "copilot": default_model,
         "gpt-4": "chat", 
         "gpt-4o": "chat",
         "o1": "reasoning",

--- a/g4f/Provider/CopilotApp.py
+++ b/g4f/Provider/CopilotApp.py
@@ -16,15 +16,15 @@ class CopilotApp(AsyncGeneratorProvider, ProviderModelMixin):
     supports_stream = True
 
     default_model = "smart"
-    models = ["smart", "reasoning", "chat", "study", "search", "gpt-4", "gpt-4o"]
+    models = ["smart", "reasoning", "chat", "study", "search"]
     model_aliases = {
         "copilot": default_model,
         "gpt-4": "chat", 
         "gpt-4o": "chat",
         "o1": "reasoning",
+        "o1-preview": "reasoning",
         "o3-mini": "reasoning",
-        "gpt-5": "smart",
-        "think-deeper": "reasoning"
+        "gpt-5": "smart"
     }
 
     @classmethod

--- a/g4f/Provider/__init__.py
+++ b/g4f/Provider/__init__.py
@@ -200,3 +200,20 @@ class ProviderUtils:
                     return provider
                     
         raise ValueError(f"Provider with label '{label}' not found")
+
+import sys
+import types
+
+class LazyProviderModule(types.ModuleType):
+    def __getattribute__(self, name):
+        if name.startswith('__'):
+            return super().__getattribute__(name)
+        
+        map_paths = super().__getattribute__('__map_paths__')
+        if name in map_paths:
+            return super().__getattribute__('__getattr__')(name)
+            
+        return super().__getattribute__(name)
+
+sys.modules[__name__].__class__ = LazyProviderModule
+

--- a/g4f/client/__init__.py
+++ b/g4f/client/__init__.py
@@ -529,7 +529,7 @@ class Images:
         error = None
         response = None
         if isinstance(provider_handler, IterListProvider):
-            for provider in provider_handler.providers:
+            for provider in provider_handler.get_providers():
                 try:
                     response = await self._generate_image_response(provider, get_name(provider), model, prompt, **kwargs)
                     if response is not None:

--- a/g4f/models.py
+++ b/g4f/models.py
@@ -839,9 +839,17 @@ def _get_best_providers(model: Model) -> List:
         return []
     
     if isinstance(model.best_provider, IterListProvider):
-        return model.best_provider.providers
+        return model.best_provider.get_providers()
 
-    return [model.best_provider]
+    if isinstance(model.best_provider, str):
+        try:
+            from .Provider import __getattr__
+            provider = __getattr__(model.best_provider)
+            return [provider] if getattr(provider, "working", False) else []
+        except AttributeError:
+            return []
+
+    return [model.best_provider] if getattr(model.best_provider, "working", False) else []
 
 # Generate __models__ using the auto-discovered models
 __models__ = {

--- a/g4f/models.py
+++ b/g4f/models.py
@@ -243,6 +243,31 @@ gpt_oss_120b = Model(
     best_provider = IterListProvider(["Together", "HuggingFace", "OpenRouter", "Groq"])
 )
 
+# Copilot (Microsoft)
+smart = Model(
+    name          = 'smart',
+    base_provider = 'Microsoft',
+    best_provider = IterListProvider(["CopilotApp", "CopilotAccount", "Copilot"])
+)
+
+reasoning = Model(
+    name          = 'reasoning',
+    base_provider = 'Microsoft',
+    best_provider = IterListProvider(["CopilotApp", "CopilotAccount"])
+)
+
+study = Model(
+    name          = 'study',
+    base_provider = 'Microsoft',
+    best_provider = IterListProvider(["CopilotApp", "CopilotAccount"])
+)
+
+search = Model(
+    name          = 'search',
+    base_provider = 'Microsoft',
+    best_provider = IterListProvider(["CopilotApp", "CopilotAccount"])
+)
+
 # dall-e
 dall_e_3 = ImageModel(
     name = 'dall-e-3',

--- a/g4f/models.py
+++ b/g4f/models.py
@@ -243,31 +243,6 @@ gpt_oss_120b = Model(
     best_provider = IterListProvider(["Together", "HuggingFace", "OpenRouter", "Groq"])
 )
 
-# Copilot (Microsoft)
-smart = Model(
-    name          = 'smart',
-    base_provider = 'Microsoft',
-    best_provider = IterListProvider(["CopilotApp"])
-)
-
-reasoning = Model(
-    name          = 'reasoning',
-    base_provider = 'Microsoft',
-    best_provider = IterListProvider(["CopilotApp"])
-)
-
-study = Model(
-    name          = 'study',
-    base_provider = 'Microsoft',
-    best_provider = IterListProvider(["CopilotApp"])
-)
-
-search = Model(
-    name          = 'search',
-    base_provider = 'Microsoft',
-    best_provider = IterListProvider(["CopilotApp"])
-)
-
 # dall-e
 dall_e_3 = ImageModel(
     name = 'dall-e-3',

--- a/g4f/models.py
+++ b/g4f/models.py
@@ -839,17 +839,9 @@ def _get_best_providers(model: Model) -> List:
         return []
     
     if isinstance(model.best_provider, IterListProvider):
-        return model.best_provider.get_providers()
+        return model.best_provider.providers
 
-    if isinstance(model.best_provider, str):
-        try:
-            from .Provider import __getattr__
-            provider = __getattr__(model.best_provider)
-            return [provider] if getattr(provider, "working", False) else []
-        except AttributeError:
-            return []
-
-    return [model.best_provider] if getattr(model.best_provider, "working", False) else []
+    return [model.best_provider]
 
 # Generate __models__ using the auto-discovered models
 __models__ = {

--- a/g4f/models.py
+++ b/g4f/models.py
@@ -247,25 +247,25 @@ gpt_oss_120b = Model(
 smart = Model(
     name          = 'smart',
     base_provider = 'Microsoft',
-    best_provider = IterListProvider(["CopilotApp", "CopilotAccount", "Copilot"])
+    best_provider = IterListProvider(["CopilotApp"])
 )
 
 reasoning = Model(
     name          = 'reasoning',
     base_provider = 'Microsoft',
-    best_provider = IterListProvider(["CopilotApp", "CopilotAccount"])
+    best_provider = IterListProvider(["CopilotApp"])
 )
 
 study = Model(
     name          = 'study',
     base_provider = 'Microsoft',
-    best_provider = IterListProvider(["CopilotApp", "CopilotAccount"])
+    best_provider = IterListProvider(["CopilotApp"])
 )
 
 search = Model(
     name          = 'search',
     base_provider = 'Microsoft',
-    best_provider = IterListProvider(["CopilotApp", "CopilotAccount"])
+    best_provider = IterListProvider(["CopilotApp"])
 )
 
 # dall-e

--- a/g4f/providers/any_model_map.py
+++ b/g4f/providers/any_model_map.py
@@ -1,82 +1,77 @@
-audio_models = ['openai-audio']
-image_models = ['dall-e-3', 'gpt-image', 'sdxl-turbo', 'sd-3.5-large', 'flux', 'flux-pro', 'flux-dev', 'flux-schnell', 'flux-redux', 'flux-depth', 'flux-canny', 'flux-kontext', 'flux-dev-lora', 'gpt-image', 'flux', 'turbo', 'kontext', 'flux-kontext', 'sdxl-turbo', 'nanobanana', 'nanobanana-pro', 'seedream', 'seedream-pro', 'gpt-image', 'gpt-image-1.5', 'flux', 'z-image', '', 'flux-1.1-pro', 'flux.1-kontext-pro', 'qwen3-max-preview', 'qwen-plus-2025-09-11', 'qwen3-235b-a22b', 'qwen3-coder-plus', 'qwen3-30b-a3b', 'qwen3-coder-30b-a3b-instruct', 'qwen-max-latest', 'qwen-plus-2025-01-25', 'qwen-turbo-2025-02-11', 'qwen2.5-omni-7b', 'qwen2.5-vl-32b-instruct', 'qwen2.5-14b-instruct-1m', 'qwen2.5-coder-32b-instruct', 'qwen2.5-72b-instruct', 'black-forest-labs/FLUX.1-dev', 'black-forest-labs/FLUX.1-schnell', 'Qwen/Qwen-Image-2512', 'unsloth/Qwen-Image-2512-GGUF', 'Wuli-art/Qwen-Image-2512-Turbo-LoRA', 'Tongyi-MAI/Z-Image-Turbo', 'lightx2v/Qwen-Image-2512-Lightning', 'fal/FLUX.2-dev-Turbo', 'Phr00t/Qwen-Image-Edit-Rapid-AIO', 'inclusionAI/TwinFlow-Z-Image-Turbo', 'lodestones/Zeta-Chroma', 'stabilityai/stable-diffusion-xl-base-1.0', 'Qwen/Qwen-Image', 'flux-dev', 'flux-schnell', 'qwen-image-2512', 'qwen-image-2512-gguf', 'qwen-image-2512-turbo-lora', 'z-image-turbo', 'qwen-image-2512-lightning', 'flux.2-dev-turbo', 'qwen-image-edit-rapid-aio', 'twinflow-z-image-turbo', 'zeta-chroma', 'stable-diffusion-xl-base-1.0', 'qwen-image', 'Qwen/Qwen-Image-2512', 'Tongyi-MAI/Z-Image-Turbo', 'fal/FLUX.2-dev-Turbo', 'black-forest-labs/FLUX.1-dev', 'black-forest-labs/FLUX.1-schnell', 'stabilityai/stable-diffusion-xl-base-1.0', 'Qwen/Qwen-Image', 'stabilityai/stable-diffusion-3.5-large', 'lightx2v/Qwen-Image-Lightning', 'ByteDance/Hyper-SD', 'tarn59/pixel_art_style_lora_z_image_turbo', 'stabilityai/stable-diffusion-3-medium', 'Shakker-Labs/FLUX.1-dev-LoRA-Logo-Design', 'bdsqlsz/qinglong_DetailedEyes_Z-Image', 'Shakker-Labs/AWPortrait-Z', 'stabilityai/stable-diffusion-3-medium-diffusers', 'fofr/sdxl-emoji', 'XLabs-AI/flux-RealismLora', 'Seanwang1221/FanBingbing_FLUX', 'tencent/SRPO', 'olesheva/Photorealistic_Fashion_Magazine_Editorial_LoRA', 'ostris/zimage_turbo_training_adapter', 'meituan-longcat/LongCat-Image', 'sigstevens33/ASH', 'JunkieMonkey69/StefanieJoosten_ZimageTurbo', 'jusiflix/UltraRealisticInfluncer', 'nerijs/pixel-art-xl', 'ntc-ai/SDXL-LoRA-slider.pixel-art', 'ntc-ai/SDXL-LoRA-slider.asleep', 'ntc-ai/SDXL-LoRA-slider.sexy', 'ntc-ai/SDXL-LoRA-slider.unreal-engine', 'ntc-ai/SDXL-LoRA-slider.spritesheet', 'ByteDance/SDXL-Lightning', 'h1t/TCD-SDXL-LoRA', 'sWizad/pokemon-trainer-sprite-pixelart', 'Kwai-Kolors/Kolors', 'wonwizard/flux_lora_cute_korean_girl', 'prithivMLmods/Canopus-Pixar-3D-Flux-LoRA', 'UmeAiRT/FLUX.1-dev-LoRA-Modern_Pixel_art', 'AlekseyCalvin/Alexander_BLOK_Flux_LoRA_SilverAgePoets_v1', 'martintomov/ecom-flux-v2', 'stabilityai/stable-diffusion-3.5-large-turbo', 'Keltezaa/kirsten-dunst-actress-2000s-flux', 'stabilityai/stable-diffusion-3.5-medium', 'gokaygokay/Flux-Seamless-Texture-LoRA', 'gokaygokay/Flux-2D-Game-Assets-LoRA', 'glif-loradex-trainer/bulbul_VST_Plugin', 'prithivMLmods/Retro-Pixel-Flux-LoRA', 'strangerzonehf/Flux-Ultimate-LoRA-Collection', 'AlekseyCalvin/Sergey_Esenin_Poet_FluxLoRA_BySilverAgePoets', 'Keltezaa/jennifer-garner-mid-2000s', 'SedatAl/Interior-Flux-Lora', 'Alpha-VLLM/Lumina-Image-2.0', 'HiDream-ai/HiDream-I1-Full', 'Seanwang1221/Yangmi_SD15_FLUX', 'sokoloveai/flux.1-consistent-character-anna', 'flymy-ai/qwen-image-realism-lora', 'rorito/Insw', 'TheRaf7/ultra-real-wan2.2', 'pictgensupport/vintagejapanesematchbooks', 'flymy-ai/qwen-image-anime-irl-lora', 'Lingyuzhou/Qwen_majic_beauty', 'prithivMLmods/Qwen-Image-Studio-Realism', 'tencent/HunyuanImage-2.1', 'Daverrrr75/Qwen-Lora-Lenovo-Ultrareal', 'Daverrrr75/Qwen-Remove-Clothing', 'renderartist/saturday-morning-qwen', 'briaai/FIBO', 'wolfer45/qwen4play-v2', 'AIDC-AI/Ovis-Image-7B', 'renderartist/Technically-Color-Z-Image-Turbo', 'Danrisi/Lenovo_UltraReal_Z_Image', 'wcde/Z-Image-Turbo-DeJPEG-Lora', 'renderartist/Classic-Painting-Z-Image-Turbo-LoRA', 'AlekseyCalvin/Marionette_Modernism_Z-image-Turbo_LoRA', 'bunnycore/Z-Art-2.1', 'Ttio2/Z-Image-Turbo-pencil-sketch', 'Norton0924/pixel_art_style_lora_z_image_turbo', 'cptsl/NipplePokies', 'cptsl/DetailSlider', 'Sumitc13/Z-image-Turbo_LogC4_lora', 'RomixERR/Age_Slider_Z-Images-turbo', 'RomixERR/Pornmaster_v1-Z-Images-Turbo', 'JunkieMonkey69/Chaseinfinity_ZimageTurbo', 'cptsl/MysticXXXv4', 'ABDALLALSWAITI/Spectra-Etch', 'JunkieMonkey69/BarbaraPalvin_ZimageTurbo', 'Rido567/ame_Z-Image_1000', 'ABDALLALSWAITI/aimaginedworlds', 'je-suis-tm/wong_kar_wai_fallen_angels_lora_flux', 'je-suis-tm/wong_kar_wai_fallen_angels_lora_flux2_nf4', 'je-suis-tm/wong_kar_wai_my_blueberry_nights_lora_flux', 'je-suis-tm/pachu_torres_style_lora_flux', 'enhanceaiteam/Flux-uncensored', 'starsfriday/Qwen-Image-NSFW', 'CultriX/flux-nsfw-highress', 'Ryouko65777/Flux-Uncensored-V2', 'lustlyai/Flux_Lustly.ai_Uncensored_nsfw_v1', 'imagepipeline/flux_uncensored_nsfw_v2', 'Hoshino-Yumetsuki/qwen-image-anime-nsfw-lora', 'wolfer45/mystic-xxx-zit-v4', 'wolfer45/nsfw-zit', 'qwen-image-2512', 'z-image-turbo', 'flux.2-dev-turbo', 'flux-dev', 'flux-schnell', 'stable-diffusion-xl-base-1.0', 'qwen-image', 'sd-3.5-large', 'qwen-image-lightning', 'hyper-sd', 'pixel.art.style.lora.z.image.turbo', 'stable-diffusion-3-medium', 'flux-dev-lora-logo-design', 'qinglong.detailedeyes.z-image', 'awportrait-z', 'stable-diffusion-3-medium-diffusers', 'sdxl-emoji', 'flux-realismlora', 'fanbingbing.flux', 'srpo', 'photorealistic.fashion.magazine.editorial.lora', 'zimage.turbo.training.adapter', 'longcat-image', 'ash', 'stefaniejoosten.zimageturbo', 'ultrarealisticinfluncer', 'pixel-art-xl', 'sdxl-lora-slider.pixel-art', 'sdxl-lora-slider.asleep', 'sdxl-lora-slider.sexy', 'sdxl-lora-slider.unreal-engine', 'sdxl-lora-slider.spritesheet', 'sdxl-lightning', 'tcd-sdxl-lora', 'pokemon-trainer-sprite-pixelart', 'kolors', 'flux.lora.cute.korean.girl', 'canopus-pixar-3d-flux-lora', 'flux-dev-lora-modern.pixel.art', 'alexander.blok.flux.lora.silveragepoets.v1', 'ecom-flux', 'sd-3.5-large-turbo', 'kirsten-dunst-actress-2000s-flux', 'stable-diffusion-3.5-medium', 'flux-seamless-texture-lora', 'flux-2d-game-assets-lora', 'bulbul.vst.plugin', 'retro-pixel-flux-lora', 'flux-ultimate-lora-collection', 'sergey.esenin.poet.fluxlora.bysilveragepoets', 'jennifer-garner-mid-2000s', 'interior-flux-lora', 'lumina-image-2.0', 'hidream-i1-full', 'yangmi.sd15.flux', 'flux-consistent-character-anna', 'qwen-image-realism-lora', 'insw', 'ultra-real-wan2.2', 'vintagejapanesematchbooks', 'qwen-image-anime-irl-lora', 'qwen-.majic.beauty', 'qwen-image-studio-realism', 'hunyuanimage-2.1', 'qwen-lora-lenovo-ultrareal', 'qwen-remove-clothing', 'saturday-morning-qwen-', 'fibo', 'qwen-4play', 'ovis-image-7b', 'technically-color-z-image-turbo', 'lenovo.ultrareal.z.image', 'z-image-turbo-dejpeg-lora', 'classic-painting-z-image-turbo-lora', 'marionette.modernism.z-image-turbo.lora', 'z-art-2.1', 'z-image-turbo-pencil-sketch', 'pixel.art.style.lora.z.image.turbo', 'nipplepokies', 'detailslider', 'z-image-turbo.logc4.lora', 'age.slider.z-images-turbo', 'pornmaster.v1-z-images-turbo', 'chaseinfinity.zimageturbo', 'mysticxxxv4', 'spectra-etch', 'barbarapalvin.zimageturbo', 'ame.z-image.1000', 'aimaginedworlds', 'wong.kar.wai.fallen.angels.lora.flux', 'wong.kar.wai.fallen.angels.lora.flux2.nf4', 'wong.kar.wai.my.blueberry.nights.lora.flux', 'pachu.torres.style.lora.flux', 'flux-uncensored', 'qwen-image-nsfw', 'flux-nsfw-highress', 'flux-uncensored', 'flux.lustly.ai.uncensored.nsfw.v1', 'flux.uncensored.nsfw.v2', 'qwen-image-anime-nsfw-lora', 'mystic-xxx-zit', 'nsfw-zit', 'hunyuan-image-3.0', 'tangerine', 'vidu-q2-image', 'mai-image-1', 'imagen-4.0-fast-generate-001', 'flux-2-pro', 'recraft-v3', 'flux-2-flex', 'imagen-3.0-generate-002', 'gemini-3-pro-image-preview-4k (nano-banana-pro)', 'photon', 'z-image', 'flux-2-flex-20251231', 'imagen-4.0-ultra-generate-001', 'gemini-3-pro-image-preview-2k (nano-banana-pro)', 'flux-2-dev', 'imagen-4.0-generate-001', 'flux-2-pro-20251231', 'flux-2-max', 'gpt-image-1-high-fidelity', 'qwen-image-prompt-extend', 'flux-2-dev-20251222', 'flux-1-kontext-max', 'flux-2-max-20251222', 'qwen-image-edit', 'hazel-gen-2', 'seededit-3.0', 'ideogram-v3-quality', 'hunyuan-image-2.1', 'hazel-gen-4', 'qwen-image-2512', 'wan2.5-t2i-preview', 'hidream-e1.1', 'reve-v1.1', 'chatgpt-image-latest (20251216)', 'seedream-4.5', 'hunyuan-image-3.0-fal', 'gpt-image-1-mini', 'dall-e-3', 'qwen-image-edit-2511', 'reve-v1.1-fast', 'gpt-image-1', 'gemini-2.0-flash-preview-image-generation', 'gemini-2.5-flash-image-preview (nano-banana)', 'seedream-3', 'seedream-4-high-res-fal', 'gpt-image-1.5', 'wan2.5-preview', 'flux-1-kontext-pro', 'wan2.5-i2i-preview', 'flux-1-kontext-dev', 'lucid-origin', 'gemini-3-pro-image-preview (nano-banana-pro)', 'hunyuan-image-3.0', 'tangerine', 'vidu-q2-image', 'mai-image-1', 'imagen-4.0-fast-generate', 'flux-2-pro', 'recraft', 'flux-2-flex', 'imagen-3.0-generate', 'gemini-3-pro-image-preview-4k (nano-banana-pro)', 'photon', 'z-image', 'flux-2-flex', 'imagen-4.0-ultra-generate', 'gemini-3-pro-image-preview-2k (nano-banana-pro)', 'flux-2-dev', 'imagen-4.0-generate', 'flux-2-pro', 'flux-2-max', 'gpt-image-1-high-fidelity', 'qwen-image-prompt-extend', 'flux-2-dev', 'flux-1-kontext-max', 'flux-2-max', 'qwen-image-edit', 'hazel-gen-2', 'seededit-3.0', 'ideogram-v3-quality', 'hunyuan-image-2.1', 'hazel-gen-4', 'qwen-image-2512', 'wan2.5-t2i', 'hidream-e1.1', 'reve-v1.1', 'chatgpt-image (20251216)', 'seedream-4.5', 'hunyuan-image-3.0-fal', 'gpt-image-1-mini', 'dall-e-3', 'qwen-image-edit-2511', 'reve-v1.1-fast', 'gpt-image-1', 'gemini-2.0-flash-preview-image-generation', 'gemini-2.5-flash-image-preview (nano-banana)', 'seedream-3', 'seedream-4-high-res-fal', 'gpt-image-1.5', 'wan2.5', 'flux-1-kontext-pro', 'wan2.5-i2i', 'flux-1-kontext-dev', 'lucid-origin', 'gemini-3-pro-image-preview (nano-banana-pro)', 'flux-dev', 'flux', 'flux-kontext-dev', 'sd-3.5-large', 'janus-pro-7b-image', 'flux-dev', 'flux', 'flux-kontext-dev', 'sd-3.5-large', 'janus-pro-7b-image']
-vision_models = ['gpt-5-2', 'gpt-5-2-instant', 'gpt-5-2-thinking', 'gpt-5-1', 'gpt-5-1-instant', 'gpt-5-1-thinking', 'gpt-5', 'gpt-5-instant', 'gpt-5-thinking', 'gpt-4', 'gpt-4.1', 'gpt-4.1-mini', 'gpt-4.5', 'gpt-4o', 'gpt-4o-mini', 'o1', 'o1-mini', 'o3-mini', 'o3-mini-high', 'o4-mini', 'o4-mini-high', 'openai', 'gpt-4.1', 'o4-mini', 'model-router', 'flux.1-kontext-pro', 'qwen3-max-preview', 'qwen-plus-2025-09-11', 'qwen3-235b-a22b', 'qwen3-coder-plus', 'qwen3-30b-a3b', 'qwen3-coder-30b-a3b-instruct', 'qwen-max-latest', 'qwen-plus-2025-01-25', 'qwen-turbo-2025-02-11', 'qwen2.5-omni-7b', 'qvq-72b-preview-0310', 'qwen2.5-vl-32b-instruct', 'qwen2.5-14b-instruct-1m', 'qwen2.5-coder-32b-instruct', 'qwen2.5-72b-instruct', 'openai/gpt-oss-120b', 'meta-llama/Llama-3.2-90B-Vision-Instruct', 'openai/gpt-oss-120b', 'openai/gpt-oss-20b', 'gpt-oss-120b', 'llama-3.2-90b-vision', 'gpt-oss-120b', 'gpt-oss-20b', 'meta-llama/Llama-3.2-11B-Vision-Instruct', 'Qwen/Qwen2-VL-7B-Instruct', 'llama-3.2-11b-vision', 'qwen-2-vl-7b', 'gemini-2.5-flash', 'gpt-4.1-2025-04-14', 'mistral-small-3.1-24b-instruct-2503', 'qwen3-vl-8b-thinking', 'qwen3-vl-8b-instruct', 'mistral-medium-2505', 'hunyuan-vision-1.5-thinking', 'EB45-turbo-vl-0906', 'llama-4-maverick-17b-128e-instruct', 'gemini-2.5-flash-lite-preview-06-17-thinking', 'mistral-small-2506', 'grok-4-0709', 'gemini-3-flash', 'phantom-mm-1125-1', 'gemini-2.0-flash-001', 'amazon.nova-pro-v1:0', 'raptor-0107', 'gpt-5-high-no-system-prompt', 'EB45-vision', 'mistral-medium-2508', 'gemini-3-flash (thinking-minimal)', 'glm-4.5v', 'raptor-vision-1015', 'glm-4.6v', 'kiwi-do', 'gpt-5.2-high', 'anonymous-1111', 'gpt-5.1', 'gpt-5.2', 'glm-4.6v-flash', 'gemini-3-flash', 'gpt-5-chat', 'gemini-2.5-pro', 'ernie-5.0-preview-1220', 'omg-wow', 'raptor-1119', 'raptor', 'gemini-2.5-flash-lite-preview-09-2025-no-thinking', 'gemini-2.5-flash-preview-09-2025', 'qwen3-vl-235b-a22b-instruct', 'gpt-4.1-mini-2025-04-14', 'qwen3-vl-235b-a22b-thinking', 'qwen3-omni-flash', 'stephen-vision-csfix', 'raptor-1124', 'raptor-1123', 'step-3-mini-2511', 'chatgpt-4o-latest-20250326', 'ernie-exp-vl-251016', 'qwen-vl-max-2025-08-13', 'step-3', 'gemini-3-pro', 'gemma-3-27b-it', 'gpt-5-high', 'ernie-5.0-preview-1120', 'nightride-on', 'nightride-on-v2', 'o3-2025-04-16', 'aegis-core', 'gpt-5.1-high', 'raptor-vision-1107', 'o4-mini-2025-04-16', 'gpt-5-mini-high', 'gpt-5-nano-high', 'gpt-5-high-new-system-prompt', 'MiMo-VL-7B-RL-2508', 'raptor-1.8-1208', 'vidu-q2-image', 'flux-2-pro', 'flux-2-flex', 'gemini-3-pro-image-preview-4k (nano-banana-pro)', 'flux-2-flex-20251231', 'gemini-3-pro-image-preview-2k (nano-banana-pro)', 'flux-2-dev', 'flux-2-pro-20251231', 'flux-2-max', 'gpt-image-1-high-fidelity', 'flux-2-dev-20251222', 'flux-1-kontext-max', 'flux-2-max-20251222', 'qwen-image-edit', 'seededit-3.0', 'hidream-e1.1', 'reve-v1.1', 'chatgpt-image-latest (20251216)', 'seedream-4.5', 'gpt-image-1-mini', 'qwen-image-edit-2511', 'reve-v1.1-fast', 'gpt-image-1', 'gemini-2.0-flash-preview-image-generation', 'gemini-2.5-flash-image-preview (nano-banana)', 'seedream-4-high-res-fal', 'gpt-image-1.5', 'flux-1-kontext-pro', 'wan2.5-i2i-preview', 'flux-1-kontext-dev', 'gemini-3-pro-image-preview (nano-banana-pro)', 'gemini-3-pro-grounding', 'seedance-v1.5-pro', 'wan2.5-t2v-preview', 'ray-3', 'hailuo-02-standard', 'hunyuan-video-1.5', 'kling-2.6-pro', 'veo-3-fast', 'veo-2', 'veo-3', 'hailuo-02-pro', 'hailuo-02-fast', 'hailuo-2.3-fast', 'veo-3-audio', 'seedance-v1-lite', 'veo-3-fast-audio', 'seedance-v1-pro', 'kling-v2.1-standard', 'pika-v2.2', 'runway-gen4-turbo', 'kling-v2.1-master', 'wan-v2.2-a14b', 'kling-2.5-turbo-1080p', 'wan2.5-i2v-preview', 'veo-3.1-audio', 'veo-3.1-fast-audio', 'hailuo-2.3', 'ray2', 'gemini-2.5-flash', 'gpt-4.1', 'mistral-small-3.1-24b-2503', 'qwen-3-vl-8b-thinking', 'qwen-3-vl-8b', 'mistral-medium-2505', 'hunyuan-vision-1.5-thinking', 'eb45-turbo-vl-0906', 'llama-4-maverick-17b-128e', 'gemini-2.5-flash-lite-preview-thinking', 'mistral-small-2506', 'grok-4-0709', 'gemini-3-flash', 'phantom-mm-1125-1', 'gemini-2.0-flash', 'amazon.nova-pro', 'raptor-0107', 'gpt-5-high-no-system-prompt', 'eb45-vision', 'mistral-medium-2508', 'gemini-3-flash (thinking-minimal)', 'glm-4.5v', 'raptor-vision-1015', 'glm-4.6v', 'kiwi-do', 'gpt-5.2-high', 'anonymous-1111', 'gpt-5.1', 'gpt-5.2', 'glm-4.6v-flash', 'gemini-3-flash', 'gpt-5-chat', 'gemini-2.5-pro', 'ernie-5.0-preview-1220', 'omg-wow', 'raptor-1119', 'raptor', 'gemini-2.5-flash-lite-preview25-no-thinking', 'gemini-2.5-flash-preview25', 'qwen-3-vl-235b-a22b', 'gpt-4.1-mini', 'qwen-3-vl-235b-a22b-thinking', 'qwen-3-omni-flash', 'stephen-vision-csfix', 'raptor-1124', 'raptor-1123', 'step-3-mini-2511', 'chatgpt-4o', 'ernie-exp-vl-251016', 'qwen-vl-max', 'step-3', 'gemini-3-pro', 'gemma-3-27b-it', 'gpt-5-high', 'ernie-5.0-preview-1120', 'nightride-on', 'nightride-on', 'o3', 'aegis-core', 'gpt-5.1-high', 'raptor-vision-1107', 'o4-mini', 'gpt-5-mini-high', 'gpt-5-nano-high', 'gpt-5-high-new-system-prompt', 'mimo-vl-7b-rl-2508', 'raptor-1.8-1208', 'vidu-q2-image', 'flux-2-pro', 'flux-2-flex', 'gemini-3-pro-image-preview-4k (nano-banana-pro)', 'flux-2-flex', 'gemini-3-pro-image-preview-2k (nano-banana-pro)', 'flux-2-dev', 'flux-2-pro', 'flux-2-max', 'gpt-image-1-high-fidelity', 'flux-2-dev', 'flux-1-kontext-max', 'flux-2-max', 'qwen-image-edit', 'seededit-3.0', 'hidream-e1.1', 'reve-v1.1', 'chatgpt-image (20251216)', 'seedream-4.5', 'gpt-image-1-mini', 'qwen-image-edit-2511', 'reve-v1.1-fast', 'gpt-image-1', 'gemini-2.0-flash-preview-image-generation', 'gemini-2.5-flash-image-preview (nano-banana)', 'seedream-4-high-res-fal', 'gpt-image-1.5', 'flux-1-kontext-pro', 'wan2.5-i2i', 'flux-1-kontext-dev', 'gemini-3-pro-image-preview (nano-banana-pro)', 'gemini-3-pro-grounding', 'seedance-v1.5-pro', 'wan2.5-t2v', 'ray-3', 'hailuo-02-standard', 'hunyuan-video-1.5', 'kling-2.6-pro', 'veo-3-fast', 'veo-2', 'veo-3', 'hailuo-02-pro', 'hailuo-02-fast', 'hailuo-2.3-fast', 'veo-3-audio', 'seedance-v1-lite', 'veo-3-fast-audio', 'seedance-v1-pro', 'kling-v2.1-standard', 'pika-v2.2', 'runway-gen4-turbo', 'kling-v2.1-master', 'wan-v2.2-a14b', 'kling-2.5-turbo-1080p', 'wan2.5-i2v', 'veo-3.1-audio', 'veo-3.1-fast-audio', 'hailuo-2.3', 'ray2', 'gpt-4.1', 'gpt-4.1-mini', 'gpt-4.1-nano', 'gpt-4.5-preview', 'gpt-4o', 'gpt-4o-mini', 'gpt-5-2025-08-07', 'gpt-5-chat-latest', 'gpt-5-mini-2025-08-07', 'gpt-5-nano-2025-08-07', 'gpt-5.1', 'gpt-5.1-chat-latest', 'gpt-5.1-codex', 'gpt-5.1-codex-max', 'gpt-5.1-codex-mini', 'gpt-5.2-2025-12-11', 'gpt-5.2-chat-latest', 'gpt-5.2-pro-2025-12-11', 'grok-2-vision', 'grok-vision-beta', 'o1', 'o1-mini', 'o1-pro', 'o3', 'o3-mini', 'o3-pro', 'o4-mini', 'phi-4-multimodal', 'openrouter:meta-llama/llama-3.2-11b-vision-instruct', 'openrouter:meta-llama/llama-3.2-90b-vision-instruct', 'openrouter:microsoft/phi-4-multimodal-instruct', 'openrouter:openai/chatgpt-4o-latest', 'openrouter:openai/gpt-3.5-turbo', 'openrouter:openai/gpt-3.5-turbo-0613', 'openrouter:openai/gpt-3.5-turbo-16k', 'openrouter:openai/gpt-3.5-turbo-instruct', 'openrouter:openai/gpt-4', 'openrouter:openai/gpt-4-0314', 'openrouter:openai/gpt-4-1106-preview', 'openrouter:openai/gpt-4-turbo', 'openrouter:openai/gpt-4-turbo-preview', 'openrouter:openai/gpt-4.1', 'openrouter:openai/gpt-4.1-mini', 'openrouter:openai/gpt-4.1-nano', 'openrouter:openai/gpt-4o', 'openrouter:openai/gpt-4o-2024-05-13', 'openrouter:openai/gpt-4o-2024-08-06', 'openrouter:openai/gpt-4o-2024-11-20', 'openrouter:openai/gpt-4o-audio-preview', 'openrouter:openai/gpt-4o-mini', 'openrouter:openai/gpt-4o-mini-2024-07-18', 'openrouter:openai/gpt-4o-mini-search-preview', 'openrouter:openai/gpt-4o-search-preview', 'openrouter:openai/gpt-4o:extended', 'openrouter:openai/gpt-5', 'openrouter:openai/gpt-5-chat', 'openrouter:openai/gpt-5-codex', 'openrouter:openai/gpt-5-image', 'openrouter:openai/gpt-5-image-mini', 'openrouter:openai/gpt-5-mini', 'openrouter:openai/gpt-5-nano', 'openrouter:openai/gpt-5-pro', 'openrouter:openai/gpt-5.1', 'openrouter:openai/gpt-5.1-chat', 'openrouter:openai/gpt-5.1-codex', 'openrouter:openai/gpt-5.1-codex-max', 'openrouter:openai/gpt-5.1-codex-mini', 'openrouter:openai/gpt-5.2', 'openrouter:openai/gpt-5.2-chat', 'openrouter:openai/gpt-5.2-pro', 'openrouter:openai/gpt-oss-120b', 'openrouter:openai/gpt-oss-120b:exacto', 'openrouter:openai/gpt-oss-120b:free', 'openrouter:openai/gpt-oss-20b', 'openrouter:openai/gpt-oss-20b:free', 'openrouter:openai/gpt-oss-safeguard-20b', 'openrouter:openai/o1', 'openrouter:openai/o1-pro', 'openrouter:openai/o3', 'openrouter:openai/o3-deep-research', 'openrouter:openai/o3-mini', 'openrouter:openai/o3-mini-high', 'openrouter:openai/o3-pro', 'openrouter:openai/o4-mini', 'openrouter:openai/o4-mini-deep-research', 'openrouter:openai/o4-mini-high', 'openrouter:sao10k/l3-euryale-70b', 'openrouter:sao10k/l3-lunaris-8b', 'openrouter:sao10k/l3.1-70b-hanami-x1', 'openrouter:sao10k/l3.1-euryale-70b', 'openrouter:sao10k/l3.3-euryale-70b', 'gpt-4.1', 'gpt-4.1-mini', 'gpt-4.1-nano', 'gpt-4.5', 'gpt-4o', 'gpt-4o-mini', 'gpt-5', 'gpt-5-chat', 'gpt-5-mini', 'gpt-5-nano', 'gpt-5.1', 'gpt-5.1-chat', 'gpt-5.1-codex', 'gpt-5.1-codex-max', 'gpt-5.1-codex-mini', 'gpt-5.2', 'gpt-5.2-chat', 'gpt-5.2-pro', 'grok-2-vision', 'grok-vision-beta', 'o1', 'o1-mini', 'o1-pro', 'o3', 'o3-mini', 'o3-pro', 'o4-mini', 'phi-4-multimodal', 'llama-3.2-11b-vision', 'llama-3.2-90b-vision', 'phi-4-multimodal', 'chatgpt-4o', 'gpt-3.5-turbo', 'gpt-3.5-turbo-0613', 'gpt-3.5-turbo-16k', 'gpt-3.5-turbo', 'gpt-4', 'gpt-4-0314', 'gpt-4-1106', 'gpt-4-turbo', 'gpt-4-turbo', 'gpt-4.1', 'gpt-4.1-mini', 'gpt-4.1-nano', 'gpt-4o', 'gpt-4o', 'gpt-4o', 'gpt-4o', 'gpt-4o-audio', 'gpt-4o-mini', 'gpt-4o-mini', 'gpt-4o-mini-search', 'gpt-4o-search', 'gpt-4o', 'gpt-5', 'gpt-5-chat', 'gpt-5-codex', 'gpt-5-image', 'gpt-5-image-mini', 'gpt-5-mini', 'gpt-5-nano', 'gpt-5-pro', 'gpt-5.1', 'gpt-5.1-chat', 'gpt-5.1-codex', 'gpt-5.1-codex-max', 'gpt-5.1-codex-mini', 'gpt-5.2', 'gpt-5.2-chat', 'gpt-5.2-pro', 'gpt-oss-120b', 'gpt-oss-120b', 'gpt-oss-120b', 'gpt-oss-20b', 'gpt-oss-20b', 'gpt-oss-safeguard-20b', 'o1', 'o1-pro', 'o3', 'o3-deep-research', 'o3-mini', 'o3-mini-high', 'o3-pro', 'o4-mini', 'o4-mini-deep-research', 'o4-mini-high', 'l3-euryale-70b', 'l3-lunaris-8b', 'l3.1-70b-hanami-x1', 'l3.1-euryale-70b', 'l3.3-euryale-70b', 'janus-pro-7b', 'phi-4-multimodal', 'janus-pro-7b', 'phi-4-multimodal']
-video_models = ['veo-3.1-fast', 'seedance', 'seedance-pro', 'tencent/HunyuanVideo-1.5', 'meituan-longcat/LongCat-Video', 'Wan-AI/Wan2.2-T2V-A14B', 'Wan-AI/Wan2.1-T2V-1.3B', 'tencent/HunyuanVideo', 'Wan-AI/Wan2.2-TI2V-5B', 'Wan-AI/Wan2.2-T2V-A14B-Diffusers', 'zai-org/CogVideoX-5b', 'genmo/mochi-1-preview', 'Wan-AI/Wan2.1-T2V-14B', 'htdong/Wan-Alpha', 'hunyuanvideo-1.5', 'longcat-video', 'wan2.2-t2v-a14b', 'wan2.1-t2v-1.3b', 'hunyuanvideo', 'wan2.2-ti2v-5b', 'wan2.2-t2v-a14b-diffusers', 'cogvideox-5b', 'mochi-1', 'wan2.1-t2v-14b', 'wan-alpha', 'video', 'video']
+audio_models = ['openai-audio', 'openai-audio-large']
+image_models = ['dall-e-3', 'gpt-image', 'sdxl-turbo', 'sd-3.5-large', 'flux', 'flux-pro', 'flux-dev', 'flux-schnell', 'flux-redux', 'flux-depth', 'flux-canny', 'flux-kontext', 'flux-dev-lora', 'gpt-image', 'sana', 'gemini-3.5-flash', 'qwen3.7-plus', 'qwen3.7-max', 'qwen3.6-plus', 'qwen3.6-27b', 'qwen3.5-plus', 'qwen3.5-omni-plus', 'qwen3.6-35b-a3b', 'qwen3.5-flash', 'qwen3.5-397b-a17b', 'qwen3.5-122b-a10b', 'qwen3.5-omni-flash', 'qwen3.5-27b', 'qwen3.5-35b-a3b', 'qwen3-max-2026-01-23', 'qwen-plus-2025-07-28', 'qwen3-coder-plus', 'qwen3-vl-plus', 'qwen3-omni-flash-2025-12-01', 'black-forest-labs/FLUX-2-klein-4b', 'black-forest-labs/FLUX-2-klein-9b', 'flux-2-klein-4b', 'flux-2-klein-9b', 'black-forest-labs/FLUX.1-dev', 'black-forest-labs/FLUX.1-schnell', 'krea/Krea-2-Turbo', 'krea/Krea-2-Raw', 'AlperKTS/Krea2_FP8', 'ideogram-ai/ideogram-4-fp8', 'Tongyi-MAI/Z-Image-Turbo', 'vantagewithai/Krea-2-Turbo-GGUF', 'ostris/ideogram_4_turbotime_lora', 'krea/Krea-2-LoRA-retroanime', 'ideogram-ai/ideogram-4-nf4', 'Phr00t/Qwen-Image-Edit-Rapid-AIO', 'gokaygokay/Krea-2-Realism-LoRA', 'ponpoke/flux2-klein-9b-uncensored-text-encoder', 'flux-dev', 'flux-schnell', 'krea-2-turbo', 'krea-2-raw', 'krea2.fp8', 'ideogram-4', 'z-image-turbo', 'krea-2-turbo-gguf', 'ideogram.4.turbotime.lora', 'krea-2-lora-retroanime', 'ideogram-4-nf4', 'qwen-image-edit-rapid-aio', 'krea-2-realism-lora', 'flux2-klein-9b-uncensored-text-encoder', 'krea/Krea-2-Turbo', 'black-forest-labs/FLUX.1-dev', 'ideogram-ai/ideogram-4-fp8', 'Tongyi-MAI/Z-Image-Turbo', 'ostris/ideogram_4_turbotime_lora', 'krea/Krea-2-LoRA-retroanime', 'black-forest-labs/FLUX.1-schnell', 'stabilityai/stable-diffusion-xl-base-1.0', 'krea/Krea-2-LoRA-darkbrush', 'krea/Krea-2-LoRA-sunsetblur', 'krea/Krea-2-LoRA-neondrip', 'krea/Krea-2-LoRA-vintagetarot', 'Qwen/Qwen-Image', 'baidu/ERNIE-Image', 'ostris/ideogram_4_unconditional_lora', 'krea/Krea-2-LoRA-dotmatrix', 'krea/Krea-2-LoRA-softwatercolor', 'krea/Krea-2-LoRA-kidsdrawing', 'victor/Krea-2-LoRA-magritte', 'Tongyi-MAI/Z-Image', 'krea/Krea-2-LoRA-rainywindow', 'ostris/krea2_turbo_training_adapter', 'baidu/ERNIE-Image-Turbo', 'stabilityai/stable-diffusion-3.5-medium', 'DeverStyle/Ideogram-4.0-Loras', 'fal/FLUX.2-dev-Turbo', 'Qwen/Qwen-Image-2512', 'AIImageStudio/RadianceChromeVoluptuous_Krea2Turbo_v1.0', 'stabilityai/stable-diffusion-3.5-large', 'jmanhype/VHS-Rally-95-LoRA-v1-Ideogram-v4', 'nerijs/pixel-art-xl', 'AunyMoons/loras-pack', 'stabilityai/stable-diffusion-3-medium', 'stabilityai/stable-diffusion-3.5-large-turbo', 'ostris/zimage_turbo_training_adapter', 'jarod2212/Aetheria_Moonlight_Shadow', 'jarod2212/PrimalFashion_SaharaBloom', 'jarod2212/Primal_Fashion_Egyptian_Muse', 'DeverStyle/Krea2-Loras', 'ntc-ai/SDXL-LoRA-slider.great-lighting', 'ntc-ai/SDXL-LoRA-slider.cinematic-lighting', 'Blib-la/caricature_lora_sdxl', 'MarkBW/hannahowo-xl', 'MarkBW/vault-suit-pony-xl', 'MarkBW/olivia-casta-xl', 'MarkBW/smoking-xl', 'MarkBW/knit-sweaterdress-xl', 'MarkBW/deep-neckline-xl', 'MarkBW/sofilein-xl', 'MarkBW/elizabeth-lauren-xl', 'jasperai/flash-sdxl', 'MarkBW/robot-torso-xl', 'MarkBW/emily-bloom2-xl', 'MarkBW/skin-freckles-xl', 'MarkBW/mia-khalifa-xl', 'MarkBW/breckie-hill-xl', 'MarkBW/lily-brown-xl', 'MarkBW/handbra-xl', 'fofr/sdxl-emoji', 'MarkBW/polaroid-filmstyle-xl', 'MarkBW/kaellyn-xl', 'MarkBW/phone-exposure-xl', 'MarkBW/sarang-xl', 'MarkBW/neon-gothic-xl', 'MarkBW/berry0314-pony-xl', 'MarkBW/berry0314-xl', 'jack1101/kpopiu', 'busetolunay/building_flux_lora_v1', 'Shakker-Labs/FLUX.1-dev-LoRA-Logo-Design', 'furaidosu/flux-lora-simple-vector', 'gokaygokay/Flux-White-Background-LoRA', 'Shakker-Labs/FLUX.1-dev-LoRA-Text-Poster', 'gokaygokay/Flux-Double-Exposure-LoRA', 'prithivMLmods/Retro-Pixel-Flux-LoRA', 'gokaygokay/Flux-Realistic-Backgrounds-LoRA', 'strangerzonehf/Flux-Midjourney-Mix2-LoRA', 'data-is-better-together/open-image-preferences-v1-flux-dev-lora', 'mrcuddle/live2d-model-maker', 'AiWise/Detail-Tweaker-XL_v1', 'WiroAI/GTA6-style-flux-lora', 'Keltezaa/katherine-heigl-90s-flux', 'Keltezaa/kate-beckinsale-flux', 'Jonjew/MelissaBenoist', 'Jonjew/MaureenMcCormickMarciaBrady', 'Grahcev/juliette_style_LoRA', 'Jonjew/EvanRachelWood', 'shreenithi20/flux_lora_sketch_style', 'Seanwang1221/Dilraba_FLUX', 'Seanwang1221/Yangmi_SD15_FLUX', 'Rempeyek/Woman_Cloth_XL', 'gokaygokay/Flux-Krea-Realism-LoRA', 'rzgar/fortnite_style_flux_kontext', 'lightx2v/Qwen-Image-Lightning', 'starsfriday/Qwen-Image-EVA-LoRA', 'Muapi/flux-frank-frazetta-style-oil-painting', 'Muapi/game-assets-cartoon-style-3d-isometric-background-assets-for-small-games-flux', 'Muapi/toonfusion-style-ilxl-ponyxl-flux', 'Muapi/iconic-jessica-rabbit', 'Shakker-Labs/AWPortrait-QW', 'Edweibin/flux-dev-nfsw', 'Muapi/clash-royale-style-flux-lora', 'ostris/qwen_image_detail_slider', 'briaai/FIBO', 'Manishsahu53/flux-kontext-fashion-extractor', 'ApathyGhost/EmoElin', 'tarn59/pixel_art_style_lora_z_image_turbo', 'DeverStyle/Z-Image-loras', 'cahlen/black-metal-art-sdxl-lora', 'mikkoph/mikkoph-zimage-turbo', 'NucleusAI/Nucleus-Image', 'Heouzen/LoKR_mc_woman_FLUX1D', 'Bruece/FLUX.1-dev-CMO', 'Muapi/sxz-3d-render-plastic-shader-flux', 'Muapi/fuko-from-undead-unluck', 'Herthu99/Mikahhzimg', 'jarod2212/NeuroSpin_ZIT', 'Muapi/envy-flux-toon-01', 'Muapi/nobody_7-pale-female-uncensored-flux1.d', 'Muapi/game-icon', 'jarod2212/RebelEssence_Grunge_Edition', 'jmanhype/Ektachrome-LoRA-v1-Ideogram-v4', 'Muapi/final-fantasy-concept-art-style-flux', 'Muapi/flux_3d-cartoon', 'Danish1212/pakistani-truck-art-sdxl-lora', 'jarod2212/Rebel_Essence_Emo_Version', 'jarod2212/Rebel_Essence_Bikers', 'Muapi/picture-story-book-for-children-xl-xl', 'Muapi/game-casual-characters', 'Muapi/backtoon-simple-cartoon-background-maker-lora-for-sdxl', 'jarod2212/PrimalFashion_Bailarinas', 'RudySen/Krea2-realism-V1', 'Muapi/china-ktv-girls-ktv', 'mikkoph/mikkoph-krea2', 'ilkerzgi/krea-2-bold-brushy-kidlit-lora', 'ilkerzgi/krea-2-bold-clay-toy-render-lora', 'ilkerzgi/krea-2-chunky-crayon-kidlit-lora', 'ilkerzgi/krea-2-dark-medieval-inkline-lora', 'ilkerzgi/krea-2-dark-ornate-linework-lora', 'ilkerzgi/krea-2-eerie-amber-gloom-lora', 'ilkerzgi/krea-2-engraved-chiaroscuro-ember-lora', 'ilkerzgi/krea-2-felted-wool-whimsy-lora', 'ilkerzgi/krea-2-embroidered-textile-diorama-lora', 'ilkerzgi/krea-2-felt-craft-diorama-lora', 'ilkerzgi/krea-2-electric-blue-horror-poster-lora', 'ilkerzgi/krea-2-felt-craft-miniature-lora', 'ilkerzgi/krea-2-graphic-novel-earthy-ink-lora', 'ilkerzgi/krea-2-indigo-dusk-inkline-lora', 'openfree/flux-chatgpt-ghibli-lora', 'lustlyai/Flux_Lustly.ai_Uncensored_nsfw_v1', 'starsfriday/Qwen-Image-NSFW', 'thutes-gbr25/NSFW-MASTER-Z-IMAGE-TURBO', 'Baraje/SexGod_NSFW_Female_Nudes_QWEN_Image_Edit_2511', 'krea-2-turbo', 'flux-dev', 'ideogram-4', 'z-image-turbo', 'ideogram.4.turbotime.lora', 'krea-2-lora-retroanime', 'flux-schnell', 'stable-diffusion-xl-base-1.0', 'krea-2-lora-darkbrush', 'krea-2-lora-sunsetblur', 'krea-2-lora-neondrip', 'krea-2-lora-vintagetarot', 'qwen-image', 'ernie-image', 'ideogram.4.unconditional.lora', 'krea-2-lora-dotmatrix', 'krea-2-lora-softwatercolor', 'krea-2-lora-kidsdrawing', 'krea-2-lora-magritte', 'z-image', 'krea-2-lora-rainywindow', 'krea2.turbo.training.adapter', 'ernie-image-turbo', 'stable-diffusion-3.5-medium', 'ideogram-4.0-loras', 'flux.2-dev-turbo', 'qwen-image-2512', 'radiancechromevoluptuous.krea2turbo.v1.0', 'sd-3.5-large', 'vhs-rally-95-lora-v1-ideogram', 'pixel-art-xl', 'loras-pack', 'stable-diffusion-3-medium', 'sd-3.5-large-turbo', 'zimage.turbo.training.adapter', 'aetheria.moonlight.shadow', 'primalfashion.saharabloom', 'primal.fashion.egyptian.muse', 'krea2-loras', 'sdxl-lora-slider.great-lighting', 'sdxl-lora-slider.cinematic-lighting', 'caricature.lora.sdxl', 'hannahowo-xl', 'vault-suit-pony-xl', 'olivia-casta-xl', 'smoking-xl', 'knit-sweaterdress-xl', 'deep-neckline-xl', 'sofilein-xl', 'elizabeth-lauren-xl', 'flash-sdxl', 'robot-torso-xl', 'emily-bloom2-xl', 'skin-freckles-xl', 'mia-khalifa-xl', 'breckie-hill-xl', 'lily-brown-xl', 'handbra-xl', 'sdxl-emoji', 'polaroid-filmstyle-xl', 'kaellyn-xl', 'phone-exposure-xl', 'sarang-xl', 'neon-gothic-xl', 'berry0314-pony-xl', 'berry0314-xl', 'kpopiu', 'building.flux.lora.v1', 'flux-dev-lora-logo-design', 'flux-lora-simple-vector', 'flux-white-background-lora', 'flux-dev-lora-text-poster', 'flux-double-exposure-lora', 'retro-pixel-flux-lora', 'flux-realistic-backgrounds-lora', 'flux-midjourney-mix2-lora', 'open-image-preferences-v1-flux-dev-lora', 'live2d-model-maker', 'detail-tweaker-xl.v1', 'gta6-style-flux-lora', 'katherine-heigl-90s-flux', 'kate-beckinsale-flux', 'melissabenoist', 'maureenmccormickmarciabrady', 'juliette.style.lora', 'evanrachelwood', 'flux.lora.sketch.style', 'dilraba.flux', 'yangmi.sd15.flux', 'woman.cloth.xl', 'flux-krea-realism-lora', 'fortnite.style.flux.kontext', 'qwen-image-lightning', 'qwen-image-eva-lora', 'flux-frank-frazetta-style-oil-painting', 'game-assets-cartoon-style-3d-isometric-background-assets-for-small-games-flux', 'toonfusion-style-ilxl-ponyxl-flux', 'iconic-jessica-rabbit', 'awportrait-qw', 'flux-dev-nfsw', 'clash-royale-style-flux-lora', 'qwen-.image.detail.slider', 'fibo', 'flux-kontext-fashion-extractor', 'emoelin', 'pixel.art.style.lora.z.image.turbo', 'z-image-loras', 'black-metal-art-sdxl-lora', 'mikkoph-zimage-turbo', 'nucleus-image', 'lokr.mc.woman.flux1d', 'flux-dev-cmo', 'sxz-3d-render-plastic-shader-flux', 'fuko-from-undead-unluck', 'mikahhzimg', 'neurospin.zit', 'envy-flux-toon-01', 'nobody.7-pale-female-uncensored-flux1.d', 'game-icon', 'rebelessence.grunge.edition', 'ektachrome-lora-v1-ideogram', 'final-fantasy-concept-art-style-flux', 'flux.3d-cartoon', 'pakistani-truck-art-sdxl-lora', 'rebel.essence.emo.version', 'rebel.essence.bikers', 'picture-story-book-for-children-xl-xl', 'game-casual-characters', 'backtoon-simple-cartoon-background-maker-lora-for-sdxl', 'primalfashion.bailarinas', 'krea2-realism', 'china-ktv-girls-ktv', 'mikkoph-krea2', 'krea-2-bold-brushy-kidlit-lora', 'krea-2-bold-clay-toy-render-lora', 'krea-2-chunky-crayon-kidlit-lora', 'krea-2-dark-medieval-inkline-lora', 'krea-2-dark-ornate-linework-lora', 'krea-2-eerie-amber-gloom-lora', 'krea-2-engraved-chiaroscuro-ember-lora', 'krea-2-felted-wool-whimsy-lora', 'krea-2-embroidered-textile-diorama-lora', 'krea-2-felt-craft-diorama-lora', 'krea-2-electric-blue-horror-poster-lora', 'krea-2-felt-craft-miniature-lora', 'krea-2-graphic-novel-earthy-ink-lora', 'krea-2-indigo-dusk-inkline-lora', 'flux-chatgpt-ghibli-lora', 'flux.lustly.ai.uncensored.nsfw.v1', 'qwen-image-nsfw', 'nsfw-master-z-image-turbo', 'sexgod.nsfw.female.nudes.qwen-.image.edit.2511', 'Max', 'botbot2', 'gemini-3.1-flash-image-preview (nano-banana-2) [web-search]', 'gpt-image-1.5-high-fidelity', 'gemini-3-pro-image-preview-2k (nano-banana-pro)', 'nonnas-meatballs-open-weight', 'recraft-v4.1-utility-pro', 'flux-2-pro', 'left-bank', 'flux-2-dev', 'seedream-4.5', 'seedream-5.0-lite', 'recraft-v4.1-pro', 'imagen-4.0-generate-001', 'qwen-image-2512', 'hidream-o1-image', 'krea-2-medium', 'wan2.5-preview', 'wan2.5-t2i-preview', 'gpt-image-1-high-fidelity', 'gpt-image-1', 'recraft-v4', 'wan2.7-image-pro', 'krea-2-large', 'wan2.7-image', 'seedream-3', 'z-image', 'flux-1-kontext-max', 'cosmos3-super', 'flux-1-kontext-pro', 'imagen-3.0-generate-002', 'cosmos3-super-agentic', 'ideogram-v3-quality', 'photon', 'recraft-v3', 'lucid-origin', 'flux-1-kontext-dev', 'harbor', 'gpt-image-2 (medium)', 'thunder', 'flow-state', 'citrus', 'habanero', 'spinosaurus', 'flow-state-2', 'kelly', 'flow-state-3', 'hidream-o1-image-1.5', 'nonnos-meatballs-open-weight', 'greenbean', 'waffle', 'flashfennel', 'itadori-sv1', 'pebble-1', 'phantom_brush', 'pebble-2', 'zen-bear-v3', 'auto-bear-v3', 'hidream-e1.1', 'gcps-fast', 'qwen-image-2.0', 'qwen-image-2.0-pro', 'flashbrown-a', 'hunyuan-image-3.0-fal', 'uni-1.1-max', 'uni-1.1', 'soft-shell', 'flashbrown-b', 'instant-ramen', 'zen-bear-v2', 'text-to-image-autoeval-test', 'chives', 'fennel', 'super-cara', 'frenchfry', 'sungod', 'super-gcp', 'zen-bear', 'shakshouka', 'ellsworth', 'parasaurolophus', 'spectral_ink', 'babylon', 'seededit-3.0', 'dialogue', 'altair', 'king-crab', 'paper-lantern', 'crepe', 'blue-crab', 'fennelbaby', 'caudipteryx', 'reve-v1.1-fast', 'zen-bear-v4', 'mussaurus', 'tyrannosaurus', 'auto-bear-v2', 'jalapeno', 'avalon', 'hotate', 'gemini-2.5-flash-image-preview (nano-banana)', 'archaeopteryx', 'snow-crab', 'grok-imagine-image-quality', 'hunyuan-image-2.1', 'red-rock', 'grok-imagine-image', 'dimetrodon', 'phantom_quill', 'qwen-image-edit', 'wan2.5-i2i-preview', 'imagen-4.0-ultra-generate-001', 'mondrian', 'wan2.6-t2i', 'imagen-4.0-fast-generate-001', 'qwen-image-edit-2511', 'chatgpt-image-latest-high-fidelity (20251216)', 'wan2.6-image', 'max', 'botbot2', 'gemini-3.1-flash-image-preview (nano-banana-2) [web-search]', 'gpt-image-1.5-high-fidelity', 'gemini-3-pro-image-preview-2k (nano-banana-pro)', 'nonnas-meatballs-open-weight', 'recraft-v4.1-utility-pro', 'flux-2-pro', 'left-bank', 'flux-2-dev', 'seedream-4.5', 'seedream-5.0-lite', 'recraft-v4.1-pro', 'imagen-4.0-generate', 'qwen-image-2512', 'hidream-o1-image', 'krea-2-medium', 'wan2.5', 'wan2.5-t2i', 'gpt-image-1-high-fidelity', 'gpt-image-1', 'recraft', 'wan2.7-image-pro', 'krea-2-large', 'wan2.7-image', 'seedream-3', 'z-image', 'flux-1-kontext-max', 'cosmos3-super', 'flux-1-kontext-pro', 'imagen-3.0-generate', 'cosmos3-super-agentic', 'ideogram-v3-quality', 'photon', 'recraft', 'lucid-origin', 'flux-1-kontext-dev', 'harbor', 'gpt-image-2 (medium)', 'thunder', 'flow-state', 'citrus', 'habanero', 'spinosaurus', 'flow-state-2', 'kelly', 'flow-state-3', 'hidream-o1-image-1.5', 'nonnos-meatballs-open-weight', 'greenbean', 'waffle', 'flashfennel', 'itadori-sv1', 'pebble-1', 'phantom.brush', 'pebble-2', 'zen-bear', 'auto-bear', 'hidream-e1.1', 'gcps-fast', 'qwen-image-2.0', 'qwen-image-2.0-pro', 'flashbrown-a', 'hunyuan-image-3.0-fal', 'uni-1.1-max', 'uni-1.1', 'soft-shell', 'flashbrown-b', 'instant-ramen', 'zen-bear', 'text-to-image-autoeval-test', 'chives', 'fennel', 'super-cara', 'frenchfry', 'sungod', 'super-gcp', 'zen-bear', 'shakshouka', 'ellsworth', 'parasaurolophus', 'spectral.ink', 'babylon', 'seededit-3.0', 'dialogue', 'altair', 'king-crab', 'paper-lantern', 'crepe', 'blue-crab', 'fennelbaby', 'caudipteryx', 'reve-v1.1-fast', 'zen-bear', 'mussaurus', 'tyrannosaurus', 'auto-bear', 'jalapeno', 'avalon', 'hotate', 'gemini-2.5-flash-image-preview (nano-banana)', 'archaeopteryx', 'snow-crab', 'grok-imagine-image-quality', 'hunyuan-image-2.1', 'red-rock', 'grok-imagine-image', 'dimetrodon', 'phantom.quill', 'qwen-image-edit', 'wan2.5-i2i', 'imagen-4.0-ultra-generate', 'mondrian', 'wan2.6-t2i', 'imagen-4.0-fast-generate', 'qwen-image-edit-2511', 'chatgpt-image-high-fidelity (20251216)', 'wan2.6-image', 'flux-kontext-dev', 'flux', 'sd-3.5-large', 'flux-dev', 'flux-kontext-dev', 'flux', 'sd-3.5-large', 'flux-dev']
+vision_models = ['auto', 'gpt-5-2', 'gpt-5-2-instant', 'gpt-5-2-thinking', 'gpt-5-1', 'gpt-5-1-instant', 'gpt-5-1-thinking', 'gpt-5', 'gpt-5-instant', 'gpt-5-thinking', 'gpt-4', 'gpt-4.1', 'gpt-4.1-mini', 'gpt-4.5', 'gpt-4o', 'gpt-4o-mini', 'o1', 'o1-mini', 'o3-mini', 'o3-mini-high', 'o4-mini', 'o4-mini-high', 'openai', 'openai-fast', 'gpt-5.4', 'gpt-5.4-mini', 'openai-large', 'mistral-small-3.2', 'mistral', 'gemini-3-flash', 'gemini', 'gemini-flash-lite-3.1', 'gemini-fast', 'gemma', 'grok', 'grok-4-20-reasoning', 'grok-large', 'gemini-search', 'gemini-search-fast', 'gemini-search-large', 'claude-fast', 'claude', 'claude-opus-4.6', 'claude-opus-4.7', 'claude-large', 'kimi', 'kimi-code', 'gemini-large', 'nova', 'llama-maverick', 'llama-scout', 'minimax', 'mistral-large', 'polly', 'qwen-large', 'qwen-vision', 'qwen-vision-pro', 'step-flash', 'qwen3.7-plus', 'qwen3.6-plus', 'qwen3.6-27b', 'qwen-latest-series-invite-beta-v16', 'qwen3.5-plus', 'qwen3.5-omni-plus', 'qwen3.6-35b-a3b', 'qwen3.5-flash', 'qwen3.5-397b-a17b', 'qwen3.5-122b-a10b', 'qwen3.5-omni-flash', 'qwen3.5-27b', 'qwen3.5-35b-a3b', 'qwen3-max-2026-01-23', 'qwen-plus-2025-07-28', 'qwen3-coder-plus', 'qwen3-vl-plus', 'qwen3-omni-flash-2025-12-01', 'meta-llama/Llama-3.2-11B-Vision-Instruct', 'Qwen/Qwen2-VL-7B-Instruct', 'llama-3.2-11b-vision', 'qwen-2-vl-7b', 'Max', 'claude-opus-4-6-thinking', 'claude-opus-4-7-thinking', 'claude-opus-4-6', 'claude-opus-4-7', 'gemini-3.1-pro-preview', 'gemini-3.1-pro-preview', 'gpt-5.4-high-no-system-prompt', 'gpt-5.2-chat-latest', 'grok-4.20-beta-0309-reasoning', 'gemini-3-flash', 'gpt-5.5-instant', 'grok-4.20-multi-agent-beta-0309', 'claude-sonnet-4-6', 'gpt-5.4-no-system-prompt', 'gpt-5.1-high', 'minimax-m3', 'minimax-m3', 'gpt-5.4-mini-high', 'gemini-2.5-pro', 'gpt-5.1', 'gpt-5.2-high', 'gpt-5.2', 'gpt-5-high', 'gemini-3.1-flash-lite-preview', 'mimo-v2-omni', 'kimi-k2.5-instant', 'o3-2025-04-16', 'gpt-5-chat', 'qwen3.5-122b-a10b', 'mistral-large-3', 'qwen3-vl-235b-a22b-instruct', 'gpt-4.1-2025-04-14', 'gemini-2.5-flash', 'mistral-medium-2508', 'qwen3.5-27b', 'gpt-5.4-nano-high', 'qwen3.5-flash', 'hunyuan-vision-1.5-thinking', 'qwen3.5-35b-a3b', 'qwen3-vl-235b-a22b-thinking', 'gpt-5-mini-high', 'o4-mini-2025-04-16', 'mistral-medium-2505', 'gpt-4.1-mini-2025-04-14', 'gemma-3-27b-it', 'gemini-2.0-flash-001', 'mistral-small-2506', 'gpt-5-nano-high', 'mistral-small-3.1-24b-instruct-2503', 'steed-0217', 'step-3.7-flash', 'maylynx-alpha', 'may-beta', 'dola-seed-2.0-preview-vision', 'gemma-4-31b-it', 'gpt-5-high-no-system-prompt', 'pisces-0226d', 'pisces-0318-vision', 'june-alpha', 'maymo-beta', 'pisces-0309-vision', 'anonymous-1111', 'spark', 'hearth', 'pisces-0309b', 'scorch', 'dola-seed-2.0-pro-vision', 'nightride-on', 'nightride-on-v2', 'zephyr', 'pisces-0309c', 'atlas', 'vortex', 'botbot2', 'orion', 'pisces-0320', 'kimi-k2.7-code', 'vierra', 'rotten-apple', 'pisces-0309d', 'queen-bee', 'EB45-vision', 'velo', 'kiwi-do', 'mistral-medium-3.5', 'muse-spark', 'stephen-vision-csfix', 'raptor-1123', 'raptor-1124', 'step-3-mini-2511', 'ernie-exp-vl-251016', 'pteronura', 'significant-otter', 'gpt-5.5-xhigh', 'steed-0611', 'kimi-k2.5', 'ernie-5.0-preview-1220', 'momoda-alpha', 'momoda-beta', 'gpt-5-high-new-system-prompt', 'qwen3-vl-8b-thinking', 'kimi-k2.6', 'claude-fable-5', 'qwen3.7-plus', 'steed-0507', 'grok-4.3-high', 'claude-opus-4-8-thinking', 'gemini-3-flash (thinking-minimal)', 'qwen3.5-397b-a17b', 'qwen-vl-max-2025-08-13', 'qwen3-omni-flash', 'qwen3-vl-8b-instruct', 'gpt-5.5-dlp-test', 'grok-4.3', 'may-alpha', 'glassy_lagoon', 'emerald_lagoon', 'gpt-5.5', 'mimo-v2.5', 'claude-opus-4-8', 'amazon.nova-pro-v1:0', 'gpt-5.5-high', 'gemini-3.5-flash', 'glm-5v-turbo', 'kimi-k2.7-code', 'gpt-5.3-codex', 'qwen3.5-122b-a10b-code', 'qwen3.5-27b-code', 'qwen3.5-35b-a3b-code', 'may-alpha', 'lucario', 'eevee', 'gpt-5.4', 'gpt-5.4', 'gpt-5.4-medium', 'gpt-5.2-high', 'gpt-5.4-high', 'metagross', 'riolu', 'gpt-5.5', 'momoda-alpha', 'muse-spark', 'gpt-5.5-xhigh', 'qwen3.7-plus', 'gpt-5.4-high', 'kimi-k2.6', 'gpt-5.5-high', 'qwen3.6-plus', 'gpt-5.4-medium', 'gemini-3.1-flash-image-preview (nano-banana-2) [web-search]', 'gpt-image-1.5-high-fidelity', 'gemini-3-pro-image-preview-2k (nano-banana-pro)', 'flux-2-pro', 'flux-2-dev', 'seedream-4.5', 'seedream-5.0-lite', 'gpt-image-1-high-fidelity', 'gpt-image-1', 'wan2.7-image-pro', 'wan2.7-image', 'flux-1-kontext-max', 'flux-1-kontext-pro', 'flux-1-kontext-dev', 'gpt-image-2 (medium)', 'flow-state', 'habanero', 'flow-state-2', 'flow-state-3', 'greenbean', 'flashfennel', 'itadori-sv1', 'phantom_brush', 'zen-bear-v3', 'pebble-2', 'pebble-1', 'hidream-e1.1', 'gcps-fast', 'qwen-image-2.0', 'qwen-image-2.0-pro', 'uni-1.1-max', 'uni-1.1', 'instant-ramen', 'zen-bear-v2', 'chives', 'flow-state', 'fennel', 'sungod', 'super-gcp', 'zen-bear', 'spectral_ink', 'seededit-3.0', 'dialogue', 'paper-lantern', 'ellsworth', 'blue-crab', 'kelly', 'fennelbaby', 'reve-v1.1-fast', 'zen-bear-v4', 'jalapeno', 'gpt-image-2 (medium)', 'avalon', 'gemini-2.5-flash-image-preview (nano-banana)', 'grok-imagine-image-quality', 'red-rock', 'zen-bear-v4', 'grok-imagine-image', 'phantom_quill', 'qwen-image-edit', 'wan2.5-i2i-preview', 'qwen-image-edit-2511', 'chatgpt-image-latest-high-fidelity (20251216)', 'wan2.6-image', 'bouncybohr', 'k2', 'model-x-2', 'veo-3.1-audio-1080p', 'veo-3.1-audio', 'veo-3.1-fast-audio', 'veo-3.1-fast-audio-1080p', 'wan2.6-t2v', 'wan2.5-t2v-preview', 'seedance-v1.5-pro', 'kling-2.5-turbo-1080p', 'kling-2.6-pro', 'pixel-parrot', 'ray-3', 'hailuo-2.3', 'hailuo-02-pro', 'seedance-v1-pro', 'hailuo-02-standard', 'hunyuan-video-1.5', 'veo-2', 'kling-v2.1-master', 'ltx-2-19b', 'wan-v2.2-a14b', 'seedance-v1-lite', 'ray2', 'pika-v2.2', 'wan2.7-i2v', 'markhor', 'grok-imagine-video', 'wan2.6-i2v', 'pixverse-v5.6', 'snowflake', 'grok-imagine-video-1.5-preview-720p', 'hailuo-2.3-fast', 'veo-3.1-audio-4k', 'polaris', 'veo-3.1-fast-audio-4k', 'kling-v2.1-standard', 'hailuo-02-fast', 'kling-v3', 'kling-2.6-standard', 'wan2.5-i2v-preview', 'kandinsky-5.0-i2v-pro', 'runway-gen4-turbo', 'max', 'claude-opus-4-6-thinking', 'claude-opus-4-7-thinking', 'claude-opus-4-6', 'claude-opus-4-7', 'gemini-3.1-pro', 'gemini-3.1-pro', 'gpt-5.4-high-no-system-prompt', 'gpt-5.2-chat', 'grok-4.20-beta-0309-reasoning', 'gemini-3-flash', 'gpt-5.5-instant', 'grok-4.20-multi-agent-beta-0309', 'claude-sonnet-4-6', 'gpt-5.4-no-system-prompt', 'gpt-5.1-high', 'minimax-m3', 'minimax-m3', 'gpt-5.4-mini-high', 'gemini-2.5-pro', 'gpt-5.1', 'gpt-5.2-high', 'gpt-5.2', 'gpt-5-high', 'gemini-3.1-flash-lite', 'mimo-v2-omni', 'kimi-k2.5-instant', 'o3', 'gpt-5-chat', 'qwen-3.5-122b-a10b', 'mistral-large-3', 'qwen-3-vl-235b-a22b', 'gpt-4.1', 'gemini-2.5-flash', 'mistral-medium-2508', 'qwen-3.5-27b', 'gpt-5.4-nano-high', 'qwen-3.5-flash', 'hunyuan-vision-1.5-thinking', 'qwen-3.5-35b-a3b', 'qwen-3-vl-235b-a22b-thinking', 'gpt-5-mini-high', 'o4-mini', 'mistral-medium-2505', 'gpt-4.1-mini', 'gemma-3-27b-it', 'gemini-2.0-flash', 'mistral-small-2506', 'gpt-5-nano-high', 'mistral-small-3.1-24b-2503', 'steed-0217', 'step-3.7-flash', 'maylynx-alpha', 'may-beta', 'dola-seed-2.0-preview-vision', 'gemma-4-31b-it', 'gpt-5-high-no-system-prompt', 'pisces-0226d', 'pisces-0318-vision', 'june-alpha', 'maymo-beta', 'pisces-0309-vision', 'anonymous-1111', 'spark', 'hearth', 'pisces-0309b', 'scorch', 'dola-seed-2.0-pro-vision', 'nightride-on', 'nightride-on', 'zephyr', 'pisces-0309c', 'atlas', 'vortex', 'botbot2', 'orion', 'pisces-0320', 'kimi-k2.7-code', 'vierra', 'rotten-apple', 'pisces-0309d', 'queen-bee', 'eb45-vision', 'velo', 'kiwi-do', 'mistral-medium-3.5', 'muse-spark', 'stephen-vision-csfix', 'raptor-1123', 'raptor-1124', 'step-3-mini-2511', 'ernie-exp-vl-251016', 'pteronura', 'significant-otter', 'gpt-5.5-xhigh', 'steed-0611', 'kimi-k2.5', 'ernie-5.0-preview-1220', 'momoda-alpha', 'momoda-beta', 'gpt-5-high-new-system-prompt', 'qwen-3-vl-8b-thinking', 'kimi-k2.6', 'claude-fable-5', 'qwen-3.7-plus', 'steed-0507', 'grok-4.3-high', 'claude-opus-4-8-thinking', 'gemini-3-flash (thinking-minimal)', 'qwen-3.5-397b-a17b', 'qwen-vl-max', 'qwen-3-omni-flash', 'qwen-3-vl-8b', 'gpt-5.5-dlp-test', 'grok-4.3', 'may-alpha', 'glassy.lagoon', 'emerald.lagoon', 'gpt-5.5', 'mimo-v2.5', 'claude-opus-4-8', 'amazon.nova-pro', 'gpt-5.5-high', 'gemini-3.5-flash', 'glm-5v-turbo', 'kimi-k2.7-code', 'gpt-5.3-codex', 'qwen-3.5-122b-a10b-code', 'qwen-3.5-27b-code', 'qwen-3.5-35b-a3b-code', 'may-alpha', 'lucario', 'eevee', 'gpt-5.4', 'gpt-5.4', 'gpt-5.4-medium', 'gpt-5.2-high', 'gpt-5.4-high', 'metagross', 'riolu', 'gpt-5.5', 'momoda-alpha', 'muse-spark', 'gpt-5.5-xhigh', 'qwen-3.7-plus', 'gpt-5.4-high', 'kimi-k2.6', 'gpt-5.5-high', 'qwen-3.6-plus', 'gpt-5.4-medium', 'gemini-3.1-flash-image-preview (nano-banana-2) [web-search]', 'gpt-image-1.5-high-fidelity', 'gemini-3-pro-image-preview-2k (nano-banana-pro)', 'flux-2-pro', 'flux-2-dev', 'seedream-4.5', 'seedream-5.0-lite', 'gpt-image-1-high-fidelity', 'gpt-image-1', 'wan2.7-image-pro', 'wan2.7-image', 'flux-1-kontext-max', 'flux-1-kontext-pro', 'flux-1-kontext-dev', 'gpt-image-2 (medium)', 'flow-state', 'habanero', 'flow-state-2', 'flow-state-3', 'greenbean', 'flashfennel', 'itadori-sv1', 'phantom.brush', 'zen-bear', 'pebble-2', 'pebble-1', 'hidream-e1.1', 'gcps-fast', 'qwen-image-2.0', 'qwen-image-2.0-pro', 'uni-1.1-max', 'uni-1.1', 'instant-ramen', 'zen-bear', 'chives', 'flow-state', 'fennel', 'sungod', 'super-gcp', 'zen-bear', 'spectral.ink', 'seededit-3.0', 'dialogue', 'paper-lantern', 'ellsworth', 'blue-crab', 'kelly', 'fennelbaby', 'reve-v1.1-fast', 'zen-bear', 'jalapeno', 'gpt-image-2 (medium)', 'avalon', 'gemini-2.5-flash-image-preview (nano-banana)', 'grok-imagine-image-quality', 'red-rock', 'zen-bear', 'grok-imagine-image', 'phantom.quill', 'qwen-image-edit', 'wan2.5-i2i', 'qwen-image-edit-2511', 'chatgpt-image-high-fidelity (20251216)', 'wan2.6-image', 'bouncybohr', 'k2', 'model-x-2', 'veo-3.1-audio-1080p', 'veo-3.1-audio', 'veo-3.1-fast-audio', 'veo-3.1-fast-audio-1080p', 'wan2.6-t2v', 'wan2.5-t2v', 'seedance-v1.5-pro', 'kling-2.5-turbo-1080p', 'kling-2.6-pro', 'pixel-parrot', 'ray-3', 'hailuo-2.3', 'hailuo-02-pro', 'seedance-v1-pro', 'hailuo-02-standard', 'hunyuan-video-1.5', 'veo-2', 'kling-v2.1-master', 'ltx-2-19b', 'wan-v2.2-a14b', 'seedance-v1-lite', 'ray2', 'pika-v2.2', 'wan2.7-i2v', 'markhor', 'grok-imagine-video', 'wan2.6-i2v', 'pixverse-v5.6', 'snowflake', 'grok-imagine-video-1.5-preview-720p', 'hailuo-2.3-fast', 'veo-3.1-audio-4k', 'polaris', 'veo-3.1-fast-audio-4k', 'kling-v2.1-standard', 'hailuo-02-fast', 'kling', 'kling-2.6-standard', 'wan2.5-i2v', 'kandinsky-5.0-i2v-pro', 'runway-gen4-turbo', 'azure:openai/gpt-4o', 'azure:openai/gpt-5', 'azure:openai/gpt-5-codex', 'azure:openai/gpt-5-mini', 'azure:openai/gpt-5-nano', 'azure:openai/gpt-5.1', 'azure:openai/gpt-5.1-codex', 'azure:openai/gpt-5.1-codex-mini', 'azure:openai/gpt-5.2', 'azure:openai/gpt-5.2-codex', 'azure:openai/gpt-5.3-codex', 'azure:openai/gpt-5.4', 'azure:openai/gpt-5.4-mini', 'azure:openai/gpt-5.4-nano', 'moonshotai:moonshotai/moonshot-v1-128k-vision-preview', 'moonshotai:moonshotai/moonshot-v1-32k-vision-preview', 'moonshotai:moonshotai/moonshot-v1-8k-vision-preview', 'openai:openai/gpt-4.1', 'openai:openai/gpt-4.1-mini', 'openai:openai/gpt-4.1-nano', 'openai:openai/gpt-4.5-preview', 'openai:openai/gpt-4o-mini', 'openai:openai/gpt-5', 'openai:openai/gpt-5-chat', 'openai:openai/gpt-5-mini', 'openai:openai/gpt-5-nano', 'openai:openai/gpt-5.1-chat', 'openai:openai/gpt-5.2', 'openai:openai/gpt-5.2-chat', 'openai:openai/gpt-5.2-pro', 'openai:openai/gpt-5.4', 'openai:openai/gpt-5.4-pro', 'openai:openai/gpt-5.5', 'openai:openai/gpt-5.5-pro', 'openai:openai/o1', 'openai:openai/o1-mini', 'openai:openai/o1-pro', 'openai:openai/o3', 'openai:openai/o3-mini', 'openai:openai/o3-pro', 'openai:openai/o4-mini', 'openrouter:meta-llama/llama-3.2-11b-vision-instruct', 'openrouter:openai/gpt-3.5-turbo', 'openrouter:openai/gpt-3.5-turbo-0613', 'openrouter:openai/gpt-3.5-turbo-16k', 'openrouter:openai/gpt-3.5-turbo-instruct', 'openrouter:openai/gpt-4', 'openrouter:openai/gpt-4-turbo', 'openrouter:openai/gpt-4-turbo-preview', 'openrouter:openai/gpt-4o-2024-05-13', 'openrouter:openai/gpt-4o-2024-08-06', 'openrouter:openai/gpt-4o-2024-11-20', 'openrouter:openai/gpt-4o-mini-2024-07-18', 'openrouter:openai/gpt-4o-mini-search-preview', 'openrouter:openai/gpt-4o-search-preview', 'openrouter:openai/gpt-5-image', 'openrouter:openai/gpt-5-image-mini', 'openrouter:openai/gpt-5-pro', 'openrouter:openai/gpt-5.1-codex-max', 'openrouter:openai/gpt-5.3-chat', 'openrouter:openai/gpt-5.4-image-2', 'openrouter:openai/gpt-audio', 'openrouter:openai/gpt-audio-mini', 'openrouter:openai/gpt-chat-latest', 'openrouter:openai/gpt-oss-120b:free', 'openrouter:openai/gpt-oss-20b:free', 'openrouter:openai/gpt-oss-safeguard-20b', 'openrouter:openai/o3-deep-research', 'openrouter:openai/o3-mini-high', 'openrouter:openai/o4-mini-deep-research', 'openrouter:openai/o4-mini-high', 'openrouter:sao10k/l3-lunaris-8b', 'openrouter:sao10k/l3.1-70b-hanami-x1', 'openrouter:sao10k/l3.1-euryale-70b', 'openrouter:sao10k/l3.3-euryale-70b', 'openrouter:~openai/gpt-latest', 'openrouter:~openai/gpt-mini-latest', 'togetherai:openai/gpt-oss-120b', 'togetherai:openai/gpt-oss-20b', 'x-ai:x-ai/grok-2-vision', 'x-ai:x-ai/grok-2-vision-1212', 'x-ai:x-ai/grok-vision-beta', 'gpt-4o', 'gpt-5', 'gpt-5-codex', 'gpt-5-mini', 'gpt-5-nano', 'gpt-5.1', 'gpt-5.1-codex', 'gpt-5.1-codex-mini', 'gpt-5.2', 'gpt-5.2-codex', 'gpt-5.3-codex', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.4-nano', 'moonshot-v1-128k-vision', 'moonshot-v1-32k-vision', 'moonshot-v1-8k-vision', 'gpt-4.1', 'gpt-4.1-mini', 'gpt-4.1-nano', 'gpt-4.5', 'gpt-4o-mini', 'gpt-5', 'gpt-5-chat', 'gpt-5-mini', 'gpt-5-nano', 'gpt-5.1-chat', 'gpt-5.2', 'gpt-5.2-chat', 'gpt-5.2-pro', 'gpt-5.4', 'gpt-5.4-pro', 'gpt-5.5', 'gpt-5.5-pro', 'o1', 'o1-mini', 'o1-pro', 'o3', 'o3-mini', 'o3-pro', 'o4-mini', 'llama-3.2-11b-vision', 'gpt-3.5-turbo', 'gpt-3.5-turbo-0613', 'gpt-3.5-turbo-16k', 'gpt-3.5-turbo', 'gpt-4', 'gpt-4-turbo', 'gpt-4-turbo', 'gpt-4o', 'gpt-4o', 'gpt-4o', 'gpt-4o-mini', 'gpt-4o-mini-search', 'gpt-4o-search', 'gpt-5-image', 'gpt-5-image-mini', 'gpt-5-pro', 'gpt-5.1-codex-max', 'gpt-5.3-chat', 'gpt-5.4-image-2', 'gpt-audio', 'gpt-audio-mini', 'gpt-chat', 'gpt-oss-120b', 'gpt-oss-20b', 'gpt-oss-safeguard-20b', 'o3-deep-research', 'o3-mini-high', 'o4-mini-deep-research', 'o4-mini-high', 'l3-lunaris-8b', 'l3.1-70b-hanami-x1', 'l3.1-euryale-70b', 'l3.3-euryale-70b', 'gpt', 'gpt-mini', 'gpt-oss-120b', 'gpt-oss-20b', 'grok-2-vision', 'grok-2-vision-1212', 'grok-vision-beta']
+video_models = ['Wan-AI/Wan2.2-TI2V-5B', 'meituan-longcat/LongCat-Video', 'Wan-AI/Wan2.1-T2V-1.3B', 'Wan-AI/Wan2.1-T2V-14B', 'tencent/HunyuanVideo-1.5', 'Wan-AI/Wan2.2-T2V-A14B', 'Wan-AI/Wan2.2-T2V-A14B-Diffusers', 'zai-org/CogVideoX-5b', 'genmo/mochi-1-preview', 'wan2.2-ti2v-5b', 'longcat-video', 'wan2.1-t2v-1.3b', 'wan2.1-t2v-14b', 'hunyuanvideo-1.5', 'wan2.2-t2v-a14b', 'wan2.2-t2v-a14b-diffusers', 'cogvideox-5b', 'mochi-1', 'bouncybohr', 'k2', 'model-x-2', 'veo-3.1-audio-1080p', 'wan2.7-t2v', 'veo-3.1-audio', 'sora-2-pro', 'veo-3.1-fast-audio', 'veo-3.1-fast-audio-1080p', 'wan2.6-t2v', 'sora-2', 'wan2.5-t2v-preview', 'seedance-v1.5-pro', 'runway-gen-4.5', 'kling-2.5-turbo-1080p', 'kling-2.6-pro', 'pixel-parrot', 'kling-o1-pro', 'ray-3', 'hailuo-2.3', 'hailuo-02-pro', 'seedance-v1-pro', 'hailuo-02-standard', 'kandinsky-5.0-t2v-pro', 'hunyuan-video-1.5', 'veo-2', 'kling-v2.1-master', 'ltx-2-19b', 'wan-v2.2-a14b', 'kandinsky-5.0-t2v-lite', 'seedance-v1-lite', 'sora', 'ray2', 'pika-v2.2', 'mochi-v1', 'tbd', 'wan2.7-i2v', 'markhor', 'grok-imagine-video', 'model-x', 'wan2.6-i2v', 'runway-gen4-aleph', 'pixverse-v5.6', 'snowflake', 'grok-imagine-video-1.5-preview-720p', 'bubble-tea', 'hailuo-2.3-fast', 'kling-o3-pro', 'culumus', 'veo-3.1-audio-4k', 'polaris', 'veo-3.1-fast-audio-4k', 'kling-v3', 'kling-v2.1-standard', 'hailuo-02-fast', 'kling-2.6-standard', 'wan2.5-i2v-preview', 'wan-vace', 'kandinsky-5.0-i2v-pro', 'runway-gen4-turbo', 'bouncybohr', 'k2', 'model-x-2', 'veo-3.1-audio-1080p', 'wan2.7-t2v', 'veo-3.1-audio', 'sora-2-pro', 'veo-3.1-fast-audio', 'veo-3.1-fast-audio-1080p', 'wan2.6-t2v', 'sora-2', 'wan2.5-t2v', 'seedance-v1.5-pro', 'runway-gen-4.5', 'kling-2.5-turbo-1080p', 'kling-2.6-pro', 'pixel-parrot', 'kling-o1-pro', 'ray-3', 'hailuo-2.3', 'hailuo-02-pro', 'seedance-v1-pro', 'hailuo-02-standard', 'kandinsky-5.0-t2v-pro', 'hunyuan-video-1.5', 'veo-2', 'kling-v2.1-master', 'ltx-2-19b', 'wan-v2.2-a14b', 'kandinsky-5.0-t2v-lite', 'seedance-v1-lite', 'sora', 'ray2', 'pika-v2.2', 'mochi', 'tbd', 'wan2.7-i2v', 'markhor', 'grok-imagine-video', 'model-x', 'wan2.6-i2v', 'runway-gen4-aleph', 'pixverse-v5.6', 'snowflake', 'grok-imagine-video-1.5-preview-720p', 'bubble-tea', 'hailuo-2.3-fast', 'kling-o3-pro', 'culumus', 'veo-3.1-audio-4k', 'polaris', 'veo-3.1-fast-audio-4k', 'kling', 'kling-v2.1-standard', 'hailuo-02-fast', 'kling-2.6-standard', 'wan2.5-i2v', 'wan-vace', 'kandinsky-5.0-i2v-pro', 'runway-gen4-turbo', 'video']
 model_map = {
   "default": {
-    "CopilotApp": "",
-    "Copilot": "",
-    "DeepInfra": "",
-    "OperaAria": "",
-    "Startnest": "",
-    "GLM": "",
-    "PollinationsAI": "",
+    "Ollama": "",
     "Qwen": "",
-    "Together": "",
-    "Chatai": "",
+    "DeepInfra": "",
+    "PollinationsAI": "",
     "WeWordle": "",
+    "GLM": "",
     "TeachAnything": "",
     "OpenaiChat": "",
-    "Cloudflare": ""
+    "Together": "",
+    "OperaAria": "",
+    "CopilotApp": ""
   },
   "gpt-4": {
-    "CopilotApp": "Copilot",
-    "Copilot": "Copilot",
+    "CopilotApp": "chat",
     "Yqcloud": "gpt-4",
     "WeWordle": "gpt-4",
     "OpenaiChat": "gpt-4",
+    "Copilot": "Copilot",
     "CopilotAccount": "Copilot",
     "PuterJS": "openrouter:openai/gpt-4",
+    "ApiAirforce": "gpt-4",
     "CopilotSession": "Copilot",
     "OpenRouter": "openai/gpt-4"
   },
   "gpt-4o": {
-    "CopilotApp": "Copilot",
+    "CopilotApp": "chat",
     "OpenaiChat": "gpt-4o",
     "Copilot": "Copilot",
     "CopilotAccount": "Copilot",
-    "PuterJS": "openrouter:openai/gpt-4o:extended",
+    "PuterJS": "openrouter:openai/gpt-4o-2024-11-20",
     "CopilotSession": "Copilot",
-    "GithubCopilot": "gpt-4o",
-    "OpenRouter": "openai/gpt-4o:extended",
-    "Yupp": "openai/gpt-4o:extended<>OPR"
+    "OpenRouter": "openai/gpt-4o",
+    "WeWordle": "gpt-4o"
   },
   "gpt-4o-mini": {
-    "Chatai": "gpt-4o-mini-2024-07-18",
     "OpenaiChat": "gpt-4o-mini",
     "PuterJS": "openrouter:openai/gpt-4o-mini-2024-07-18",
     "ApiAirforce": "gpt-4o-mini",
     "OpenRouter": "openai/gpt-4o-mini-2024-07-18",
-    "Yupp": "gpt-4o-mini"
+    "WeWordle": "gpt-4o-mini"
   },
   "gpt-4o-mini-tts": {
-    "OpenAIFM": "coral"
+    "OpenAIFM": "coral",
+    "ApiAirforce": "gpt-4o-mini-tts"
   },
   "o1": {
-    "CopilotApp": "Think Deeper",
-    "Copilot": "Think Deeper",
     "OpenaiAccount": "o1",
     "OpenaiChat": "o1",
+    "Copilot": "Think Deeper",
     "CopilotAccount": "Think Deeper",
-    "PuterJS": "openrouter:openai/o1",
+    "PuterJS": "openai:openai/o1",
+    "ApiAirforce": "o1",
+    "CopilotApp": "reasoning",
     "CopilotSession": "Think Deeper",
-    "GithubCopilot": "o1-preview",
-    "OpenRouter": "openai/o1",
-    "Yupp": "openai/o1"
+    "OpenRouter": "openai/o1"
   },
   "o1-mini": {
     "OpenaiAccount": "o1-mini",
     "OpenaiChat": "o1-mini",
-    "PuterJS": "o1-mini",
-    "GithubCopilot": "o1-mini"
+    "PuterJS": "openai:openai/o1-mini"
   },
   "o3-mini": {
     "OpenaiChat": "o3-mini",
     "LMArena": "o3-mini",
-    "PuterJS": "openrouter:openai/o3-mini",
-    "GithubCopilot": "o3-mini",
-    "OpenRouter": "openai/o3-mini",
-    "Yupp": "o3-mini-2025-01-31"
+    "PuterJS": "openai:openai/o3-mini",
+    "ApiAirforce": "o3-mini-2025-01-31",
+    "CopilotApp": "reasoning",
+    "OpenRouter": "openai/o3-mini"
   },
   "o3-mini-high": {
     "OpenaiAccount": "o3-mini-high",
@@ -86,12 +81,10 @@ model_map = {
   },
   "o4-mini": {
     "OpenaiChat": "o4-mini",
-    "Azure": "o4-mini",
     "LMArena": "o4-mini-2025-04-16",
-    "PuterJS": "openrouter:openai/o4-mini",
-    "GithubCopilot": "o4-mini",
-    "OpenRouter": "openai/o4-mini",
-    "Yupp": "o4-mini"
+    "PuterJS": "openai:openai/o4-mini",
+    "ApiAirforce": "o4-mini",
+    "OpenRouter": "openai/o4-mini"
   },
   "o4-mini-high": {
     "OpenaiChat": "o4-mini-high",
@@ -100,55 +93,66 @@ model_map = {
   },
   "gpt-4.1": {
     "OpenaiChat": "gpt-4-1",
-    "Azure": "gpt-4.1",
     "LMArena": "gpt-4.1-2025-04-14",
-    "PuterJS": "openrouter:openai/gpt-4.1",
-    "GithubCopilot": "gpt-4.1",
-    "OpenRouter": "openai/gpt-4.1",
-    "Yupp": "gpt-4.1-2025-04-14"
+    "PuterJS": "openai:openai/gpt-4.1",
+    "ApiAirforce": "gpt-4.1",
+    "OpenRouter": "openai/gpt-4.1"
   },
   "gpt-4.1-mini": {
     "OpenaiChat": "gpt-4-1-mini",
     "LMArena": "gpt-4.1-mini-2025-04-14",
-    "PuterJS": "openrouter:openai/gpt-4.1-mini",
-    "OpenRouter": "openai/gpt-4.1-mini",
-    "Yupp": "gpt-4.1-mini-2025-04-14"
+    "PuterJS": "openai:openai/gpt-4.1-mini",
+    "OpenRouter": "openai/gpt-4.1-mini"
   },
   "gpt-4.1-nano": {
     "PollinationsAI": "openai-fast",
-    "PuterJS": "openrouter:openai/gpt-4.1-nano",
-    "OpenRouter": "openai/gpt-4.1-nano",
-    "Yupp": "gpt-4.1-nano-2025-04-14"
+    "PuterJS": "openai:openai/gpt-4.1-nano",
+    "ApiAirforce": "gpt-4.1-nano",
+    "OpenRouter": "openai/gpt-4.1-nano"
   },
   "gpt-4.5": {
     "OpenaiChat": "gpt-4-5",
-    "PuterJS": "gpt-4.5-preview"
+    "PuterJS": "openai:openai/gpt-4.5-preview"
   },
   "gpt-oss-120b": {
     "Together": "openai/gpt-oss-120b",
-    "DeepInfra": "openai/gpt-oss-120b",
     "HuggingFace": "openai/gpt-oss-120b",
-    "OpenRouter": "openai/gpt-oss-120b:free",
+    "OpenRouter": "openai/gpt-oss-120b",
     "Groq": "openai/gpt-oss-120b",
-    "OpenRouterFree": "openai/gpt-oss-120b:free",
     "LMArena": "gpt-oss-120b",
-    "PuterJS": "openrouter:openai/gpt-oss-120b:free",
-    "HuggingFaceAPI": "openai/gpt-oss-120b",
-    "Nvidia": "openai/gpt-oss-120b",
-    "Ollama": "gpt-oss:120b",
+    "PuterJS": "togetherai:openai/gpt-oss-120b",
     "ApiAirforce": "gpt-oss-120b",
-    "GradientNetwork": "GPT OSS 120B",
     "HuggingChat": "openai/gpt-oss-120b",
-    "Yupp": "openai/gpt-oss-120b:exacto<>OPR"
+    "HuggingFaceAPI": "openai/gpt-oss-120b",
+    "Ollama": "gpt-oss:120b"
+  },
+  "smart": {
+    "CopilotApp": "smart",
+    "CopilotAccount": "smart",
+    "Copilot": "smart"
+  },
+  "reasoning": {
+    "CopilotApp": "reasoning",
+    "CopilotAccount": "reasoning"
+  },
+  "study": {
+    "CopilotApp": "study",
+    "CopilotAccount": "Study",
+    "Copilot": "Study",
+    "CopilotSession": "Study"
+  },
+  "search": {
+    "CopilotApp": "search",
+    "CopilotAccount": "search",
+    "Video": "search"
   },
   "dall-e-3": {
-    "CopilotAccount": "Copilot",
     "OpenaiAccount": "dall-e-3",
     "MicrosoftDesigner": "dall-e-3",
     "BingCreateImages": "dall-e-3",
-    "LMArena": "dall-e-3",
-    "OpenaiChat": "gpt-image",
-    "Yupp": "dall-e-3"
+    "CopilotAccount": "Copilot",
+    "ApiAirforce": "dall-e-3",
+    "OpenaiChat": "gpt-image"
   },
   "gpt-image": {
     "PollinationsImage": "gpt-image",
@@ -161,15 +165,13 @@ model_map = {
   },
   "llama-2-70b": {
     "Together": "llama-2-70b",
-    "PuterJS": "openrouter:meta-llama/llama-2-70b-chat",
-    "Nvidia": "meta/llama2-70b"
+    "PuterJS": "openrouter:meta-llama/llama-2-70b-chat"
   },
   "llama-3-8b": {
     "Together": "llama-3-8b",
     "PuterJS": "openrouter:meta-llama/llama-3-8b-instruct",
-    "HuggingFaceAPI": "meta-llama/Meta-Llama-3-8B-Instruct",
-    "Nvidia": "meta/llama3-8b-instruct",
     "HuggingChat": "meta-llama/Meta-Llama-3-8B-Instruct",
+    "HuggingFaceAPI": "meta-llama/Meta-Llama-3-8B-Instruct",
     "OpenRouter": "meta-llama/llama-3-8b-instruct",
     "PerplexityApi": "llama-3-8b-instruct"
   },
@@ -177,64 +179,49 @@ model_map = {
     "Together": "llama-3-70b",
     "PuterJS": "openrouter:meta-llama/llama-3-70b-instruct",
     "HuggingFaceAPI": "meta-llama/Meta-Llama-3-70B-Instruct",
-    "Nvidia": "meta/llama3-70b-instruct",
-    "HuggingChat": "meta-llama/Meta-Llama-3-70B-Instruct",
-    "OpenRouter": "meta-llama/llama-3-70b-instruct",
     "PerplexityApi": "llama-3-70b-instruct",
     "Replicate": "meta/meta-llama-3-70b-instruct"
   },
   "llama-3.1-8b": {
-    "DeepInfra": "meta-llama/Meta-Llama-3.1-8B-Instruct",
     "Together": "llama-3.1-8b",
     "HuggingFace": "meta-llama/Llama-3.1-8B",
     "PuterJS": [
       "openrouter:meta-llama/llama-3.1-8b-instruct:free",
       "openrouter:meta-llama/llama-3.1-8b-instruct"
     ],
-    "HuggingFaceAPI": "NousResearch/Meta-Llama-3.1-8B-Instruct",
-    "Nvidia": "meta/llama-3.1-8b-instruct",
     "Cerebras": "llama3.1-8b",
     "GlhfChat": "hf:meta-llama/Llama-3.1-8B-Instruct",
     "HuggingChat": "meta-llama/Llama-3.1-8B-Instruct",
-    "OpenRouter": "meta-llama/llama-3.1-8b-instruct",
-    "Yupp": "Meta-Llama-3.1-8B-Instruct"
+    "HuggingFaceAPI": "meta-llama/Llama-3.1-8B-Instruct",
+    "OpenRouter": "meta-llama/llama-3.1-8b-instruct"
   },
   "llama-3.1-70b": {
     "Together": "llama-3.1-70b",
     "PuterJS": "openrouter:meta-llama/llama-3.1-70b-instruct",
-    "HuggingFaceAPI": "NousResearch/Meta-Llama-3.1-70B-Instruct",
-    "Nvidia": "meta/llama-3.1-70b-instruct",
     "Cerebras": "llama3.1-70b",
     "GlhfChat": "hf:meta-llama/Llama-3.1-70B-Instruct",
     "HuggingChat": "meta-llama/Llama-3.1-70B-Instruct",
-    "OpenRouter": "meta-llama/llama-3.1-70b-instruct",
-    "Yupp": "meta-llama/llama-3.1-70b-instruct"
+    "OpenRouter": "meta-llama/llama-3.1-70b-instruct"
   },
   "llama-3.1-405b": {
     "Together": "llama-3.1-405b",
-    "OpenRouterFree": "meta-llama/llama-3.1-405b-instruct:free",
     "PuterJS": [
       "openrouter:meta-llama/llama-3.1-405b:free",
       "openrouter:meta-llama/llama-3.1-405b",
       "openrouter:meta-llama/llama-3.1-405b-instruct"
     ],
-    "Nvidia": "meta/llama-3.1-405b-instruct",
-    "GlhfChat": "hf:meta-llama/Llama-3.1-405B-Instruct",
-    "OpenRouter": "meta-llama/llama-3.1-405b-instruct:free"
+    "GlhfChat": "hf:meta-llama/Llama-3.1-405B-Instruct"
   },
   "llama-3.2-3b": {
     "Together": "llama-3.2-3b",
-    "OpenRouterFree": "meta-llama/llama-3.2-3b-instruct:free",
     "HuggingFace": "meta-llama/Llama-3.2-3B-Instruct",
     "PuterJS": [
       "openrouter:meta-llama/llama-3.2-3b-instruct:free",
       "openrouter:meta-llama/llama-3.2-3b-instruct"
     ],
-    "HuggingFaceAPI": "meta-llama/Llama-3.2-3B-Instruct",
-    "Nvidia": "meta/llama-3.2-3b-instruct",
     "GlhfChat": "hf:meta-llama/Llama-3.2-3B-Instruct",
-    "HuggingChat": "meta-llama/Llama-3.2-3B-Instruct",
-    "OpenRouter": "meta-llama/llama-3.2-3b-instruct:free"
+    "HuggingFaceAPI": "meta-llama/Llama-3.2-3B-Instruct",
+    "OpenRouter": "meta-llama/llama-3.2-3b-instruct"
   },
   "llama-3.2-11b": {
     "Together": "llama-3.2-11b",
@@ -247,78 +234,61 @@ model_map = {
     "HuggingFaceAPI": "meta-llama/Llama-3.2-11B-Vision-Instruct"
   },
   "llama-3.2-90b": {
-    "DeepInfra": "meta-llama/Llama-3.2-90B-Vision-Instruct",
     "Together": "llama-3.2-90b",
     "PuterJS": "openrouter:meta-llama/llama-3.2-90b-vision-instruct"
   },
   "llama-3.3-70b": {
-    "DeepInfra": "meta-llama/Llama-3.3-70B-Instruct",
     "Together": "llama-3.3-70b",
     "HuggingChat": "meta-llama/Llama-3.3-70B-Instruct",
     "HuggingFace": "meta-llama/Llama-3.3-70B-Instruct",
-    "OpenRouterFree": "meta-llama/llama-3.3-70b-instruct:free",
-    "LMArena": "llama-3.3-70b-instruct",
     "PuterJS": [
       "openrouter:meta-llama/llama-3.3-70b-instruct:free",
       "openrouter:meta-llama/llama-3.3-70b-instruct"
     ],
-    "HuggingFaceAPI": "meta-llama/Llama-3.3-70B-Instruct",
-    "Nvidia": "meta/llama-3.3-70b-instruct",
     "Cerebras": "llama-3.3-70b",
     "GlhfChat": "hf:meta-llama/Llama-3.3-70B-Instruct",
-    "OpenRouter": "meta-llama/llama-3.3-70b-instruct:free",
-    "Yupp": "Meta-Llama-3.3-70B-Instruct"
+    "HuggingFaceAPI": "meta-llama/Llama-3.3-70B-Instruct",
+    "OpenRouter": "meta-llama/llama-3.3-70b-instruct",
+    "PollinationsAI": "llama"
   },
   "llama-4-scout": {
-    "DeepInfra": "meta-llama/Llama-4-Scout-17B-16E-Instruct",
-    "PollinationsAI": "llamascout",
+    "PollinationsAI": "llama-scout",
     "Together": "llama-4-scout",
     "PuterJS": [
       "openrouter:meta-llama/llama-4-scout:free",
       "openrouter:meta-llama/llama-4-scout"
     ],
-    "ApiAirforce": "llama-4-scout",
     "OpenRouter": "meta-llama/llama-4-scout"
   },
   "llama-4-maverick": {
-    "DeepInfra": "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
     "Together": "llama-4-maverick",
     "PuterJS": [
       "openrouter:meta-llama/llama-4-maverick:free",
       "openrouter:meta-llama/llama-4-maverick"
     ],
-    "ApiAirforce": "llama-4-maverick",
-    "OpenRouter": "meta-llama/llama-4-maverick"
+    "OpenRouter": "meta-llama/llama-4-maverick",
+    "PollinationsAI": "llama-maverick"
   },
   "mistral-7b": {
-    "Together": "mistral-7b",
-    "OpenRouterFree": "mistralai/mistral-7b-instruct:free",
-    "PuterJS": "openrouter:mistralai/mistral-7b-instruct:free",
-    "OpenRouter": "mistralai/mistral-7b-instruct:free"
+    "Together": "mistral-7b"
   },
   "mixtral-8x7b": {
-    "Together": "mixtral-8x7b",
-    "PuterJS": "openrouter:mistralai/mixtral-8x7b-instruct",
-    "Groq": "mixtral-8x7b-32768",
-    "OpenRouter": "mistralai/mixtral-8x7b-instruct"
+    "Together": "mixtral-8x7b"
   },
   "mistral-nemo": {
     "HuggingChat": "mistralai/Mistral-Nemo-Instruct-2407",
     "HuggingFace": "mistralai/Mistral-Nemo-Instruct-2407",
-    "PuterJS": "openrouter:mistralai/mistral-nemo",
     "HuggingFaceAPI": "mistralai/Mistral-Nemo-Instruct-2407",
+    "OllamaSwarm": "mistral-nemo:latest",
     "OpenRouter": "mistralai/mistral-nemo"
   },
   "mistral-small-24b": {
-    "Together": "mistral-small-24b",
-    "Nvidia": "mistralai/mistral-small-24b-instruct"
+    "Together": "mistral-small-24b"
   },
   "mistral-small-3.1-24b": {
-    "DeepInfra": "mistralai/Mistral-Small-3.1-24B-Instruct-2503",
     "PollinationsAI": "mistral-small",
-    "OpenRouterFree": "mistralai/mistral-small-3.1-24b-instruct:free",
-    "PuterJS": "openrouter:mistralai/mistral-small-3.1-24b-instruct:free",
-    "OpenRouter": "mistralai/mistral-small-3.1-24b-instruct:free"
+    "PuterJS": "openrouter:mistralai/mistral-small-3.1-24b-instruct",
+    "OpenRouter": "mistralai/mistral-small-3.1-24b-instruct"
   },
   "hermes-2-dpo": {
     "Together": "hermes-2-dpo",
@@ -328,43 +298,7 @@ model_map = {
     "HuggingChat": "microsoft/Phi-3.5-mini-instruct",
     "HuggingFace": "microsoft/Phi-3.5-mini-instruct",
     "PuterJS": "openrouter:microsoft/phi-3.5-mini-128k-instruct",
-    "HuggingFaceAPI": "microsoft/Phi-3.5-mini-instruct",
-    "Nvidia": "microsoft/phi-3.5-mini-instruct"
-  },
-  "phi-4": {
-    "DeepInfra": "microsoft/phi-4",
-    "HuggingSpace": "phi-4-multimodal",
-    "PuterJS": "openrouter:microsoft/phi-4",
-    "Microsoft_Phi_4_Multimodal": "phi-4-multimodal",
-    "OpenRouter": "microsoft/phi-4",
-    "Yupp": "microsoft/phi-4"
-  },
-  "phi-4-multimodal": {
-    "DeepInfra": "microsoft/Phi-4-multimodal-instruct",
-    "HuggingSpace": "phi-4-multimodal",
-    "PuterJS": "openrouter:microsoft/phi-4-multimodal-instruct",
-    "Microsoft_Phi_4_Multimodal": "phi-4-multimodal",
-    "Nvidia": "microsoft/phi-4-multimodal-instruct",
-    "OpenRouter": "microsoft/phi-4-multimodal-instruct",
-    "Yupp": "microsoft/phi-4-multimodal-instruct"
-  },
-  "phi-4-reasoning-plus": {
-    "DeepInfra": "microsoft/phi-4-reasoning-plus",
-    "PuterJS": [
-      "openrouter:microsoft/phi-4-reasoning-plus:free",
-      "openrouter:microsoft/phi-4-reasoning-plus"
-    ],
-    "OpenRouter": "microsoft/phi-4-reasoning-plus"
-  },
-  "wizardlm-2-7b": {
-    "DeepInfra": "microsoft/WizardLM-2-7B"
-  },
-  "wizardlm-2-8x22b": {
-    "DeepInfra": "microsoft/WizardLM-2-8x22B",
-    "PuterJS": "openrouter:microsoft/wizardlm-2-8x22b",
-    "HuggingFaceAPI": "alpindale/WizardLM-2-8x22B",
-    "HuggingChat": "alpindale/WizardLM-2-8x22B",
-    "OpenRouter": "microsoft/wizardlm-2-8x22b"
+    "HuggingFaceAPI": "microsoft/Phi-3.5-mini-instruct"
   },
   "gemini-2.0": {
     "Gemini": "gemini-2.0"
@@ -378,11 +312,7 @@ model_map = {
       "openrouter:google/gemini-2.0-flash-lite-001",
       "openrouter:google/gemini-2.0-flash-001",
       "openrouter:google/gemini-2.0-flash-exp:free"
-    ],
-    "ApiAirforce": "gemini-2.0-flash",
-    "GithubCopilot": "gemini-2.0-flash",
-    "OpenRouter": "google/gemini-2.0-flash-001",
-    "Yupp": "gemini-2.0-flash-001"
+    ]
   },
   "gemini-2.0-flash-thinking": {
     "Gemini": "gemini-2.0-flash-thinking",
@@ -395,73 +325,61 @@ model_map = {
     "Gemini": "gemini-2.5-flash",
     "GeminiPro": "gemini-2.5-flash",
     "GeminiCLI": "gemini-2.5-flash",
-    "DeepInfra": "google/gemini-2.5-flash",
     "LMArena": "gemini-2.5-flash",
     "PuterJS": "openrouter:google/gemini-2.5-flash-preview",
+    "Antigravity": "gemini-2.5-flash",
     "ApiAirforce": "gemini-2.5-flash",
-    "OpenRouter": "google/gemini-2.5-flash",
-    "Yupp": "gemini-2.5-flash"
+    "OpenRouter": "google/gemini-2.5-flash"
   },
   "gemini-2.5-pro": {
     "Gemini": "gemini-2.5-pro",
     "GeminiPro": "gemini-2.5-pro",
     "GeminiCLI": "gemini-2.5-pro",
-    "DeepInfra": "google/gemini-2.5-pro",
     "LMArena": "gemini-2.5-pro",
     "PuterJS": [
       "openrouter:google/gemini-2.5-pro-preview",
       "openrouter:google/gemini-2.5-pro-exp-03-25"
     ],
+    "Antigravity": "gemini-2.5-pro",
     "ApiAirforce": "gemini-2.5-pro",
-    "GithubCopilot": "gemini-2.5-pro",
     "OpenRouter": "google/gemini-2.5-pro-preview-05-06",
-    "Yupp": "gemini-2.5-pro"
+    "PollinationsAI": "gemini-large"
   },
   "gemini-3-pro-preview": {
     "GeminiCLI": "gemini-3-pro-preview"
   },
-  "codegemma-7b": {
-    "DeepInfra": "google/codegemma-7b-it",
-    "Nvidia": "google/codegemma-7b"
+  "gemini-3.1-pro": {
+    "Gemini": "gemini-3.1-pro",
+    "LMArena": "gemini-3.1-pro",
+    "PuterJS": "openrouter:google/gemini-3.1-pro-preview",
+    "ApiAirforce": "gemini-3.1-pro",
+    "OpenRouter": "google/gemini-3.1-pro-preview",
+    "PollinationsAI": "gemini-large"
   },
-  "gemma-2b": {
-    "Together": "gemma-2b",
-    "Nvidia": "google/gemma-2b"
+  "gemini-3.1-flash-lite": {
+    "Gemini": "gemini-3.1-flash-lite",
+    "LMArena": "gemini-3.1-flash-lite-preview",
+    "PuterJS": "openrouter:google/gemini-3.1-flash-lite-preview",
+    "ApiAirforce": "gemini-3.1-flash-lite",
+    "OpenRouter": "google/gemini-3.1-flash-lite-preview",
+    "PollinationsAI": "gemini-flash-lite-3.1"
   },
-  "gemma-1.1-7b": {
-    "DeepInfra": "google/gemma-1.1-7b-it"
-  },
-  "gemma-2-9b": {
-    "DeepInfra": "google/gemma-2-9b-it",
-    "PuterJS": [
-      "openrouter:google/gemma-2-9b-it:free",
-      "openrouter:google/gemma-2-9b-it"
-    ]
+  "gemini-3.5-flash": {
+    "Gemini": "gemini-3.5-flash",
+    "LMArena": "gemini-3.5-flash",
+    "PuterJS": "openrouter:google/gemini-3.5-flash",
+    "ApiAirforce": "gemini-3.5-flash",
+    "OpenRouter": "google/gemini-3.5-flash",
+    "PollinationsAI": "gemini"
   },
   "gemma-2-27b": {
     "Together": "gemma-2-27b",
-    "DeepInfra": "google/gemma-2-27b-it",
     "HuggingFace": "google/gemma-2-27b-it",
     "PuterJS": "openrouter:google/gemma-2-27b-it",
-    "HuggingFaceAPI": "google/gemma-2-27b-it",
-    "HuggingChat": "google/gemma-2-27b-it"
-  },
-  "gemma-3-4b": {
-    "DeepInfra": "google/gemma-3-4b-it",
-    "PuterJS": [
-      "openrouter:google/gemma-3-4b-it:free",
-      "openrouter:google/gemma-3-4b-it"
-    ]
-  },
-  "gemma-3-12b": {
-    "DeepInfra": "google/gemma-3-12b-it",
-    "PuterJS": [
-      "openrouter:google/gemma-3-12b-it:free",
-      "openrouter:google/gemma-3-12b-it"
-    ]
+    "HuggingChat": "google/gemma-2-27b-it",
+    "HuggingFaceAPI": "google/gemma-2-27b-it"
   },
   "gemma-3-27b": {
-    "DeepInfra": "google/gemma-3-27b-it",
     "Together": "gemma-3-27b",
     "PuterJS": [
       "openrouter:google/gemma-3-27b-it:free",
@@ -478,7 +396,8 @@ model_map = {
       "openrouter:cohere/command-r",
       "openrouter:cohere/command-r-03-2024"
     ],
-    "CohereForAI_C4AI_Command": "command-r-08-2024"
+    "CohereForAI_C4AI_Command": "command-r-08-2024",
+    "OllamaSwarm": "command-r:35b"
   },
   "command-r-plus": {
     "HuggingSpace": [
@@ -492,12 +411,12 @@ model_map = {
       "openrouter:cohere/command-r-plus",
       "openrouter:cohere/command-r-plus-04-2024"
     ],
-    "HuggingFaceAPI": "CohereForAI/c4ai-command-r-plus-08-2024",
     "CohereForAI_C4AI_Command": [
       "command-r-plus-08-2024",
       "command-r-plus"
     ],
-    "Yupp": "command-r-plus"
+    "HuggingFaceAPI": "CohereForAI/c4ai-command-r-plus-08-2024",
+    "OllamaSwarm": "command-r-plus:104b"
   },
   "command-r7b": {
     "HuggingSpace": [
@@ -517,13 +436,11 @@ model_map = {
     "OpenRouter": "cohere/command-a"
   },
   "qwen-2-72b": {
-    "HuggingSpace": "qwen-qwen2-72b-instruct",
     "Together": "qwen-2-72b",
     "HuggingFace": "Qwen/Qwen2-72B-Instruct",
     "PuterJS": "openrouter:qwen/qwen-2-72b-instruct",
-    "HuggingFaceAPI": "Qwen/Qwen2-72B-Instruct",
     "HuggingChat": "Qwen/Qwen2-72B-Instruct",
-    "Qwen_Qwen_2_72B": "qwen-qwen2-72b-instruct"
+    "HuggingFaceAPI": "Qwen/Qwen2-72B-Instruct"
   },
   "qwen-2-vl-7b": {
     "HuggingFaceAPI": "Qwen/Qwen2-VL-7B-Instruct",
@@ -533,10 +450,6 @@ model_map = {
   "qwen-2-vl-72b": {
     "Together": "qwen-2-vl-72b"
   },
-  "qwen-2.5": {
-    "HuggingSpace": "qwen-qwen2-5",
-    "Qwen_Qwen_2_5": "qwen-qwen2-5"
-  },
   "qwen-2.5-7b": {
     "Together": "qwen-2.5-7b",
     "HuggingFace": "Qwen/Qwen2.5-7B-Instruct",
@@ -544,49 +457,35 @@ model_map = {
       "openrouter:qwen/qwen-2.5-7b-instruct:free",
       "openrouter:qwen/qwen-2.5-7b-instruct"
     ],
-    "HuggingFaceAPI": "unsloth/Qwen2.5-7B-Instruct",
-    "Nvidia": "qwen/qwen2.5-7b-instruct",
     "GlhfChat": "hf:Qwen/Qwen2.5-7B-Instruct",
     "HuggingChat": "Qwen/Qwen2.5-7B-Instruct",
+    "HuggingFaceAPI": "Qwen/Qwen2.5-7B",
     "OpenRouter": "qwen/qwen-2.5-7b-instruct"
   },
   "qwen-2.5-72b": {
     "Together": "qwen-2.5-72b",
-    "Qwen": "qwen2.5-72b-instruct",
     "HuggingFace": "Qwen/Qwen2.5-Coder-32B-Instruct",
     "PuterJS": [
       "openrouter:qwen/qwen-2.5-72b-instruct:free",
       "openrouter:qwen/qwen-2.5-72b-instruct"
     ],
-    "HuggingFaceAPI": "Qwen/Qwen2.5-Coder-32B-Instruct",
     "GlhfChat": "hf:Qwen/Qwen2.5-72B-Instruct",
     "HuggingChat": "Qwen/Qwen2.5-Coder-32B-Instruct",
-    "OpenRouter": "qwen/qwen-2.5-72b-instruct",
-    "Yupp": "qwen/qwen-2.5-72b-instruct"
+    "HuggingFaceAPI": "Qwen/Qwen2.5-Coder-32B-Instruct",
+    "OpenRouter": "qwen/qwen-2.5-72b-instruct"
   },
   "qwen-2.5-coder-32b": {
     "Together": "qwen-2.5-coder-32b",
     "HuggingChat": "Qwen/Qwen2.5-Coder-32B-Instruct",
-    "Qwen": "qwen2.5-coder-32b-instruct",
     "HuggingFace": "Qwen/Qwen2.5-Coder-32B-Instruct",
     "PuterJS": [
       "openrouter:qwen/qwen-2.5-coder-32b-instruct:free",
       "openrouter:qwen/qwen-2.5-coder-32b-instruct"
     ],
-    "HuggingFaceAPI": "Qwen/Qwen2.5-Coder-32B-Instruct",
-    "Nvidia": "qwen/qwen2.5-coder-32b-instruct",
     "GlhfChat": "hf:Qwen/Qwen2.5-Coder-32B-Instruct",
+    "HuggingFaceAPI": "Qwen/Qwen2.5-Coder-32B-Instruct",
     "OpenRouter": "qwen/qwen-2.5-coder-32b-instruct",
-    "PollinationsAI": "qwen-3-coder",
-    "Yupp": "qwen/qwen-2.5-coder-32b-instruct"
-  },
-  "qwen-2.5-1m": {
-    "HuggingSpace": "qwen-2.5-1m-demo",
-    "Qwen_Qwen_2_5M": "qwen-2.5-1m-demo"
-  },
-  "qwen-2.5-max": {
-    "HuggingSpace": "qwen-qwen2-5-max",
-    "Qwen_Qwen_2_5_Max": "qwen-qwen2-5-max"
+    "PollinationsAI": "qwen-3-coder"
   },
   "qwen-2.5-vl-72b": {
     "Together": "qwen-2.5-vl-72b",
@@ -594,81 +493,31 @@ model_map = {
       "openrouter:qwen/qwen2.5-vl-72b-instruct:free",
       "openrouter:qwen/qwen2.5-vl-72b-instruct"
     ],
-    "HuggingFaceAPI": "Qwen/Qwen2.5-VL-72B-Instruct",
     "HuggingChat": "Qwen/Qwen2.5-VL-72B-Instruct",
-    "OpenRouter": "qwen/qwen2.5-vl-72b-instruct",
-    "Yupp": "qwen2.5-vl-72b-instruct"
+    "HuggingFaceAPI": "Qwen/Qwen2.5-VL-72B-Instruct",
+    "OpenRouter": "qwen/qwen2.5-vl-72b-instruct"
   },
   "qwen-3-235b": {
-    "DeepInfra": "Qwen/Qwen3-235B-A22B",
     "Together": "qwen-3-235b",
-    "HuggingSpace": "qwen3-235b-a22b",
     "PuterJS": [
       "openrouter:qwen/qwen3-235b-a22b:free",
       "openrouter:qwen/qwen3-235b-a22b"
-    ],
-    "ApiAirforce": "qwen3-235b",
-    "GradientNetwork": "Qwen3 235B",
-    "Qwen_Qwen_3": "qwen3-235b-a22b"
+    ]
   },
   "qwen-3-32b": {
-    "DeepInfra": "Qwen/Qwen3-32B",
     "Together": "qwen-3-32b",
-    "HuggingSpace": "qwen3-32b",
     "PuterJS": [
       "openrouter:qwen/qwen3-32b:free",
       "openrouter:qwen/qwen3-32b"
     ],
-    "HuggingFaceAPI": "Qwen/Qwen3-32B",
-    "Groq": "qwen/qwen3-32b",
+    "ApiAirforce": "qwen3-32b",
     "HuggingChat": "Qwen/Qwen3-32B",
-    "OpenRouter": "qwen/qwen3-32b",
-    "Qwen_Qwen_3": "qwen3-32b"
-  },
-  "qwen-3-30b": {
-    "DeepInfra": "Qwen/Qwen3-30B-A3B",
-    "HuggingSpace": "qwen3-30b-a3b",
-    "PuterJS": [
-      "openrouter:qwen/qwen3-30b-a3b:free",
-      "openrouter:qwen/qwen3-30b-a3b"
-    ],
-    "Qwen_Qwen_3": "qwen3-30b-a3b"
-  },
-  "qwen-3-14b": {
-    "DeepInfra": "Qwen/Qwen3-14B",
-    "HuggingSpace": "qwen3-14b",
-    "PuterJS": [
-      "openrouter:qwen/qwen3-14b:free",
-      "openrouter:qwen/qwen3-14b"
-    ],
-    "HuggingFaceAPI": "Qwen/Qwen3-14B",
-    "HuggingChat": "Qwen/Qwen3-14B",
-    "OpenRouter": "qwen/qwen3-14b",
-    "Qwen_Qwen_3": "qwen3-14b"
-  },
-  "qwen-3-4b": {
-    "HuggingSpace": "qwen3-4b",
-    "OpenRouterFree": "qwen/qwen3-4b:free",
-    "PuterJS": "openrouter:qwen/qwen3-4b:free",
-    "OpenRouter": "qwen/qwen3-4b:free",
-    "Qwen_Qwen_3": "qwen3-4b"
-  },
-  "qwen-3-1.7b": {
-    "HuggingSpace": "qwen3-1.7b",
-    "PuterJS": "openrouter:qwen/qwen3-1.7b:free",
-    "HuggingFaceAPI": "Qwen/Qwen3-1.7B",
-    "Qwen_Qwen_3": "qwen3-1.7b"
-  },
-  "qwen-3-0.6b": {
-    "HuggingSpace": "qwen3-0.6b",
-    "PuterJS": "openrouter:qwen/qwen3-0.6b-04-28:free",
-    "Qwen_Qwen_3": "qwen3-0.6b"
+    "HuggingFaceAPI": "Qwen/Qwen3-32B",
+    "OpenRouter": "qwen/qwen3-32b"
   },
   "qwq-32b": {
-    "DeepInfra": "Qwen/QwQ-32B",
     "Together": "qwq-32b",
     "HuggingChat": "Qwen/QwQ-32B",
-    "Qwen": "qwq-32b",
     "HuggingFace": "Qwen/QwQ-32B",
     "LMArena": "qwq-32b",
     "PuterJS": [
@@ -676,64 +525,45 @@ model_map = {
       "openrouter:qwen/qwq-32b:free",
       "openrouter:qwen/qwq-32b"
     ],
-    "HuggingFaceAPI": "Qwen/QwQ-32B",
-    "Nvidia": "qwen/qwq-32b",
     "GlhfChat": "hf:Qwen/QwQ-32B-Preview",
-    "OpenRouter": "qwen/qwq-32b",
-    "Yupp": "qwen/qwq-32b"
+    "HuggingFaceAPI": "Qwen/QwQ-32B"
   },
   "deepseek-v3": {
-    "DeepInfra": [
-      "deepseek-ai/DeepSeek-V3",
-      "deepseek-ai/DeepSeek-V3-0324"
-    ],
     "Together": "deepseek-v3",
-    "PuterJS": "openrouter:deepseek/deepseek-v3-base:free",
-    "PollinationsAI": "deepseek"
+    "PuterJS": "openrouter:deepseek/deepseek-v3-base:free"
   },
   "deepseek-r1": {
-    "DeepInfra": [
-      "deepseek-ai/DeepSeek-R1",
-      "deepseek-ai/DeepSeek-R1-0528"
-    ],
     "PollinationsAI": "deepseek-reasoning",
     "Together": "deepseek-r1",
     "HuggingChat": "deepseek-ai/DeepSeek-R1",
     "HuggingFace": "deepseek-ai/DeepSeek-R1",
-    "Azure": "deepseek-r1",
     "PuterJS": [
       "deepseek-reasoner",
       "openrouter:deepseek/deepseek-r1:free",
       "openrouter:deepseek/deepseek-r1"
     ],
-    "HuggingFaceAPI": "deepseek-ai/DeepSeek-R1",
-    "Nvidia": "deepseek-ai/deepseek-r1",
     "ApiAirforce": "deepseek-r1",
     "Cerebras": "deepseek-r1-distill-llama-70b",
+    "DeepSeekAPI": "deepseek-r1",
+    "HuggingFaceAPI": "deepseek-ai/DeepSeek-R1",
+    "OllamaSwarm": "deepseek-r1:7b",
     "OpenRouter": "deepseek/deepseek-r1",
-    "Yupp": "deepseek/deepseek-r1"
-  },
-  "deepseek-r1-turbo": {
-    "DeepInfra": "deepseek-ai/DeepSeek-R1-Turbo"
+    "WeWordle": "v3"
   },
   "deepseek-r1-distill-llama-70b": {
-    "DeepInfra": "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
     "Together": "deepseek-r1-distill-llama-70b",
     "PuterJS": [
       "openrouter:deepseek/deepseek-r1-distill-llama-70b:free",
       "openrouter:deepseek/deepseek-r1-distill-llama-70b"
     ],
-    "HuggingFaceAPI": "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
     "Cerebras": "deepseek-r1-distill-llama-70b",
     "HuggingChat": "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
-    "OpenRouter": "deepseek/deepseek-r1-distill-llama-70b",
-    "Yupp": "DeepSeek-R1-Distill-Llama-70B"
+    "OpenRouter": "deepseek/deepseek-r1-distill-llama-70b"
   },
   "deepseek-r1-distill-qwen-1.5b": {
     "Together": "deepseek-r1-distill-qwen-1.5b",
     "PuterJS": "openrouter:deepseek/deepseek-r1-distill-qwen-1.5b",
-    "HuggingFaceAPI": "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",
-    "HuggingChat": "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
+    "HuggingFaceAPI": "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
   },
   "deepseek-r1-distill-qwen-14b": {
     "Together": "deepseek-r1-distill-qwen-14b",
@@ -741,62 +571,7 @@ model_map = {
       "openrouter:deepseek/deepseek-r1-distill-qwen-14b:free",
       "openrouter:deepseek/deepseek-r1-distill-qwen-14b"
     ],
-    "HuggingFaceAPI": "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B",
-    "Nvidia": "deepseek-ai/deepseek-r1-distill-qwen-14b",
-    "HuggingChat": "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B",
-    "OpenRouter": "deepseek/deepseek-r1-distill-qwen-14b"
-  },
-  "deepseek-r1-distill-qwen-32b": {
-    "DeepInfra": "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B",
-    "HuggingFace": "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B",
-    "PuterJS": [
-      "openrouter:deepseek/deepseek-r1-distill-qwen-32b:free",
-      "openrouter:deepseek/deepseek-r1-distill-qwen-32b"
-    ],
-    "HuggingFaceAPI": "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B",
-    "Nvidia": "deepseek-ai/deepseek-r1-distill-qwen-32b",
-    "HuggingChat": "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B",
-    "OpenRouter": "deepseek/deepseek-r1-distill-qwen-32b"
-  },
-  "deepseek-prover-v2": {
-    "DeepInfra": "deepseek-ai/DeepSeek-Prover-V2-671B",
-    "PuterJS": [
-      "openrouter:deepseek/deepseek-prover-v2:free",
-      "openrouter:deepseek/deepseek-prover-v2"
-    ]
-  },
-  "deepseek-prover-v2-671b": {
-    "DeepInfra": "deepseek-ai/DeepSeek-Prover-V2-671B",
-    "HuggingChat": "deepseek-ai/DeepSeek-Prover-V2-671B"
-  },
-  "deepseek-v3-0324": {
-    "DeepInfra": "deepseek-ai/DeepSeek-V3-0324",
-    "LMArena": "deepseek-v3-0324",
-    "PuterJS": [
-      "deepseek-chat",
-      "openrouter:deepseek/deepseek-chat-v3-0324:free",
-      "openrouter:deepseek/deepseek-chat-v3-0324"
-    ],
-    "HuggingChat": "deepseek-ai/DeepSeek-V3-0324"
-  },
-  "deepseek-v3-0324-turbo": {
-    "DeepInfra": "deepseek-ai/DeepSeek-V3-0324-Turbo"
-  },
-  "deepseek-r1-0528": {
-    "DeepInfra": "deepseek-ai/DeepSeek-R1-0528",
-    "OpenRouterFree": "deepseek/deepseek-r1-0528:free",
-    "PuterJS": "openrouter:deepseek/deepseek-r1-0528:free",
-    "HuggingFaceAPI": "deepseek-ai/DeepSeek-R1-0528",
-    "Nvidia": "deepseek-ai/deepseek-r1-0528",
-    "HuggingChat": "deepseek-ai/DeepSeek-R1-0528",
-    "OpenRouter": "deepseek/deepseek-r1-0528:free"
-  },
-  "deepseek-r1-0528-turbo": {
-    "DeepInfra": "deepseek-ai/DeepSeek-R1-0528-Turbo"
-  },
-  "janus-pro-7b": {
-    "DeepseekAI_JanusPro7b": "janus-pro-7b",
-    "HuggingSpace": "janus-pro-7b"
+    "HuggingFaceAPI": "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B"
   },
   "grok-2": {
     "Grok": "grok-2",
@@ -807,37 +582,30 @@ model_map = {
   },
   "grok-3": {
     "Grok": "grok-3",
-    "Azure": "grok-3",
-    "PuterJS": "openrouter:x-ai/grok-3",
-    "OpenRouter": "x-ai/grok-3"
+    "PuterJS": "x-ai:x-ai/grok-3",
+    "ApiAirforce": "grok-3"
   },
   "grok-3-r1": {
     "Grok": "grok-3-reasoning"
   },
   "kimi-k2": {
     "HuggingFace": "moonshotai/Kimi-K2-Instruct",
-    "DeepInfra": "moonshotai/Kimi-K2-Instruct",
-    "Groq": "moonshotai/kimi-k2-instruct",
-    "PollinationsAI": "kimi-k2-thinking",
-    "OpenRouterFree": "moonshotai/kimi-k2:free",
-    "PuterJS": "openrouter:moonshotai/kimi-k2:free",
-    "HuggingFaceAPI": "moonshotai/Kimi-K2-Instruct",
-    "Nvidia": "moonshotai/kimi-k2-instruct",
-    "Ollama": "kimi-k2:1t",
+    "Groq": "moonshotai/Kimi-K2-Instruct",
+    "PuterJS": "openrouter:moonshotai/kimi-k2",
     "ApiAirforce": "kimi-k2",
     "HuggingChat": "moonshotai/Kimi-K2-Instruct",
-    "OpenRouter": "moonshotai/kimi-k2:free"
+    "OllamaSwarm": "kimi-k2:1t-cloud",
+    "OpenRouter": "moonshotai/kimi-k2"
   },
   "sonar": {
     "PuterJS": "openrouter:perplexity/sonar",
-    "PollinationsAI": "perplexity-fast",
     "OpenRouter": "perplexity/sonar",
-    "Yupp": "sonar"
+    "PollinationsAI": "perplexity-fast"
   },
   "sonar-pro": {
     "PuterJS": "openrouter:perplexity/sonar-pro",
     "OpenRouter": "perplexity/sonar-pro",
-    "Yupp": "sonar-pro"
+    "PollinationsAI": "perplexity"
   },
   "sonar-reasoning": {
     "PuterJS": "openrouter:perplexity/sonar-reasoning",
@@ -846,7 +614,7 @@ model_map = {
   "sonar-reasoning-pro": {
     "PuterJS": "openrouter:perplexity/sonar-reasoning-pro",
     "OpenRouter": "perplexity/sonar-reasoning-pro",
-    "Yupp": "sonar-reasoning-pro"
+    "PollinationsAI": "perplexity-reasoning"
   },
   "r1-1776": {
     "Together": "r1-1776",
@@ -860,45 +628,32 @@ model_map = {
     "PuterJS": "openrouter:nvidia/llama-3.1-nemotron-70b-instruct",
     "HuggingFaceAPI": "nvidia/Llama-3.1-Nemotron-70B-Instruct-HF"
   },
-  "dolphin-2.6": {
-    "DeepInfra": "cognitivecomputations/dolphin-2.6-mixtral-8x7b"
-  },
-  "dolphin-2.9": {
-    "DeepInfra": "cognitivecomputations/dolphin-2.9.1-llama-3-70b"
-  },
-  "airoboros-70b": {
-    "DeepInfra": "deepinfra/airoboros-70b"
-  },
-  "lzlv-70b": {
-    "DeepInfra": "lizpreciatior/lzlv_70b_fp16_hf"
-  },
   "aria": {
     "OperaAria": "aria"
   },
   "sdxl-turbo": {
     "HuggingFaceMedia": "stabilityai/sdxl-turbo",
     "PollinationsImage": "sdxl-turbo",
-    "PollinationsAI": "turbo",
     "HuggingFace": "stabilityai/sdxl-turbo",
-    "HuggingChat": "stabilityai/sdxl-turbo"
+    "HuggingChat": "stabilityai/sdxl-turbo",
+    "PollinationsAI": "turbo"
   },
   "sd-3.5-large": {
     "HuggingFaceMedia": "stabilityai/stable-diffusion-3.5-large",
     "HuggingSpace": "stabilityai-stable-diffusion-3-5-large",
     "HuggingFace": "stabilityai/stable-diffusion-3.5-large",
     "HuggingChat": "stabilityai/stable-diffusion-3.5-large",
-    "StabilityAI_SD35Large": "stabilityai-stable-diffusion-3-5-large",
-    "Yupp": "replicate/stability-ai/stable-diffusion-3.5-large"
+    "StabilityAI_SD35Large": "stabilityai-stable-diffusion-3-5-large"
   },
   "flux": {
     "HuggingFaceMedia": "black-forest-labs/FLUX.1-dev",
     "PollinationsImage": "flux",
     "Together": "flux",
     "HuggingSpace": "black-forest-labs-flux-1-dev",
-    "PollinationsAI": "flux",
     "HuggingFace": "black-forest-labs/FLUX.1-dev",
     "BlackForestLabs_Flux1Dev": "black-forest-labs-flux-1-dev",
-    "HuggingChat": "black-forest-labs/FLUX.1-dev"
+    "HuggingChat": "black-forest-labs/FLUX.1-dev",
+    "PollinationsAI": "flux"
   },
   "flux-pro": {
     "PollinationsImage": "flux-pro",
@@ -913,8 +668,7 @@ model_map = {
     "HuggingFace": "black-forest-labs/FLUX.1-dev",
     "HuggingFaceMedia": "black-forest-labs/FLUX.1-dev",
     "BlackForestLabs_Flux1Dev": "black-forest-labs-flux-1-dev",
-    "PollinationsAI": "flux",
-    "Yupp": "replicate/black-forest-labs/flux-dev"
+    "PollinationsAI": "flux"
   },
   "flux-schnell": {
     "PollinationsImage": "flux-schnell",
@@ -922,8 +676,7 @@ model_map = {
     "HuggingChat": "black-forest-labs/FLUX.1-schnell",
     "HuggingFace": "black-forest-labs/FLUX.1-schnell",
     "HuggingFaceMedia": "black-forest-labs/FLUX.1-schnell",
-    "PollinationsAI": "flux",
-    "Yupp": "replicate/black-forest-labs/flux-schnell"
+    "PollinationsAI": "flux"
   },
   "flux-redux": {
     "Together": "flux-redux"
@@ -936,20 +689,22 @@ model_map = {
   },
   "flux-kontext": {
     "PollinationsAI": "kontext",
-    "Azure": "flux.1-kontext-pro",
-    "LMArena": "flux-1-kontext-pro",
     "Together": "flux-kontext"
   },
   "flux-dev-lora": {
-    "Together": "flux-dev-lora",
-    "Yupp": "replicate/black-forest-labs/flux-dev-lora"
+    "Together": "flux-dev-lora"
+  },
+  "auto": {
+    "OpenaiChat": "auto",
+    "OpenRouter": "openrouter/auto"
   },
   "gpt-5.2": {
     "OpenaiChat": "gpt-5-2",
-    "PollinationsAI": "openai-large",
     "LMArena": "gpt-5.2",
-    "PuterJS": "openrouter:openai/gpt-5.2",
-    "OpenRouter": "openai/gpt-5.2"
+    "PuterJS": "openai:openai/gpt-5.2",
+    "ApiAirforce": "gpt-5.2",
+    "OpenRouter": "openai/gpt-5.2",
+    "PollinationsAI": "gpt-5.4"
   },
   "gpt-5.2-instant": {
     "OpenaiChat": "gpt-5-2-instant"
@@ -960,7 +715,8 @@ model_map = {
   "gpt-5.1": {
     "OpenaiChat": "gpt-5-1",
     "LMArena": "gpt-5.1",
-    "PuterJS": "openrouter:openai/gpt-5.1",
+    "PuterJS": "azure:openai/gpt-5.1",
+    "ApiAirforce": "gpt-5.1",
     "OpenRouter": "openai/gpt-5.1"
   },
   "gpt-5.1-instant": {
@@ -970,15 +726,15 @@ model_map = {
     "OpenaiChat": "gpt-5-1-thinking"
   },
   "gpt-5": {
-    "CopilotApp": "Smart (GPT-5)",
     "OpenaiChat": "gpt-5",
     "Copilot": "GPT-5",
     "Perplexity": "gpt-5",
-    "PuterJS": "openrouter:openai/gpt-5",
+    "EasyChat": "gpt-5-free",
+    "PuterJS": "openai:openai/gpt-5",
+    "ApiAirforce": "gpt-5",
+    "CopilotApp": "smart",
     "CopilotSession": "GPT-5",
-    "GithubCopilot": "gpt-5",
-    "OpenRouter": "openai/gpt-5",
-    "Yupp": "gpt-5"
+    "OpenRouter": "openai/gpt-5"
   },
   "gpt-5-instant": {
     "OpenaiChat": "gpt-5-instant"
@@ -987,174 +743,247 @@ model_map = {
     "OpenaiChat": "gpt-5-thinking",
     "Perplexity": "gpt-5-thinking"
   },
-  "study": {
-    "Copilot": "Study",
-    "CopilotAccount": "Study",
-    "CopilotSession": "Study"
+  "chat": {
+    "CopilotApp": "chat"
   },
   "openai": {
     "PollinationsAI": "openai"
   },
-  "gpt-5-nano": {
-    "PollinationsAI": "openai-fast",
-    "PuterJS": "openrouter:openai/gpt-5-nano",
-    "OpenRouter": "openai/gpt-5-nano",
-    "Yupp": "gpt-5-nano-2025-08-07"
+  "openai-fast": {
+    "PollinationsAI": "openai-fast"
   },
-  "qwen-3-coder": {
+  "gpt-5.4": {
+    "PollinationsAI": "gpt-5.4",
+    "PuterJS": "openai:openai/gpt-5.4",
+    "ApiAirforce": "gpt-5.4",
+    "OpenRouter": "openai/gpt-5.4"
+  },
+  "gpt-5.4-mini": {
+    "PollinationsAI": "gpt-5.4-mini",
+    "PuterJS": "azure:openai/gpt-5.4-mini",
+    "ApiAirforce": "gpt-5.4-mini",
+    "OpenRouter": "openai/gpt-5.4-mini"
+  },
+  "openai-large": {
+    "PollinationsAI": "openai-large"
+  },
+  "mercury": {
+    "PollinationsAI": "mercury",
+    "LMArena": "mercury"
+  },
+  "qwen-coder": {
     "PollinationsAI": "qwen-coder",
-    "OpenRouterFree": "qwen/qwen3-coder:free",
-    "PuterJS": "openrouter:qwen/qwen3-coder:free",
-    "Ollama": "qwen3-coder:480b",
-    "OpenRouter": "qwen/qwen3-coder:free",
-    "Yupp": "qwen/qwen3-coder:exacto<>OPR"
+    "OllamaSwarm": "qwen-coder:14b"
   },
-  "mistral-small": {
+  "mistral-small-3.2": {
+    "PollinationsAI": "mistral-small-3.2"
+  },
+  "mistral": {
     "PollinationsAI": "mistral",
-    "Yupp": "mistral-small-latest"
+    "OllamaSwarm": "mistral:7b-instruct-v0.3-q4_0"
   },
-  "gpt-4o-mini-audio": {
-    "PollinationsAI": "gpt-4o-mini-audio-preview",
-    "Azure": "gpt-4o-mini-audio-preview"
+  "openai-audio": {
+    "PollinationsAI": "openai-audio"
+  },
+  "openai-audio-large": {
+    "PollinationsAI": "openai-audio-large"
   },
   "gemini-3-flash": {
-    "PollinationsAI": "gemini",
+    "PollinationsAI": "gemini-3-flash",
     "LMArena": "gemini-3-flash",
     "PuterJS": "openrouter:google/gemini-3-flash-preview",
-    "Ollama": "gemini-3-flash-preview",
+    "Antigravity": "gemini-3-flash",
     "ApiAirforce": "gemini-3-flash",
+    "Ollama": "gemini-3-flash-preview",
+    "OllamaSwarm": "gemini-3-flash-preview:cloud",
     "OpenRouter": "google/gemini-3-flash-preview"
   },
-  "gemini-2.5-flash-lite": {
-    "PollinationsAI": "gemini-fast",
-    "PuterJS": "openrouter:google/gemini-2.5-flash-lite",
-    "GeminiPro": "gemini-2.5-flash-lite",
-    "OpenRouter": "google/gemini-2.5-flash-lite"
+  "gemini": {
+    "PollinationsAI": "gemini"
+  },
+  "gemini-flash-lite-3.1": {
+    "PollinationsAI": "gemini-flash-lite-3.1"
+  },
+  "gemini-fast": {
+    "PollinationsAI": "gemini-fast"
   },
   "deepseek": {
-    "PollinationsAI": "deepseek-v3",
-    "DeepInfra": "deepseek-ai/DeepSeek-V3",
-    "PuterJS": "deepseek-v3",
-    "HuggingFaceAPI": "deepseek-ai/DeepSeek-V3",
-    "ApiAirforce": "deepseek-v3",
+    "PollinationsAI": "deepseek",
+    "ApiAirforce": "deepseek",
+    "DeepSeekAPI": "deepseek-v3",
     "GlhfChat": "hf:deepseek-ai/DeepSeek-V3",
-    "HuggingChat": "deepseek-ai/DeepSeek-V3"
+    "HuggingChat": "deepseek-ai/DeepSeek-V3",
+    "HuggingFaceAPI": "deepseek-ai/DeepSeek-V3",
+    "OllamaSwarm": "deepseek-v2:16b-lite-chat-q8_0",
+    "PhindAi": "deepseek",
+    "WeWordle": "v3"
   },
-  "grok-fast": {
-    "PollinationsAI": "grok"
+  "gemma": {
+    "PollinationsAI": "gemma",
+    "OllamaSwarm": "gemma:2b-instruct",
+    "TeachAnything": "gemma"
   },
-  "gemini-3-flash-search": {
+  "deepseek-pro": {
+    "PollinationsAI": "deepseek-pro"
+  },
+  "grok": {
+    "PollinationsAI": "grok",
+    "Grok": "grok-latest",
+    "PuterJS": [
+      "openrouter:x-ai/grok-vision-beta",
+      "openrouter:x-ai/grok-2-vision-1212",
+      "openrouter:x-ai/grok-2-1212",
+      "grok-beta",
+      "grok-vision-beta",
+      "openrouter:x-ai/grok-beta",
+      "openrouter:x-ai/grok-3-beta",
+      "openrouter:x-ai/grok-3-mini-beta"
+    ]
+  },
+  "grok-4-20-reasoning": {
+    "PollinationsAI": "grok-4-20-reasoning",
+    "PuterJS": "x-ai:x-ai/grok-4-20-reasoning"
+  },
+  "grok-large": {
+    "PollinationsAI": "grok-large"
+  },
+  "gemini-search": {
     "PollinationsAI": "gemini-search"
   },
-  "chickytutor": {
-    "PollinationsAI": "chickytutor"
+  "gemini-search-fast": {
+    "PollinationsAI": "gemini-search-fast"
+  },
+  "gemini-search-large": {
+    "PollinationsAI": "gemini-search-large"
   },
   "midijourney": {
     "PollinationsAI": "midijourney"
   },
-  "claude-haiku-4-5": {
-    "PollinationsAI": "claude-haiku-4.5",
-    "LMArena": "claude-haiku-4-5-20251001",
-    "PuterJS": "openrouter:anthropic/claude-haiku-4.5",
-    "OpenRouter": "anthropic/claude-haiku-4.5",
-    "Yupp": "claude-haiku-4-5-20251001"
+  "midijourney-large": {
+    "PollinationsAI": "midijourney-large"
   },
-  "claude-sonnet-4-5": {
-    "PollinationsAI": "claude-sonnet-4.5",
-    "LMArena": "claude-sonnet-4-5-20250929",
-    "PuterJS": "openrouter:anthropic/claude-sonnet-4.5",
-    "ApiAirforce": "claude-sonnet-4.5",
-    "OpenRouter": "anthropic/claude-sonnet-4.5"
+  "claude-fast": {
+    "PollinationsAI": "claude-fast"
   },
-  "claude-opus-4.5": {
-    "PollinationsAI": "claude-large",
-    "PuterJS": "openrouter:anthropic/claude-opus-4.5",
-    "OpenRouter": "anthropic/claude-opus-4.5"
+  "claude": {
+    "PollinationsAI": "claude"
   },
-  "gemini-3-pro": {
-    "PollinationsAI": "gemini-large",
-    "Gemini": "gemini-3-pro",
-    "LMArena": "gemini-3-pro",
-    "PuterJS": "openrouter:google/gemini-3-pro-preview",
-    "Ollama": "gemini-3-pro-preview",
-    "ApiAirforce": "gemini-3-pro",
-    "GeminiCLI": "gemini-3-pro-preview",
-    "OpenRouter": "google/gemini-3-pro-preview"
+  "claude-opus-4.6": {
+    "PollinationsAI": "claude-opus-4.6",
+    "ApiAirforce": "claude-opus-4.6",
+    "OpenRouter": "anthropic/claude-opus-4.6"
   },
-  "amazon-nova-micro": {
-    "PollinationsAI": "nova-micro"
+  "claude-opus-4.7": {
+    "PollinationsAI": "claude-opus-4.7",
+    "ApiAirforce": "claude-opus-4.7",
+    "OpenRouter": "anthropic/claude-opus-4.7"
   },
-  "glm-4.7": {
-    "PollinationsAI": "glm",
-    "HuggingFace": "zai-org/GLM-4.7",
-    "LMArena": "glm-4.7",
-    "PuterJS": "openrouter:z-ai/glm-4.7",
-    "HuggingFaceAPI": "zai-org/GLM-4.7-FP8",
-    "Ollama": "glm-4.7",
-    "ApiAirforce": "glm-4.7",
-    "HuggingChat": "zai-org/GLM-4.7-FP8",
-    "OpenRouter": "z-ai/glm-4.7"
+  "claude-large": {
+    "PollinationsAI": "claude-large"
   },
-  "minimax-m3": {
-    "MiniMax": "MiniMax-M3"
+  "perplexity-fast": {
+    "PollinationsAI": "perplexity-fast"
+  },
+  "perplexity-deep": {
+    "PollinationsAI": "perplexity-deep"
+  },
+  "perplexity": {
+    "PollinationsAI": "perplexity",
+    "Perplexity": "perplexity"
+  },
+  "perplexity-reasoning": {
+    "PollinationsAI": "perplexity-reasoning"
+  },
+  "kimi": {
+    "PollinationsAI": "kimi",
+    "PuterJS": "openrouter:~moonshotai/kimi-latest",
+    "OpenRouter": "~moonshotai/kimi-latest"
+  },
+  "kimi-code": {
+    "PollinationsAI": "kimi-code"
+  },
+  "gemini-large": {
+    "PollinationsAI": "gemini-large"
+  },
+  "nova-fast": {
+    "PollinationsAI": "nova-fast"
+  },
+  "nova": {
+    "PollinationsAI": "nova",
+    "OpenAIFM": "nova"
+  },
+  "glm": {
+    "PollinationsAI": "glm"
+  },
+  "llama-": {
+    "PollinationsAI": "llama"
+  },
+  "llama-maverick": {
+    "PollinationsAI": "llama-maverick"
+  },
+  "llama-scout": {
+    "PollinationsAI": "llama-scout"
   },
   "minimax-m2.7": {
-    "MiniMax": "MiniMax-M2.7"
+    "PollinationsAI": "minimax-m2.7",
+    "LMArena": "minimax-m2.7",
+    "PuterJS": "minimax:minimax/minimax-m2.7",
+    "ApiAirforce": "minimax-m2.7",
+    "HuggingChat": "MiniMaxAI/MiniMax-M2.7",
+    "HuggingFaceAPI": "MiniMaxAI/MiniMax-M2.7",
+    "MiniMax": "MiniMax-M2.7",
+    "Ollama": "minimax-m2.7",
+    "OllamaSwarm": "minimax-m2.7:cloud",
+    "OpenRouter": "minimax/minimax-m2.7"
   },
-  "minimax-m2.7-highspeed": {
-    "MiniMax": "MiniMax-M2.7-highspeed"
-  },
-  "minimax-m2.1": {
+  "minimax": {
     "PollinationsAI": "minimax",
-    "HuggingFace": "MiniMaxAI/MiniMax-M2.1",
-    "LMArena": "minimax-m2.1-preview",
-    "PuterJS": "openrouter:minimax/minimax-m2.1",
-    "HuggingFaceAPI": "MiniMaxAI/MiniMax-M2.1",
-    "Nvidia": "minimaxai/minimax-m2.1",
-    "Ollama": "minimax-m2.1",
-    "HuggingChat": "MiniMaxAI/MiniMax-M2.1",
-    "OpenRouter": "minimax/minimax-m2.1"
+    "PuterJS": "openrouter:minimax/minimax-01",
+    "HailuoAI": "minimax"
   },
-  "turbo": {
-    "PollinationsAI": "turbo",
-    "Yupp": "fal-ai/z-image/turbo"
+  "mistral-large": {
+    "PollinationsAI": "mistral-large",
+    "OpenRouter": "mistralai/mistral-large"
   },
-  "kontext": {
-    "PollinationsAI": "kontext"
+  "polly": {
+    "PollinationsAI": "polly"
   },
-  "nanobanana": {
-    "PollinationsAI": "nanobanana"
+  "qwen-coder-large": {
+    "PollinationsAI": "qwen-coder-large"
   },
-  "nanobanana-pro": {
-    "PollinationsAI": "nanobanana-pro"
+  "qwen-large": {
+    "PollinationsAI": "qwen-large"
   },
-  "seedream": {
-    "PollinationsAI": "seedream"
+  "qwen-vision": {
+    "PollinationsAI": "qwen-vision"
   },
-  "seedream-pro": {
-    "PollinationsAI": "seedream-pro"
+  "qwen-vision-pro": {
+    "PollinationsAI": "qwen-vision-pro"
   },
-  "gpt-image-1.5": {
-    "PollinationsAI": "gptimage-large",
-    "LMArena": "gpt-image-1.5",
-    "ApiAirforce": "gpt-image-1.5"
+  "step-flash": {
+    "PollinationsAI": "step-flash"
   },
-  "z-image": {
-    "PollinationsAI": "zimage",
-    "LMArena": "z-image",
-    "ApiAirforce": "z-image"
+  "step-3.5-flash": {
+    "PollinationsAI": "step-3.5-flash",
+    "DeepInfra": "stepfun-ai/Step-3.5-Flash",
+    "LMArena": "step-3.5-flash",
+    "PuterJS": "openrouter:stepfun/step-3.5-flash",
+    "ApiAirforce": "step-3.5-flash:free",
+    "HuggingChat": "stepfun-ai/Step-3.5-Flash",
+    "HuggingFaceAPI": "stepfun-ai/Step-3.5-Flash",
+    "OpenRouter": "stepfun/step-3.5-flash"
   },
-  "openai-audio": {
-    "PollinationsAudio": "openai-audio"
+  "qwen-safety": {
+    "PollinationsAI": "qwen-safety"
   },
-  "": {
-    "Gemini": "",
-    "BlackboxPro": ""
+  "sana": {
+    "PollinationsAI": "sana"
   },
   "grok-4": {
     "Grok": "grok-4",
-    "PuterJS": "openrouter:x-ai/grok-4",
-    "OpenRouter": "x-ai/grok-4"
+    "PuterJS": "x-ai:x-ai/grok-4",
+    "ApiAirforce": "grok-4",
+    "PollinationsAI": "grok"
   },
   "grok-4-heavy": {
     "Grok": "grok-4-heavy"
@@ -1168,7 +997,7 @@ model_map = {
   "grok-3-mini": {
     "Grok": "grok-3-mini",
     "PuterJS": "openrouter:x-ai/grok-3-mini-beta",
-    "OpenRouter": "x-ai/grok-3-mini"
+    "ApiAirforce": "grok-3-mini"
   },
   "grok-3-mini-reasoning": {
     "Grok": "grok-3-mini-reasoning"
@@ -1176,445 +1005,362 @@ model_map = {
   "grok-2-image": {
     "Grok": "grok-2-image"
   },
-  "grok": {
-    "Grok": "grok-latest",
-    "PuterJS": [
-      "openrouter:x-ai/grok-vision-beta",
-      "openrouter:x-ai/grok-2-vision-1212",
-      "openrouter:x-ai/grok-2-1212",
-      "grok-beta",
-      "grok-vision-beta",
-      "openrouter:x-ai/grok-beta",
-      "openrouter:x-ai/grok-3-beta",
-      "openrouter:x-ai/grok-3-mini-beta"
-    ]
+  "qwen-3.7-plus": {
+    "Qwen": "qwen3.7-plus",
+    "LMArena": "qwen3.7-plus",
+    "PuterJS": "togetherai:qwen/qwen3.7-plus",
+    "OpenRouter": "qwen/qwen3.7-plus"
   },
-  "model-router": {
-    "Azure": "model-router"
+  "qwen-3.7-max": {
+    "Qwen": "qwen3.7-max",
+    "LMArena": "qwen3.7-max",
+    "PuterJS": "togetherai:qwen/qwen3.7-max",
+    "OpenRouter": "qwen/qwen3.7-max"
   },
-  "gpt-5-chat": {
-    "Azure": "gpt-5-chat",
-    "LMArena": "gpt-5-chat",
-    "PuterJS": "openrouter:openai/gpt-5-chat",
-    "OpenRouter": "openai/gpt-5-chat",
-    "Yupp": "gpt-5-chat-latest"
+  "qwen-3.6-plus": {
+    "Qwen": "qwen3.6-plus-preview",
+    "LMArena": "qwen3.6-plus",
+    "PuterJS": "alibaba:qwen/qwen3.6-plus",
+    "OpenRouter": "qwen/qwen3.6-plus"
   },
-  "flux-kontext-pro": {
-    "Azure": "flux.1-kontext-pro",
-    "Yupp": "replicate/black-forest-labs/flux-kontext-pro"
+  "qwen-3.6-max": {
+    "Qwen": "qwen3.6-max-preview",
+    "PuterJS": "alibaba:qwen/qwen3.6-max-preview",
+    "OpenRouter": "qwen/qwen3.6-max-preview"
+  },
+  "qwen-3.6-27b": {
+    "Qwen": "qwen3.6-27b",
+    "LMArena": "qwen3.6-27b",
+    "PuterJS": "alibaba:qwen/qwen3.6-27b",
+    "HuggingChat": "Qwen/Qwen3.6-27B",
+    "HuggingFaceAPI": "Qwen/Qwen3.6-27B",
+    "OpenRouter": "qwen/qwen3.6-27b"
+  },
+  "qwen-series-invite-beta": {
+    "Qwen": "qwen-latest-series-invite-beta-v16"
+  },
+  "qwen-3.5-plus": {
+    "Qwen": "qwen3.5-plus",
+    "PuterJS": "openrouter:qwen/qwen3.5-plus-20260420",
+    "OpenRouter": "qwen/qwen3.5-plus-02-15"
+  },
+  "qwen-3.5-omni-plus": {
+    "Qwen": "qwen3.5-omni-plus"
+  },
+  "qwen-3.6-35b-a3b": {
+    "Qwen": "qwen3.6-35b-a3b",
+    "DeepInfra": "Qwen/Qwen3.6-35B-A3B",
+    "PuterJS": "alibaba:qwen/qwen3.6-35b-a3b",
+    "ApiAirforce": "qwen3.6-35b-a3b",
+    "HuggingChat": "Qwen/Qwen3.6-35B-A3B",
+    "HuggingFaceAPI": "Qwen/Qwen3.6-35B-A3B",
+    "OpenRouter": "qwen/qwen3.6-35b-a3b"
+  },
+  "qwen-3.5-flash": {
+    "Qwen": "qwen3.5-flash",
+    "LMArena": "qwen3.5-flash",
+    "PuterJS": "openrouter:qwen/qwen3.5-flash-02-23",
+    "OpenRouter": "qwen/qwen3.5-flash-02-23"
+  },
+  "qwen-3.5-max": {
+    "Qwen": "qwen3.5-max-2026-03-08"
+  },
+  "qwen-3.5-397b-a17b": {
+    "Qwen": "qwen3.5-397b-a17b",
+    "DeepInfra": "Qwen/Qwen3.5-397B-A17B",
+    "LMArena": "qwen3.5-397b-a17b",
+    "PuterJS": "alibaba:qwen/qwen3.5-397b-a17b",
+    "ApiAirforce": "qwen3.5-397b-a17b",
+    "HuggingChat": "Qwen/Qwen3.5-397B-A17B",
+    "HuggingFaceAPI": "Qwen/Qwen3.5-397B-A17B",
+    "OpenRouter": "qwen/qwen3.5-397b-a17b"
+  },
+  "qwen-3.5-122b-a10b": {
+    "Qwen": "qwen3.5-122b-a10b",
+    "LMArena": "qwen3.5-122b-a10b",
+    "PuterJS": "alibaba:qwen/qwen3.5-122b-a10b",
+    "HuggingChat": "Qwen/Qwen3.5-122B-A10B",
+    "HuggingFaceAPI": "Qwen/Qwen3.5-122B-A10B",
+    "OpenRouter": "qwen/qwen3.5-122b-a10b"
+  },
+  "qwen-3.5-omni-flash": {
+    "Qwen": "qwen3.5-omni-flash"
+  },
+  "qwen-3.5-27b": {
+    "Qwen": "qwen3.5-27b",
+    "LMArena": "qwen3.5-27b",
+    "PuterJS": "alibaba:qwen/qwen3.5-27b",
+    "HuggingChat": "Qwen/Qwen3.5-27B",
+    "HuggingFaceAPI": "Qwen/Qwen3.5-27B",
+    "OpenRouter": "qwen/qwen3.5-27b"
+  },
+  "qwen-3.5-35b-a3b": {
+    "Qwen": "qwen3.5-35b-a3b",
+    "LMArena": "qwen3.5-35b-a3b",
+    "PuterJS": "alibaba:qwen/qwen3.5-35b-a3b",
+    "HuggingChat": "Qwen/Qwen3.5-35B-A3B",
+    "HuggingFaceAPI": "Qwen/Qwen3.5-35B-A3B",
+    "OpenRouter": "qwen/qwen3.5-35b-a3b"
   },
   "qwen-3-max": {
-    "Qwen": "qwen3-max-preview",
+    "Qwen": "qwen3-max-2026-01-23",
+    "DeepInfra": "Qwen/Qwen3-Max",
     "LMArena": "qwen3-max-2025-09-26",
-    "PuterJS": "openrouter:qwen/qwen3-max",
-    "OpenRouter": "qwen/qwen3-max",
-    "Yupp": "qwen3-max"
+    "PuterJS": "alibaba:qwen/qwen3-max",
+    "ApiAirforce": "qwen3-max",
+    "OpenRouter": "qwen/qwen3-max"
   },
   "qwen-plus": {
-    "Qwen": "qwen-plus-2025-01-25",
+    "Qwen": "qwen-plus-2025-07-28",
     "PuterJS": "openrouter:qwen/qwen-plus",
-    "OpenRouter": "qwen/qwen-plus-2025-07-28:thinking",
-    "Yupp": "qwen/qwen-plus-2025-07-28:thinking<>OPR"
-  },
-  "qwen-3-235b-a22b": {
-    "Qwen": "qwen3-235b-a22b",
-    "LMArena": "qwen3-235b-a22b",
-    "PuterJS": "openrouter:qwen/qwen3-235b-a22b",
-    "HuggingFaceAPI": "Qwen/Qwen3-235B-A22B",
-    "Nvidia": "qwen/qwen3-235b-a22b",
-    "HuggingChat": "Qwen/Qwen3-235B-A22B-FP8",
-    "OpenRouter": "qwen/qwen3-235b-a22b"
+    "ApiAirforce": "qwen-plus",
+    "OpenRouter": "qwen/qwen-plus"
   },
   "qwen-3-coder-plus": {
     "Qwen": "qwen3-coder-plus",
-    "PuterJS": "openrouter:qwen/qwen3-coder-plus",
-    "OpenRouter": "qwen/qwen3-coder-plus",
-    "QwenCode": "qwen3-coder-plus"
+    "PuterJS": "alibaba:qwen/qwen3-coder-plus",
+    "OpenRouter": "qwen/qwen3-coder-plus"
   },
-  "qwen-3-30b-a3b": {
-    "Qwen": "qwen3-30b-a3b",
-    "DeepInfra": "Qwen/Qwen3-30B-A3B",
-    "LMArena": "qwen3-30b-a3b",
-    "PuterJS": "openrouter:qwen/qwen3-30b-a3b",
-    "HuggingSpace": "qwen-3-30b-a3b",
-    "HuggingFaceAPI": "Qwen/Qwen3-30B-A3B",
-    "HuggingChat": "Qwen/Qwen3-30B-A3B",
-    "OpenRouter": "qwen/qwen3-30b-a3b",
-    "Qwen_Qwen_3": "qwen-3-30b-a3b"
+  "qwen-3-vl-plus": {
+    "Qwen": "qwen3-vl-plus",
+    "PuterJS": "alibaba:qwen/qwen3-vl-plus"
   },
-  "qwen-3-coder-30b-a3b": {
-    "Qwen": "qwen3-coder-30b-a3b-instruct",
-    "DeepInfra": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
-    "HuggingFace": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
-    "PuterJS": "openrouter:qwen/qwen3-coder-30b-a3b-instruct",
-    "HuggingFaceAPI": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
-    "HuggingChat": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
-    "OpenRouter": "qwen/qwen3-coder-30b-a3b-instruct",
-    "Yupp": "qwen3-coder-30b-a3b-instruct"
+  "qwen-3-omni-flash": {
+    "Qwen": "qwen3-omni-flash-2025-12-01",
+    "LMArena": "qwen3-omni-flash",
+    "PuterJS": "alibaba:qwen/qwen3-omni-flash"
   },
-  "qwen-max": {
-    "Qwen": "qwen-max-latest",
-    "PuterJS": "openrouter:qwen/qwen-max",
-    "OpenRouter": "qwen/qwen-max",
-    "Yupp": "qwen-max-2025-01-25"
+  "gpt-4o-mini-image": {
+    "EasyChat": "gpt-4o-mini-image-free"
   },
-  "qwen-turbo": {
-    "Qwen": "qwen-turbo-2025-02-11",
-    "PuterJS": "openrouter:qwen/qwen-turbo",
-    "OpenRouter": "qwen/qwen-turbo"
+  "grok-4.1-fast": {
+    "EasyChat": "grok-4.1-fast-free",
+    "ApiAirforce": "grok-4.1-fast"
   },
-  "qwen-2.5-omni-7b": {
-    "Qwen": "qwen2.5-omni-7b"
+  "openrouter": {
+    "EasyChat": "openrouter-free"
   },
-  "qvq-72b-preview-0310": {
-    "Qwen": "qvq-72b-preview-0310"
+  "glm-5.2": {
+    "DeepInfra": "zai-org/GLM-5.2",
+    "HuggingFace": "zai-org/GLM-5.2-FP8",
+    "PuterJS": "z-ai:z-ai/glm-5.2",
+    "ApiAirforce": "glm-5.2",
+    "HuggingChat": "zai-org/GLM-5.2",
+    "HuggingFaceAPI": "zai-org/GLM-5.2-FP8",
+    "Ollama": "glm-5.2",
+    "OllamaSwarm": "glm-5.2:cloud",
+    "OpenRouter": "z-ai/glm-5.2",
+    "PollinationsAI": "glm"
   },
-  "qwen-2.5-vl-32b": {
-    "Qwen": "qwen2.5-vl-32b-instruct",
-    "PuterJS": [
-      "openrouter:qwen/qwen2.5-vl-32b-instruct:free",
-      "openrouter:qwen/qwen2.5-vl-32b-instruct"
-    ],
-    "HuggingFaceAPI": "Qwen/Qwen2.5-VL-32B-Instruct",
-    "HuggingChat": "Qwen/Qwen2.5-VL-32B-Instruct",
-    "OpenRouter": "qwen/qwen2.5-vl-32b-instruct"
+  "kimi-k2.7-code": {
+    "DeepInfra": "moonshotai/Kimi-K2.7-Code",
+    "LMArena": "kimi-k2.7-code",
+    "PuterJS": "togetherai:moonshotai/kimi-k2.7-code",
+    "ApiAirforce": "kimi-k2.7-code",
+    "HuggingChat": "moonshotai/Kimi-K2.7-Code",
+    "HuggingFaceAPI": "moonshotai/Kimi-K2.7-Code",
+    "Ollama": "kimi-k2.7-code",
+    "OllamaSwarm": "kimi-k2.7-code:cloud",
+    "OpenRouter": "moonshotai/kimi-k2.7-code",
+    "PollinationsAI": "kimi-code"
   },
-  "qwen-2.5-14b-1m": {
-    "Qwen": "qwen2.5-14b-instruct-1m",
-    "Yupp": "qwen2.5-14b-instruct-1m"
+  "nvidia-nemotron-3-ultra-550b-a55b": {
+    "DeepInfra": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B",
+    "HuggingFace": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16",
+    "HuggingChat": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16",
+    "HuggingFaceAPI": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16"
   },
-  "trinity-mini": {
-    "OpenRouterFree": "arcee-ai/trinity-mini:free",
-    "PuterJS": "openrouter:arcee-ai/trinity-mini:free",
-    "OpenRouter": "arcee-ai/trinity-mini:free"
+  "nemotron-3-nano-omni-30b-a3b-reasoning": {
+    "DeepInfra": "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning",
+    "PuterJS": "openrouter:nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free",
+    "OpenRouter": "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free"
   },
-  "dolphin-mistral-24b-venice-edition": {
-    "OpenRouterFree": "cognitivecomputations/dolphin-mistral-24b-venice-edition:free",
-    "HuggingFace": "dphn/Dolphin-Mistral-24B-Venice-Edition",
-    "PuterJS": "openrouter:cognitivecomputations/dolphin-mistral-24b-venice-edition:free",
-    "HuggingFaceAPI": "dphn/Dolphin-Mistral-24B-Venice-Edition",
-    "OpenRouter": "cognitivecomputations/dolphin-mistral-24b-venice-edition:free",
-    "Yupp": "cognitivecomputations/dolphin-mistral-24b-venice-edition:free<>OPR"
+  "deepseek-v4-flash": {
+    "DeepInfra": "deepseek-ai/DeepSeek-V4-Flash",
+    "HuggingFace": "deepseek-ai/DeepSeek-V4-Flash",
+    "LMArena": "deepseek-v4-flash",
+    "PuterJS": "deepseek:deepseek/deepseek-v4-flash",
+    "ApiAirforce": "deepseek-v4-flash",
+    "HuggingChat": "deepseek-ai/DeepSeek-V4-Flash",
+    "HuggingFaceAPI": "deepseek-ai/DeepSeek-V4-Flash",
+    "Ollama": "deepseek-v4-flash",
+    "OllamaSwarm": "deepseek-v4-flash:cloud",
+    "OpenRouter": "deepseek/deepseek-v4-flash",
+    "PollinationsAI": "deepseek"
   },
-  "gemini-2.0-flash-exp": {
-    "OpenRouterFree": "google/gemini-2.0-flash-exp:free",
-    "PuterJS": "openrouter:google/gemini-2.0-flash-exp:free",
-    "OpenRouter": "google/gemini-2.0-flash-exp:free"
+  "deepseek-v4-pro": {
+    "DeepInfra": "deepseek-ai/DeepSeek-V4-Pro",
+    "HuggingFace": "deepseek-ai/DeepSeek-V4-Pro",
+    "LMArena": "deepseek-v4-pro",
+    "PuterJS": "deepseek:deepseek/deepseek-v4-pro",
+    "ApiAirforce": "deepseek-v4-pro",
+    "HuggingChat": "deepseek-ai/DeepSeek-V4-Pro",
+    "HuggingFaceAPI": "deepseek-ai/DeepSeek-V4-Pro",
+    "Ollama": "deepseek-v4-pro",
+    "OllamaSwarm": "deepseek-v4-pro:cloud",
+    "OpenRouter": "deepseek/deepseek-v4-pro",
+    "PollinationsAI": "deepseek-pro"
   },
-  "gemma-3-12b-it": {
-    "OpenRouterFree": "google/gemma-3-12b-it:free",
-    "DeepInfra": "google/gemma-3-12b-it",
-    "PuterJS": "openrouter:google/gemma-3-12b-it:free",
-    "HuggingFaceAPI": "google/gemma-3-12b-it",
-    "Nvidia": "google/gemma-3-12b-it",
-    "GeminiPro": "gemma-3-12b-it",
-    "OpenRouter": "google/gemma-3-12b-it:free"
+  "kimi-k2.6": {
+    "DeepInfra": "moonshotai/Kimi-K2.6",
+    "LMArena": "kimi-k2.6",
+    "PuterJS": "moonshotai:moonshotai/kimi-k2.6",
+    "ApiAirforce": "kimi-k2.6",
+    "HuggingChat": "moonshotai/Kimi-K2.6",
+    "HuggingFaceAPI": "moonshotai/Kimi-K2.6",
+    "Ollama": "kimi-k2.6",
+    "OllamaSwarm": "kimi-k2.6:cloud",
+    "OpenRouter": "moonshotai/kimi-k2.6",
+    "PollinationsAI": "kimi"
   },
-  "gemma-3-27b-it": {
-    "OpenRouterFree": "google/gemma-3-27b-it:free",
-    "DeepInfra": "google/gemma-3-27b-it",
-    "LMArena": "gemma-3-27b-it",
-    "PuterJS": "openrouter:google/gemma-3-27b-it:free",
-    "HuggingFaceAPI": "google/gemma-3-27b-it",
-    "Nvidia": "google/gemma-3-27b-it",
-    "GeminiPro": "gemma-3-27b-it",
-    "HuggingChat": "google/gemma-3-27b-it",
-    "OpenRouter": "google/gemma-3-27b-it:free",
-    "Yupp": "google/gemma-3-27b-it"
+  "mimo-v2.5": {
+    "DeepInfra": "XiaomiMiMo/MiMo-V2.5",
+    "LMArena": "mimo-v2.5",
+    "PuterJS": "openrouter:xiaomi/mimo-v2.5",
+    "ApiAirforce": "mimo-v2.5",
+    "OpenRouter": "xiaomi/mimo-v2.5"
   },
-  "gemma-3-4b-it": {
-    "OpenRouterFree": "google/gemma-3-4b-it:free",
-    "DeepInfra": "google/gemma-3-4b-it",
-    "PuterJS": "openrouter:google/gemma-3-4b-it:free",
-    "Nvidia": "google/gemma-3-4b-it",
-    "GeminiPro": "gemma-3-4b-it",
-    "OpenRouter": "google/gemma-3-4b-it:free"
+  "mimo-v2.5-pro": {
+    "DeepInfra": "XiaomiMiMo/MiMo-V2.5-Pro",
+    "HuggingFace": "XiaomiMiMo/MiMo-V2.5-Pro",
+    "LMArena": "mimo-v2.5-pro",
+    "PuterJS": "openrouter:xiaomi/mimo-v2.5-pro",
+    "ApiAirforce": "mimo-v2.5-pro",
+    "HuggingFaceAPI": "XiaomiMiMo/MiMo-V2.5-Pro",
+    "OpenRouter": "xiaomi/mimo-v2.5-pro"
   },
-  "gemma-3n-e2b-it": {
-    "OpenRouterFree": "google/gemma-3n-e2b-it:free",
-    "PuterJS": "openrouter:google/gemma-3n-e2b-it:free",
-    "Nvidia": "google/gemma-3n-e2b-it",
-    "GeminiPro": "gemma-3n-e2b-it",
-    "OpenRouter": "google/gemma-3n-e2b-it:free"
+  "glm-5.1": {
+    "DeepInfra": "zai-org/GLM-5.1",
+    "HuggingFace": "zai-org/GLM-5.1",
+    "LMArena": "glm-5.1",
+    "PuterJS": "z-ai:z-ai/glm-5.1",
+    "ApiAirforce": "glm-5.1",
+    "HuggingChat": "zai-org/GLM-5.1-FP8",
+    "HuggingFaceAPI": "zai-org/GLM-5.1-FP8",
+    "Ollama": "glm-5.1",
+    "OllamaSwarm": "glm-5.1:cloud",
+    "OpenRouter": "z-ai/glm-5.1"
   },
-  "gemma-3n-e4b-it": {
-    "OpenRouterFree": "google/gemma-3n-e4b-it:free",
-    "LMArena": "gemma-3n-e4b-it",
-    "PuterJS": "openrouter:google/gemma-3n-e4b-it:free",
-    "Nvidia": "google/gemma-3n-e4b-it",
-    "GeminiPro": "gemma-3n-e4b-it",
-    "OpenRouter": "google/gemma-3n-e4b-it:free"
+  "gemma-4-26b-a4b-it": {
+    "DeepInfra": "google/gemma-4-26B-A4B-it",
+    "PuterJS": "openrouter:google/gemma-4-26b-a4b-it:free",
+    "HuggingChat": "google/gemma-4-26B-A4B-it",
+    "HuggingFaceAPI": "google/gemma-4-26B-A4B-it",
+    "OpenRouter": "google/gemma-4-26b-a4b-it",
+    "PollinationsAI": "gemma"
   },
-  "kat-coder-pro": {
-    "OpenRouterFree": "kwaipilot/kat-coder-pro:free",
-    "PuterJS": "openrouter:kwaipilot/kat-coder-pro:free",
-    "OpenRouter": "kwaipilot/kat-coder-pro:free",
-    "Yupp": "kwaipilot/kat-coder-pro:free<>OPR"
+  "gemma-4-31b-it": {
+    "DeepInfra": "google/gemma-4-31B-it",
+    "LMArena": "gemma-4-31b-it",
+    "PuterJS": "togetherai:google/gemma-4-31b-it",
+    "HuggingChat": "google/gemma-4-31B-it",
+    "HuggingFaceAPI": "google/gemma-4-31B-it",
+    "OpenRouter": "google/gemma-4-31b-it"
   },
-  "devstral-2512": {
-    "OpenRouterFree": "mistralai/devstral-2512:free",
-    "PuterJS": "openrouter:mistralai/devstral-2512:free",
-    "OpenRouter": "mistralai/devstral-2512:free",
-    "Yupp": "devstral-2512"
+  "nvidia-nemotron-3-super-120b-a12b": {
+    "DeepInfra": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B",
+    "HuggingFaceAPI": "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16"
   },
-  "hermes-3-llama-3.1-405b": {
-    "OpenRouterFree": "nousresearch/hermes-3-llama-3.1-405b:free",
-    "PuterJS": "openrouter:nousresearch/hermes-3-llama-3.1-405b:free",
-    "OpenRouter": "nousresearch/hermes-3-llama-3.1-405b:free"
+  "glm-5": {
+    "DeepInfra": "zai-org/GLM-5",
+    "LMArena": "glm-5",
+    "PuterJS": "z-ai:z-ai/glm-5",
+    "ApiAirforce": "glm-5",
+    "HuggingChat": "zai-org/GLM-5",
+    "HuggingFaceAPI": "zai-org/GLM-5",
+    "Ollama": "glm-5",
+    "OllamaSwarm": "glm-5:cloud",
+    "OpenRouter": "z-ai/glm-5"
   },
-  "nemotron-3-nano-30b-a3b": {
-    "OpenRouterFree": "nvidia/nemotron-3-nano-30b-a3b:free",
-    "DeepInfra": "nvidia/Nemotron-3-Nano-30B-A3B",
-    "PuterJS": "openrouter:nvidia/nemotron-3-nano-30b-a3b:free",
-    "Nvidia": "nvidia/nemotron-3-nano-30b-a3b",
-    "OpenRouter": "nvidia/nemotron-3-nano-30b-a3b:free",
-    "Yupp": "nvidia/nemotron-3-nano-30b-a3b:free<>no-think<>OPR"
+  "minimax-m2.5": {
+    "DeepInfra": "MiniMaxAI/MiniMax-M2.5",
+    "LMArena": "minimax-m2.5",
+    "PuterJS": "minimax:minimax/minimax-m2.5",
+    "ApiAirforce": "minimax-m2.5",
+    "HuggingChat": "MiniMaxAI/MiniMax-M2.5",
+    "Ollama": "minimax-m2.5",
+    "OllamaSwarm": "minimax-m2.5:cloud",
+    "OpenRouter": "minimax/minimax-m2.5",
+    "PollinationsAI": "minimax-m2.7"
   },
-  "nemotron-nano-12b-v2-vl": {
-    "OpenRouterFree": "nvidia/nemotron-nano-12b-v2-vl:free",
-    "PuterJS": "openrouter:nvidia/nemotron-nano-12b-v2-vl:free",
-    "Nvidia": "nvidia/nemotron-nano-12b-v2-vl",
-    "OpenRouter": "nvidia/nemotron-nano-12b-v2-vl:free"
+  "qwen-3-max-thinking": {
+    "DeepInfra": "Qwen/Qwen3-Max-Thinking",
+    "LMArena": "qwen3-max-thinking",
+    "PuterJS": "openrouter:qwen/qwen3-max-thinking",
+    "OpenRouter": "qwen/qwen3-max-thinking"
   },
-  "nemotron-nano-9b": {
-    "OpenRouterFree": "nvidia/nemotron-nano-9b-v2:free",
-    "PuterJS": "openrouter:nvidia/nemotron-nano-9b-v2:free",
-    "OpenRouter": "nvidia/nemotron-nano-9b-v2:free"
+  "kimi-k2.5": {
+    "DeepInfra": "moonshotai/Kimi-K2.5",
+    "LMArena": "kimi-k2.5",
+    "PuterJS": "moonshotai:moonshotai/kimi-k2.5",
+    "ApiAirforce": "kimi-k2.5",
+    "HuggingChat": "moonshotai/Kimi-K2.5",
+    "HuggingFaceAPI": "moonshotai/Kimi-K2.5",
+    "Ollama": "kimi-k2.5",
+    "OllamaSwarm": "kimi-k2.5:cloud",
+    "OpenRouter": "moonshotai/kimi-k2.5"
   },
-  "gpt-oss-20b": {
-    "OpenRouterFree": "openai/gpt-oss-20b:free",
-    "DeepInfra": "openai/gpt-oss-20b",
-    "HuggingFace": "openai/gpt-oss-20b",
-    "LMArena": "gpt-oss-20b",
-    "PuterJS": "openrouter:openai/gpt-oss-20b:free",
-    "HuggingFaceAPI": "openai/gpt-oss-20b",
-    "Nvidia": "openai/gpt-oss-20b",
-    "Ollama": "gpt-oss:20b",
-    "ApiAirforce": "gpt-oss-20b",
-    "Groq": "openai/gpt-oss-20b",
-    "HuggingChat": "openai/gpt-oss-20b",
-    "OpenRouter": "openai/gpt-oss-20b:free"
-  },
-  "qwen-2.5-vl-7b": {
-    "OpenRouterFree": "qwen/qwen-2.5-vl-7b-instruct:free",
-    "PuterJS": [
-      "openrouter:qwen/qwen-2.5-vl-7b-instruct:free",
-      "openrouter:qwen/qwen-2.5-vl-7b-instruct"
-    ],
-    "HuggingFaceAPI": "Qwen/Qwen2.5-VL-7B-Instruct",
-    "HuggingChat": "Qwen/Qwen2.5-VL-7B-Instruct",
-    "OpenRouter": "qwen/qwen-2.5-vl-7b-instruct:free",
-    "Yupp": "qwen2.5-vl-7b-instruct"
-  },
-  "deepseek-r1t-chimera": {
-    "OpenRouterFree": "tngtech/deepseek-r1t-chimera:free",
-    "PuterJS": "openrouter:tngtech/deepseek-r1t-chimera:free",
-    "OpenRouter": "tngtech/deepseek-r1t-chimera:free"
-  },
-  "deepseek-r1t2-chimera": {
-    "OpenRouterFree": "tngtech/deepseek-r1t2-chimera:free",
-    "PuterJS": "openrouter:tngtech/deepseek-r1t2-chimera:free",
-    "OpenRouter": "tngtech/deepseek-r1t2-chimera:free",
-    "Yupp": "tngtech/deepseek-r1t2-chimera:free<>OPR"
-  },
-  "tng-r1t-chimera": {
-    "OpenRouterFree": "tngtech/tng-r1t-chimera:free",
-    "PuterJS": "openrouter:tngtech/tng-r1t-chimera:free",
-    "OpenRouter": "tngtech/tng-r1t-chimera:free"
-  },
-  "mimo-v2-flash": {
-    "OpenRouterFree": "xiaomi/mimo-v2-flash:free",
-    "HuggingFace": "XiaomiMiMo/MiMo-V2-Flash",
-    "LMArena": "mimo-v2-flash",
-    "PuterJS": "openrouter:xiaomi/mimo-v2-flash:free",
-    "HuggingFaceAPI": "XiaomiMiMo/MiMo-V2-Flash",
-    "ApiAirforce": "mimo-v2-flash",
-    "HuggingChat": "XiaomiMiMo/MiMo-V2-Flash",
-    "OpenRouter": "xiaomi/mimo-v2-flash:free",
-    "Yupp": "xiaomi/mimo-v2-flash:free<>OPR"
-  },
-  "glm-4.5-air": {
-    "OpenRouterFree": "z-ai/glm-4.5-air:free",
-    "LMArena": "glm-4.5-air",
-    "PuterJS": "openrouter:z-ai/glm-4.5-air:free",
-    "HuggingFaceAPI": "zai-org/GLM-4.5-Air",
-    "ApiAirforce": "glm-4.5-air",
-    "HuggingChat": "zai-org/GLM-4.5-Air-FP8",
-    "OpenRouter": "z-ai/glm-4.5-air:free"
+  "glm-4.7-flash": {
+    "DeepInfra": "zai-org/GLM-4.7-Flash",
+    "PuterJS": "z-ai:z-ai/glm-4.7-flash",
+    "ApiAirforce": "glm-4.7-flash",
+    "HuggingChat": "zai-org/GLM-4.7-Flash",
+    "HuggingFaceAPI": "zai-org/GLM-4.7-Flash",
+    "OllamaSwarm": "glm-4.7-flash:latest",
+    "OpenRouter": "z-ai/glm-4.7-flash"
   },
   "deepseek-v3.2": {
     "DeepInfra": "deepseek-ai/DeepSeek-V3.2",
-    "HuggingFace": "deepseek-ai/DeepSeek-V3.2",
-    "LMArena": "deepseek-v3.2",
     "PuterJS": "openrouter:deepseek/deepseek-v3.2",
-    "HuggingFaceAPI": "deepseek-ai/DeepSeek-V3.2",
-    "Nvidia": "deepseek-ai/deepseek-v3.2",
-    "Ollama": "deepseek-v3.2",
-    "ApiAirforce": "deepseek-v3.2:free",
+    "ApiAirforce": "deepseek-v3.2",
     "HuggingChat": "deepseek-ai/DeepSeek-V3.2",
+    "HuggingFaceAPI": "deepseek-ai/DeepSeek-V3.2",
+    "Ollama": "deepseek-v3.2",
+    "OllamaSwarm": "deepseek-v3.2:cloud",
     "OpenRouter": "deepseek/deepseek-v3.2"
   },
-  "minimax-m2": {
-    "DeepInfra": "MiniMaxAI/MiniMax-M2",
-    "LMArena": "minimax-m2-preview",
-    "PuterJS": "openrouter:minimax/minimax-m2",
-    "HuggingFaceAPI": "MiniMaxAI/MiniMax-M2",
-    "Nvidia": "minimaxai/minimax-m2",
-    "Ollama": "minimax-m2",
-    "HuggingChat": "MiniMaxAI/MiniMax-M2",
-    "OpenRouter": "minimax/minimax-m2"
+  "flux-2-klein-4b": {
+    "DeepInfra": "black-forest-labs/FLUX-2-klein-4b"
   },
-  "kimi-k2-thinking": {
-    "DeepInfra": "moonshotai/Kimi-K2-Thinking",
-    "HuggingFace": "moonshotai/Kimi-K2-Thinking",
-    "PuterJS": "openrouter:moonshotai/kimi-k2-thinking",
-    "HuggingFaceAPI": "moonshotai/Kimi-K2-Thinking",
-    "Nvidia": "moonshotai/kimi-k2-thinking",
-    "Ollama": "kimi-k2-thinking",
-    "ApiAirforce": "kimi-k2-thinking",
-    "HuggingChat": "moonshotai/Kimi-K2-Thinking",
-    "OpenRouter": "moonshotai/kimi-k2-thinking"
+  "flux-2-klein-9b": {
+    "DeepInfra": "black-forest-labs/FLUX-2-klein-9b"
   },
-  "deepseek-ocr": {
-    "DeepInfra": "deepseek-ai/DeepSeek-OCR",
-    "HuggingFaceAPI": "deepseek-ai/DeepSeek-OCR"
+  "qwythos-9b-claude-mythos-5-1m": {
+    "HuggingFace": "empero-ai/Qwythos-9B-Claude-Mythos-5-1M",
+    "HuggingFaceAPI": "empero-ai/Qwythos-9B-Claude-Mythos-5-1M"
   },
-  "olmocr-2-7b-1025": {
-    "DeepInfra": "allenai/olmOCR-2-7B-1025"
+  "vibethinker-3b": {
+    "HuggingFace": "WeiboAI/VibeThinker-3B",
+    "HuggingFaceAPI": "WeiboAI/VibeThinker-3B"
   },
-  "paddleocr-vl-0.9b": {
-    "DeepInfra": "PaddlePaddle/PaddleOCR-VL-0.9B"
+  "ornith-1.0-9b": {
+    "HuggingFace": "deepreinforce-ai/Ornith-1.0-9B",
+    "HuggingFaceAPI": "deepreinforce-ai/Ornith-1.0-9B"
   },
-  "deepseek-v3.2-exp": {
-    "DeepInfra": "deepseek-ai/DeepSeek-V3.2-Exp",
-    "PuterJS": "openrouter:deepseek/deepseek-v3.2-exp",
-    "HuggingFaceAPI": "deepseek-ai/DeepSeek-V3.2-Exp",
-    "HuggingChat": "deepseek-ai/DeepSeek-V3.2-Exp",
-    "OpenRouter": "deepseek/deepseek-v3.2-exp"
+  "fastcontext-1.0-4b-sft": {
+    "HuggingFace": "microsoft/FastContext-1.0-4B-SFT",
+    "HuggingFaceAPI": "microsoft/FastContext-1.0-4B-SFT"
   },
-  "deepseek-v3.1-terminus": {
-    "DeepInfra": "deepseek-ai/DeepSeek-V3.1-Terminus",
-    "PuterJS": "openrouter:deepseek/deepseek-v3.1-terminus:exacto",
-    "Nvidia": "deepseek-ai/deepseek-v3.1-terminus",
-    "HuggingChat": "deepseek-ai/DeepSeek-V3.1-Terminus",
-    "OpenRouter": "deepseek/deepseek-v3.1-terminus:exacto",
-    "Yupp": "deepseek/deepseek-v3.1-terminus:exacto<>OPR"
+  "qwable-9b-claude-fable-5": {
+    "HuggingFace": "empero-ai/Qwable-9B-Claude-Fable-5",
+    "HuggingFaceAPI": "empero-ai/Qwable-9B-Claude-Fable-5"
   },
-  "qwen-3-next-80b-a3b": {
-    "DeepInfra": "Qwen/Qwen3-Next-80B-A3B-Instruct",
-    "LMArena": "qwen3-next-80b-a3b-instruct",
-    "PuterJS": "openrouter:qwen/qwen3-next-80b-a3b-instruct",
-    "HuggingFaceAPI": "Qwen/Qwen3-Next-80B-A3B-Instruct",
-    "Nvidia": "qwen/qwen3-next-80b-a3b-instruct",
-    "ApiAirforce": "qwen3-next-80b-a3b-instruct",
-    "HuggingChat": "Qwen/Qwen3-Next-80B-A3B-Instruct",
-    "OpenRouter": "qwen/qwen3-next-80b-a3b-instruct",
-    "Yupp": "qwen3-next-80b-a3b-instruct"
+  "qwable-5-27b-coder": {
+    "HuggingFace": "DJLougen/Qwable-5-27B-Coder",
+    "HuggingFaceAPI": "DJLougen/Qwable-5-27B-Coder"
   },
-  "kimi-k2-0905": {
-    "DeepInfra": "moonshotai/Kimi-K2-Instruct-0905",
-    "LMArena": "kimi-k2-0905-preview",
-    "PuterJS": "openrouter:moonshotai/kimi-k2-0905:exacto",
-    "HuggingFaceAPI": "moonshotai/Kimi-K2-Instruct-0905",
-    "Nvidia": "moonshotai/kimi-k2-instruct-0905",
-    "ApiAirforce": "kimi-k2-0905",
-    "Groq": "moonshotai/kimi-k2-instruct-0905",
-    "HuggingChat": "moonshotai/Kimi-K2-Instruct-0905",
-    "OpenRouter": "moonshotai/kimi-k2-0905:exacto",
-    "Yupp": "moonshotai/kimi-k2-0905:exacto<>OPR"
+  "gemma-4-26b-a4b-styletune": {
+    "HuggingFace": "Gryphe/Gemma-4-26B-A4B-StyleTune-V2",
+    "HuggingFaceAPI": "Gryphe/Gemma-4-26B-A4B-StyleTune-V2"
   },
-  "deepseek-v3.1": {
-    "DeepInfra": "deepseek-ai/DeepSeek-V3.1",
-    "HuggingFaceAPI": "deepseek-ai/DeepSeek-V3.1",
-    "Nvidia": "deepseek-ai/deepseek-v3.1",
-    "Ollama": "deepseek-v3.1:671b",
-    "HuggingChat": "deepseek-ai/DeepSeek-V3.1"
+  "nvidia-nemotron-3-ultra-550b-a55b-nvfp4": {
+    "HuggingFace": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4",
+    "HuggingChat": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4",
+    "HuggingFaceAPI": "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4"
   },
-  "qwen-3-coder-480b-a35b-turbo": {
-    "DeepInfra": "Qwen/Qwen3-Coder-480B-A35B-Instruct-Turbo"
-  },
-  "glm-4.5": {
-    "DeepInfra": "zai-org/GLM-4.5",
-    "LMArena": "glm-4.5",
-    "PuterJS": "openrouter:z-ai/glm-4.5",
-    "ApiAirforce": "glm-4.5",
-    "HuggingChat": "zai-org/GLM-4.5",
-    "OpenRouter": "z-ai/glm-4.5"
-  },
-  "qwen-3-235b-a22b-thinking-2507": {
-    "DeepInfra": "Qwen/Qwen3-235B-A22B-Thinking-2507",
-    "LMArena": "qwen3-235b-a22b-thinking-2507",
-    "PuterJS": "openrouter:qwen/qwen3-235b-a22b-thinking-2507",
-    "HuggingFaceAPI": "Qwen/Qwen3-235B-A22B-Thinking-2507",
-    "HuggingChat": "Qwen/Qwen3-235B-A22B-Thinking-2507",
-    "OpenRouter": "qwen/qwen3-235b-a22b-thinking-2507",
-    "Yupp": "qwen3-235b-a22b-thinking-2507"
-  },
-  "qwen-3-coder-480b-a35b": {
-    "DeepInfra": "Qwen/Qwen3-Coder-480B-A35B-Instruct",
-    "LMArena": "qwen3-coder-480b-a35b-instruct",
-    "HuggingFaceAPI": "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8",
-    "Nvidia": "qwen/qwen3-coder-480b-a35b-instruct",
-    "HuggingChat": "Qwen/Qwen3-Coder-480B-A35B-Instruct"
-  },
-  "qwen-3-235b-a22b-2507": {
-    "DeepInfra": "Qwen/Qwen3-235B-A22B-Instruct-2507",
-    "LMArena": "qwen3-235b-a22b-instruct-2507",
-    "PuterJS": "openrouter:qwen/qwen3-235b-a22b-2507",
-    "HuggingFaceAPI": "Qwen/Qwen3-235B-A22B-Instruct-2507",
-    "HuggingChat": "Qwen/Qwen3-235B-A22B-Instruct-2507",
-    "OpenRouter": "qwen/qwen3-235b-a22b-2507"
-  },
-  "llama-4-maverick-17b-128e-turbo": {
-    "DeepInfra": "meta-llama/Llama-4-Maverick-17B-128E-Instruct-Turbo"
-  },
-  "llama-4-maverick-17b-128e": {
-    "DeepInfra": "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
-    "LMArena": "llama-4-maverick-17b-128e-instruct",
-    "HuggingFaceAPI": "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
-    "Nvidia": "meta/llama-4-maverick-17b-128e-instruct",
-    "Groq": "meta-llama/llama-4-maverick-17b-128e-instruct"
-  },
-  "llama-4-scout-17b-16e": {
-    "DeepInfra": "meta-llama/Llama-4-Scout-17B-16E-Instruct",
-    "HuggingFaceAPI": "meta-llama/Llama-4-Scout-17B-16E-Instruct",
-    "Nvidia": "meta/llama-4-scout-17b-16e-instruct",
-    "Groq": "meta-llama/llama-4-scout-17b-16e-instruct"
-  },
-  "devstral-small-2507": {
-    "DeepInfra": "mistralai/Devstral-Small-2507",
-    "PuterJS": "devstral-small-2507",
-    "Yupp": "devstral-small-2507"
-  },
-  "mistral-small-3.2-24b-2506": {
-    "DeepInfra": "mistralai/Mistral-Small-3.2-24B-Instruct-2506"
-  },
-  "llama-guard-4-12b": {
-    "DeepInfra": "meta-llama/Llama-Guard-4-12B",
-    "PuterJS": "openrouter:meta-llama/llama-guard-4-12b",
-    "HuggingFaceAPI": "meta-llama/Llama-Guard-4-12B",
-    "Nvidia": "meta/llama-guard-4-12b",
-    "Groq": "meta-llama/llama-guard-4-12b",
-    "OpenRouter": "meta-llama/llama-guard-4-12b"
-  },
-  "claude-4-opus": {
-    "DeepInfra": "anthropic/claude-4-opus",
-    "GithubCopilot": "claude-4-opus"
-  },
-  "claude-4-sonnet": {
-    "DeepInfra": "anthropic/claude-4-sonnet",
-    "GithubCopilot": "claude-4-sonnet"
-  },
-  "llama-3.3-70b-turbo": {
-    "DeepInfra": "meta-llama/Llama-3.3-70B-Instruct-Turbo"
-  },
-  "moonshotai/Kimi-K2-Instruct": {
-    "DeepInfra": "moonshotai/Kimi-K2-Instruct-0905",
-    "HuggingFace": "moonshotai/Kimi-K2-Instruct-0905",
-    "HuggingFaceAPI": "moonshotai/Kimi-K2-Instruct-0905",
-    "GeminiPro": "gemma-2-9b-it",
-    "Groq": "moonshotai/kimi-k2-Instruct",
-    "HuggingChat": "moonshotai/Kimi-K2-Instruct-0905"
+  "fastcontext-1.0-4b-rl": {
+    "HuggingFace": "microsoft/FastContext-1.0-4B-RL",
+    "HuggingFaceAPI": "microsoft/FastContext-1.0-4B-RL"
   },
   "qwen-3-8b": {
     "HuggingFace": "Qwen/Qwen3-8B",
@@ -1622,37 +1368,48 @@ model_map = {
       "openrouter:qwen/qwen3-8b:free",
       "openrouter:qwen/qwen3-8b"
     ],
-    "HuggingSpace": "qwen-3-8b",
-    "HuggingFaceAPI": "unsloth/Qwen3-8B",
+    "ApiAirforce": "qwen3-8b",
     "HuggingChat": "Qwen/Qwen3-8B",
-    "OpenRouter": "qwen/qwen3-8b",
-    "Qwen_Qwen_3": "qwen-3-8b"
+    "HuggingFaceAPI": "Qwen/Qwen3-8B",
+    "OpenRouter": "qwen/qwen3-8b"
   },
-  "nvidia-nemotron-3-nano-30b-a3b": {
-    "HuggingFace": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8",
-    "LMArena": "nvidia-nemotron-3-nano-30b-a3b-bf16",
-    "HuggingFaceAPI": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8"
+  "qwen-3.6-27b-aeon-ultimate-uncensored": {
+    "HuggingFace": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16",
+    "HuggingFaceAPI": "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16"
   },
-  "qwen-3-4b-2507": {
-    "HuggingFace": "Qwen/Qwen3-4B-Instruct-2507",
-    "HuggingFaceAPI": "Qwen/Qwen3-4B-Instruct-2507",
-    "HuggingChat": "Qwen/Qwen3-4B-Instruct-2507"
+  "qwen-3-coder-30b-a3b": {
+    "HuggingFace": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
+    "PuterJS": "alibaba:qwen/qwen3-coder-30b-a3b-instruct",
+    "ApiAirforce": "qwen3-coder-30b-a3b",
+    "HuggingChat": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
+    "HuggingFaceAPI": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
+    "OpenRouter": "qwen/qwen3-coder-30b-a3b-instruct"
   },
-  "gemma-2-2b-it": {
-    "HuggingFace": "google/gemma-2-2b-it",
-    "HuggingFaceAPI": "google/gemma-2-2b-it",
-    "Nvidia": "google/gemma-2-2b-it",
-    "HuggingChat": "google/gemma-2-2b-it"
+  "qwen-3-coder-next": {
+    "HuggingFace": "Qwen/Qwen3-Coder-Next",
+    "PuterJS": "openrouter:qwen/qwen3-coder-next",
+    "HuggingChat": "Qwen/Qwen3-Coder-Next",
+    "HuggingFaceAPI": "Qwen/Qwen3-Coder-Next",
+    "Ollama": "qwen3-coder-next",
+    "OllamaSwarm": "qwen3-coder-next:q8_0",
+    "OpenRouter": "qwen/qwen3-coder-next"
   },
-  "qwen-3-4b-thinking-2507": {
-    "HuggingFace": "Qwen/Qwen3-4B-Thinking-2507",
-    "HuggingFaceAPI": "Qwen/Qwen3-4B-Thinking-2507",
-    "HuggingChat": "Qwen/Qwen3-4B-Thinking-2507"
+  "llama-3.2-1b": {
+    "HuggingFace": "meta-llama/Llama-3.2-1B-Instruct",
+    "PuterJS": [
+      "openrouter:meta-llama/llama-3.2-1b-instruct:free",
+      "openrouter:meta-llama/llama-3.2-1b-instruct"
+    ],
+    "HuggingFaceAPI": "meta-llama/Llama-3.2-1B-Instruct",
+    "OpenRouter": "meta-llama/llama-3.2-1b-instruct"
+  },
+  "z-image-engineer": {
+    "HuggingFace": "BennyDaBall/Z-Image-Engineer-V6",
+    "HuggingFaceAPI": "BennyDaBall/Z-Image-Engineer-V6"
   },
   "llama-3.2-11b-vision": {
     "HuggingFace": "meta-llama/Llama-3.2-11B-Vision-Instruct",
     "PuterJS": "openrouter:meta-llama/llama-3.2-11b-vision-instruct",
-    "Nvidia": "meta/llama-3.2-11b-vision-instruct",
     "GlhfChat": "hf:meta-llama/Llama-3.2-11B-Vision-Instruct",
     "OpenRouter": "meta-llama/llama-3.2-11b-vision-instruct"
   },
@@ -1660,72 +1417,80 @@ model_map = {
     "HuggingFace": "CohereForAI/c4ai-command-r-plus-08-2024",
     "PuterJS": "openrouter:cohere/command-r-plus-08-2024",
     "HuggingSpace": "command-r-plus-08-2024",
-    "Cohere": "command-r-plus-08-2024",
     "CohereForAI_C4AI_Command": "command-r-plus-08-2024",
-    "OpenRouter": "cohere/command-r-plus-08-2024",
-    "Yupp": "command-r-plus-08-2024"
+    "OpenRouter": "cohere/command-r-plus-08-2024"
+  },
+  "deepseek-r1-distill-qwen-32b": {
+    "HuggingFace": "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B",
+    "PuterJS": [
+      "openrouter:deepseek/deepseek-r1-distill-qwen-32b:free",
+      "openrouter:deepseek/deepseek-r1-distill-qwen-32b"
+    ],
+    "HuggingFaceAPI": "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B"
   },
   "llama-3.1-nemotron-70b": {
     "HuggingFace": "nvidia/Llama-3.1-Nemotron-70B-Instruct-HF",
-    "PuterJS": "openrouter:nvidia/llama-3.1-nemotron-70b-instruct",
-    "Nvidia": "nvidia/llama-3.1-nemotron-70b-instruct",
-    "GlhfChat": "hf:nvidia/Llama-3.1-Nemotron-70B-Instruct-HF",
-    "OpenRouter": "nvidia/llama-3.1-nemotron-70b-instruct"
+    "GlhfChat": "hf:nvidia/Llama-3.1-Nemotron-70B-Instruct-HF"
   },
   "mistral-nemo-2407": {
-    "HuggingFace": "mistralai/Mistral-Nemo-Instruct-2407",
-    "HuggingFaceAPI": "mistralai/Mistral-Nemo-Instruct-2407"
+    "HuggingFace": "mistralai/Mistral-Nemo-Instruct-2407"
   },
-  "qwen-image-2512": {
-    "HuggingFace": "Qwen/Qwen-Image-2512",
-    "LMArena": "qwen-image-2512",
-    "HuggingFaceMedia": "Qwen/Qwen-Image-2512:replicate",
-    "Yupp": "fal-ai/qwen-image-2512"
+  "krea-2-turbo": {
+    "HuggingFace": "krea/Krea-2-Turbo",
+    "HuggingFaceMedia": "krea/Krea-2-Turbo:fal-ai"
   },
-  "qwen-image-2512-gguf": {
-    "HuggingFace": "unsloth/Qwen-Image-2512-GGUF"
+  "krea-2-raw": {
+    "HuggingFace": "krea/Krea-2-Raw"
   },
-  "qwen-image-2512-turbo-lora": {
-    "HuggingFace": "Wuli-art/Qwen-Image-2512-Turbo-LoRA"
+  "krea2.fp8": {
+    "HuggingFace": "AlperKTS/Krea2_FP8"
+  },
+  "ideogram-4": {
+    "HuggingFace": "ideogram-ai/ideogram-4-fp8",
+    "HuggingFaceMedia": "ideogram-ai/ideogram-4-fp8:fal-ai"
   },
   "z-image-turbo": {
     "HuggingFace": "Tongyi-MAI/Z-Image-Turbo",
     "HuggingFaceMedia": "Tongyi-MAI/Z-Image-Turbo:wavespeed"
   },
-  "qwen-image-2512-lightning": {
-    "HuggingFace": "lightx2v/Qwen-Image-2512-Lightning"
+  "krea-2-turbo-gguf": {
+    "HuggingFace": "vantagewithai/Krea-2-Turbo-GGUF"
   },
-  "flux.2-dev-turbo": {
-    "HuggingFace": "fal/FLUX.2-dev-Turbo",
-    "HuggingFaceMedia": "fal/FLUX.2-dev-Turbo:fal-ai"
+  "ideogram.4.turbotime.lora": {
+    "HuggingFace": "ostris/ideogram_4_turbotime_lora",
+    "HuggingFaceMedia": "ostris/ideogram_4_turbotime_lora:fal-ai"
+  },
+  "krea-2-lora-retroanime": {
+    "HuggingFace": "krea/Krea-2-LoRA-retroanime",
+    "HuggingFaceMedia": "krea/Krea-2-LoRA-retroanime:fal-ai"
+  },
+  "ideogram-4-nf4": {
+    "HuggingFace": "ideogram-ai/ideogram-4-nf4"
   },
   "qwen-image-edit-rapid-aio": {
     "HuggingFace": "Phr00t/Qwen-Image-Edit-Rapid-AIO"
   },
-  "twinflow-z-image-turbo": {
-    "HuggingFace": "inclusionAI/TwinFlow-Z-Image-Turbo"
+  "krea-2-realism-lora": {
+    "HuggingFace": "gokaygokay/Krea-2-Realism-LoRA"
   },
-  "zeta-chroma": {
-    "HuggingFace": "lodestones/Zeta-Chroma"
-  },
-  "stable-diffusion-xl-base-1.0": {
-    "HuggingFace": "stabilityai/stable-diffusion-xl-base-1.0",
-    "HuggingFaceMedia": "stabilityai/stable-diffusion-xl-base-1.0:hf-inference"
-  },
-  "qwen-image": {
-    "HuggingFace": "Qwen/Qwen-Image",
-    "HuggingFaceMedia": "Qwen/Qwen-Image:replicate",
-    "Yupp": "fal-ai/qwen-image"
+  "flux2-klein-9b-uncensored-text-encoder": {
+    "HuggingFace": "ponpoke/flux2-klein-9b-uncensored-text-encoder"
   },
   "llama-3": {
     "HuggingFace": "meta-llama/Llama-3.3-70B-Instruct",
+    "HuggingChat": "meta-llama/Llama-3.3-70B-Instruct",
     "HuggingFaceAPI": "meta-llama/Llama-3.3-70B-Instruct",
-    "HuggingChat": "meta-llama/Llama-3.3-70B-Instruct"
+    "OllamaSwarm": "llama3:8b-instruct-q4_K_M"
+  },
+  "moonshotai/Kimi-K2-Instruct": {
+    "HuggingFace": "moonshotai/Kimi-K2-Instruct-0905",
+    "HuggingChat": "moonshotai/Kimi-K2-Instruct-0905",
+    "HuggingFaceAPI": "moonshotai/Kimi-K2-Instruct-0905"
   },
   "qvq-72b": {
     "HuggingFace": "Qwen/QVQ-72B-Preview",
-    "HuggingFaceAPI": "Qwen/QVQ-72B-Preview",
-    "HuggingChat": "Qwen/QVQ-72B-Preview"
+    "HuggingChat": "Qwen/QVQ-72B-Preview",
+    "HuggingFaceAPI": "Qwen/QVQ-72B-Preview"
   },
   "stable-diffusion-3.5-large": {
     "HuggingFace": "stabilityai/stable-diffusion-3.5-large",
@@ -1737,23 +1502,23 @@ model_map = {
     "HuggingFaceMedia": "stabilityai/stable-diffusion-xl-base-1.0",
     "HuggingChat": "stabilityai/stable-diffusion-xl-base-1.0"
   },
-  "hunyuanvideo-1.5": {
-    "HuggingFaceMedia": "tencent/HunyuanVideo-1.5:wavespeed"
+  "wan2.2-ti2v-5b": {
+    "HuggingFaceMedia": "Wan-AI/Wan2.2-TI2V-5B:wavespeed"
   },
   "longcat-video": {
     "HuggingFaceMedia": "meituan-longcat/LongCat-Video:fal-ai"
   },
-  "wan2.2-t2v-a14b": {
-    "HuggingFaceMedia": "Wan-AI/Wan2.2-T2V-A14B:replicate"
-  },
   "wan2.1-t2v-1.3b": {
     "HuggingFaceMedia": "Wan-AI/Wan2.1-T2V-1.3B:wavespeed"
   },
-  "hunyuanvideo": {
-    "HuggingFaceMedia": "tencent/HunyuanVideo:fal-ai"
+  "wan2.1-t2v-14b": {
+    "HuggingFaceMedia": "Wan-AI/Wan2.1-T2V-14B:wavespeed"
   },
-  "wan2.2-ti2v-5b": {
-    "HuggingFaceMedia": "Wan-AI/Wan2.2-TI2V-5B:wavespeed"
+  "hunyuanvideo-1.5": {
+    "HuggingFaceMedia": "tencent/HunyuanVideo-1.5:wavespeed"
+  },
+  "wan2.2-t2v-a14b": {
+    "HuggingFaceMedia": "Wan-AI/Wan2.2-T2V-A14B:replicate"
   },
   "wan2.2-t2v-a14b-diffusers": {
     "HuggingFaceMedia": "Wan-AI/Wan2.2-T2V-A14B-Diffusers:replicate"
@@ -1764,25 +1529,245 @@ model_map = {
   "mochi-1": {
     "HuggingFaceMedia": "genmo/mochi-1-preview:fal-ai"
   },
-  "wan2.1-t2v-14b": {
-    "HuggingFaceMedia": "Wan-AI/Wan2.1-T2V-14B:wavespeed"
+  "max": {
+    "LMArena": "Max"
   },
-  "wan-alpha": {
-    "HuggingFaceMedia": "htdong/Wan-Alpha:fal-ai"
+  "claude-opus-4-6-thinking": {
+    "LMArena": "claude-opus-4-6-thinking"
+  },
+  "claude-opus-4-7-thinking": {
+    "LMArena": "claude-opus-4-7-thinking"
+  },
+  "claude-opus-4-6": {
+    "LMArena": "claude-opus-4-6",
+    "PuterJS": "anthropic:anthropic/claude-opus-4-6"
+  },
+  "claude-opus-4-7": {
+    "LMArena": "claude-opus-4-7",
+    "PuterJS": "anthropic:anthropic/claude-opus-4-7"
+  },
+  "gemini-3-pro": {
+    "LMArena": "gemini-3-pro",
+    "ApiAirforce": "gemini-3-pro"
+  },
+  "gpt-5.4-high-no-system-prompt": {
+    "LMArena": "gpt-5.4-high-no-system-prompt"
+  },
+  "gpt-5.2-chat": {
+    "LMArena": "gpt-5.2-chat-latest",
+    "PuterJS": "openai:openai/gpt-5.2-chat",
+    "ApiAirforce": "gpt-5.2-chat",
+    "OpenRouter": "openai/gpt-5.2-chat"
+  },
+  "grok-4.20-beta-0309-reasoning": {
+    "LMArena": "grok-4.20-beta-0309-reasoning"
   },
   "claude-opus-4-5-20251101-thinking-32k": {
     "LMArena": "claude-opus-4-5-20251101-thinking-32k"
   },
-  "evo-logic": {
-    "LMArena": "evo-logic"
+  "gpt-5.5-instant": {
+    "LMArena": "gpt-5.5-instant"
+  },
+  "grok-4.20-multi-agent-beta-0309": {
+    "LMArena": "grok-4.20-multi-agent-beta-0309"
+  },
+  "claude-sonnet-4-6": {
+    "LMArena": "claude-sonnet-4-6",
+    "PuterJS": "anthropic:anthropic/claude-sonnet-4-6"
   },
   "claude-opus-4-5": {
     "LMArena": "claude-opus-4-5-20251101",
-    "PuterJS": "claude-opus-4-5-20251101"
+    "PuterJS": "anthropic:anthropic/claude-opus-4-5"
   },
-  "deepseek-v3.2-thinking": {
-    "LMArena": "deepseek-v3.2-thinking",
-    "ApiAirforce": "deepseek-v3.2-thinking"
+  "gpt-5.4-no-system-prompt": {
+    "LMArena": "gpt-5.4-no-system-prompt"
+  },
+  "ernie-5.1": {
+    "LMArena": "ernie-5.1-preview"
+  },
+  "kiteki": {
+    "LMArena": "kiteki"
+  },
+  "kizen-beta": {
+    "LMArena": "kizen-beta"
+  },
+  "claude-sonnet-4-5-20250929-thinking-32k": {
+    "LMArena": "claude-sonnet-4-5-20250929-thinking-32k"
+  },
+  "claude-sonnet-4-5": {
+    "LMArena": "claude-sonnet-4-5-20250929",
+    "PuterJS": "anthropic:anthropic/claude-sonnet-4-5",
+    "Antigravity": "claude-sonnet-4.5",
+    "ApiAirforce": "claude-sonnet-4.5",
+    "OpenRouter": "anthropic/claude-sonnet-4.5"
+  },
+  "dola-seed-2.0-pro-text": {
+    "LMArena": "dola-seed-2.0-pro-text"
+  },
+  "gpt-5.1-high": {
+    "LMArena": "gpt-5.1-high"
+  },
+  "claude-opus-4-1-20250805-thinking-16k": {
+    "LMArena": "claude-opus-4-1-20250805-thinking-16k"
+  },
+  "gpt-5.3-chat": {
+    "LMArena": "gpt-5.3-chat-latest",
+    "PuterJS": "openrouter:openai/gpt-5.3-chat",
+    "ApiAirforce": "gpt-5.3-chat",
+    "OpenRouter": "openai/gpt-5.3-chat"
+  },
+  "mimo-v2-pro": {
+    "LMArena": "mimo-v2-pro"
+  },
+  "minimax-m3": {
+    "LMArena": "minimax-m3",
+    "PuterJS": "minimax:minimax/minimax-m3",
+    "ApiAirforce": "minimax-m3",
+    "HuggingChat": "MiniMaxAI/MiniMax-M3",
+    "HuggingFaceAPI": "MiniMaxAI/MiniMax-M3",
+    "MiniMax": "MiniMax-M3",
+    "Ollama": "minimax-m3",
+    "OllamaSwarm": "minimax-m3:cloud",
+    "OpenRouter": "minimax/minimax-m3",
+    "PollinationsAI": "minimax"
+  },
+  "gpt-5.4-mini-high": {
+    "LMArena": "gpt-5.4-mini-high"
+  },
+  "claude-opus-4-1": {
+    "LMArena": "claude-opus-4-1-20250805",
+    "PuterJS": "anthropic:anthropic/claude-opus-4-1",
+    "Anthropic": "claude-opus-4-1-latest",
+    "ApiAirforce": "claude-opus-4-1"
+  },
+  "gemini-2.5-pro-grounding-exp": {
+    "LMArena": "gemini-2.5-pro-grounding-exp"
+  },
+  "glm-4.7": {
+    "LMArena": "glm-4.7",
+    "PuterJS": "z-ai:z-ai/glm-4.7",
+    "ApiAirforce": "glm-4.7",
+    "HuggingChat": "zai-org/GLM-4.7",
+    "Ollama": "glm-4.7",
+    "OllamaSwarm": "glm-4.7:cloud",
+    "OpenRouter": "z-ai/glm-4.7"
+  },
+  "gpt-5.2-high": {
+    "LMArena": "gpt-5.2-high"
+  },
+  "gpt-5-high": {
+    "LMArena": "gpt-5-high"
+  },
+  "mimo-v2-omni": {
+    "LMArena": "mimo-v2-omni"
+  },
+  "kimi-k2.5-instant": {
+    "LMArena": "kimi-k2.5-instant"
+  },
+  "o3": {
+    "LMArena": "o3-2025-04-16",
+    "PuterJS": "openai:openai/o3",
+    "ApiAirforce": "o3",
+    "OpenRouter": "openai/o3"
+  },
+  "kimi-k2-thinking-turbo": {
+    "LMArena": "kimi-k2-thinking-turbo"
+  },
+  "gpt-5-chat": {
+    "LMArena": "gpt-5-chat",
+    "PuterJS": "openai:openai/gpt-5-chat",
+    "ApiAirforce": "gpt-5-chat",
+    "OpenRouter": "openai/gpt-5-chat"
+  },
+  "claude-opus-4-20250514-thinking-16k": {
+    "LMArena": "claude-opus-4-20250514-thinking-16k"
+  },
+  "qwen-3-235b-a22b-2507": {
+    "LMArena": "qwen3-235b-a22b-instruct-2507",
+    "PuterJS": "togetherai:qwen/qwen3-235b-a22b-instruct-2507-tput",
+    "HuggingChat": "Qwen/Qwen3-235B-A22B-Instruct-2507",
+    "HuggingFaceAPI": "Qwen/Qwen3-235B-A22B-Instruct-2507",
+    "OpenRouter": "qwen/qwen3-235b-a22b-2507"
+  },
+  "kimi-k2-0905": {
+    "LMArena": "kimi-k2-0905-preview",
+    "PuterJS": "openrouter:moonshotai/kimi-k2-0905",
+    "HuggingChat": "moonshotai/Kimi-K2-Instruct-0905",
+    "HuggingFaceAPI": "moonshotai/Kimi-K2-Instruct-0905",
+    "OpenRouter": "moonshotai/kimi-k2-0905"
+  },
+  "kimi-k2-0711": {
+    "LMArena": "kimi-k2-0711-preview",
+    "ApiAirforce": "kimi-k2-0711"
+  },
+  "deep-octo": {
+    "LMArena": "deep-octo"
+  },
+  "mistral-large-3": {
+    "LMArena": "mistral-large-3",
+    "Ollama": "mistral-large-3:675b",
+    "OllamaSwarm": "mistral-large-3:675b-cloud",
+    "PollinationsAI": "mistral-large"
+  },
+  "qwen-3-vl-235b-a22b": {
+    "LMArena": "qwen3-vl-235b-a22b-instruct",
+    "PuterJS": "openrouter:qwen/qwen3-vl-235b-a22b-instruct",
+    "ApiAirforce": "qwen3-vl-235b-a22b",
+    "HuggingChat": "Qwen/Qwen3-VL-235B-A22B-Instruct",
+    "HuggingFaceAPI": "Qwen/Qwen3-VL-235B-A22B-Instruct",
+    "OpenRouter": "qwen/qwen3-vl-235b-a22b-instruct"
+  },
+  "claude-opus-4": {
+    "LMArena": "claude-opus-4-20250514",
+    "PuterJS": "anthropic:anthropic/claude-opus-4",
+    "Anthropic": "claude-opus-4-20250522",
+    "ApiAirforce": "claude-opus-4",
+    "OpenRouter": "anthropic/claude-opus-4"
+  },
+  "claude-haiku-4-5": {
+    "LMArena": "claude-haiku-4-5-20251001",
+    "PuterJS": "anthropic:anthropic/claude-haiku-4-5",
+    "ApiAirforce": "claude-haiku-4.5",
+    "OpenRouter": "anthropic/claude-haiku-4.5"
+  },
+  "mistral-medium-2508": {
+    "LMArena": "mistral-medium-2508",
+    "PuterJS": "mistralai:mistralai/mistral-medium-2508"
+  },
+  "qwen-3-235b-a22b-no-thinking": {
+    "LMArena": "qwen3-235b-a22b-no-thinking"
+  },
+  "gpt-5.4-nano-high": {
+    "LMArena": "gpt-5.4-nano-high"
+  },
+  "qwen-3-next-80b-a3b": {
+    "LMArena": "qwen3-next-80b-a3b-instruct",
+    "PuterJS": "openrouter:qwen/qwen3-next-80b-a3b-instruct:free",
+    "ApiAirforce": "qwen3-next-80b-a3b",
+    "HuggingChat": "Qwen/Qwen3-Next-80B-A3B-Instruct",
+    "HuggingFaceAPI": "Qwen/Qwen3-Next-80B-A3B-Instruct",
+    "OpenRouter": "qwen/qwen3-next-80b-a3b-instruct"
+  },
+  "longcat-flash-chat": {
+    "LMArena": "longcat-flash-chat"
+  },
+  "qwen-3-235b-a22b-thinking-2507": {
+    "LMArena": "qwen3-235b-a22b-thinking-2507",
+    "PuterJS": "openrouter:qwen/qwen3-235b-a22b-thinking-2507",
+    "HuggingChat": "Qwen/Qwen3-235B-A22B-Thinking-2507",
+    "OpenRouter": "qwen/qwen3-235b-a22b-thinking-2507"
+  },
+  "claude-sonnet-4-20250514-thinking-32k": {
+    "LMArena": "claude-sonnet-4-20250514-thinking-32k"
+  },
+  "hunyuan-vision-1.5-thinking": {
+    "LMArena": "hunyuan-vision-1.5-thinking"
+  },
+  "qwen-3-vl-235b-a22b-thinking": {
+    "LMArena": "qwen3-vl-235b-a22b-thinking",
+    "PuterJS": "openrouter:qwen/qwen3-vl-235b-a22b-thinking",
+    "HuggingChat": "Qwen/Qwen3-VL-235B-A22B-Thinking",
+    "OpenRouter": "qwen/qwen3-vl-235b-a22b-thinking"
   },
   "micro-mango": {
     "LMArena": "micro-mango"
@@ -1790,274 +1775,344 @@ model_map = {
   "mimo-v2-flash (thinking)": {
     "LMArena": "mimo-v2-flash (thinking)"
   },
-  "anonymous-1218": {
-    "LMArena": "anonymous-1218"
+  "mimo-v2-flash": {
+    "LMArena": "mimo-v2-flash"
   },
-  "mistral-small-3.1-24b-2503": {
-    "LMArena": "mistral-small-3.1-24b-instruct-2503",
-    "HuggingFaceAPI": "mistralai/Mistral-Small-3.1-24B-Instruct-2503",
-    "Nvidia": "mistralai/mistral-small-3.1-24b-instruct-2503",
-    "Yupp": "mistralai/mistral-small-3.1-24b-instruct-2503"
-  },
-  "x1-1-preview-0915": {
-    "LMArena": "x1-1-preview-0915"
-  },
-  "ibm-granite-h-small": {
-    "LMArena": "ibm-granite-h-small"
-  },
-  "qwen-3-vl-8b-thinking": {
-    "LMArena": "qwen3-vl-8b-thinking",
-    "PuterJS": "openrouter:qwen/qwen3-vl-8b-thinking",
-    "OpenRouter": "qwen/qwen3-vl-8b-thinking"
-  },
-  "qwen-3-vl-8b": {
-    "LMArena": "qwen3-vl-8b-instruct",
-    "PuterJS": "openrouter:qwen/qwen3-vl-8b-instruct",
-    "HuggingFaceAPI": "Qwen/Qwen3-VL-8B-Instruct",
-    "HuggingChat": "Qwen/Qwen3-VL-8B-Instruct",
-    "OpenRouter": "qwen/qwen3-vl-8b-instruct"
-  },
-  "ernie-exp-251024": {
-    "LMArena": "ernie-exp-251024"
-  },
-  "beluga-0104-1": {
-    "LMArena": "beluga-0104-1"
-  },
-  "mistral-medium-2505": {
-    "LMArena": "mistral-medium-2505",
-    "Yupp": "mistral-medium-2505"
-  },
-  "anonymous-1221": {
-    "LMArena": "anonymous-1221"
-  },
-  "hunyuan-vision-1.5-thinking": {
-    "LMArena": "hunyuan-vision-1.5-thinking"
-  },
-  "command-a25": {
-    "LMArena": "command-a-03-2025",
-    "HuggingSpace": "command-a-03-2025",
-    "Cohere": "command-a-03-2025",
-    "CohereForAI_C4AI_Command": "command-a-03-2025",
-    "HuggingChat": "CohereLabs/c4ai-command-a-03-2025",
-    "Yupp": "command-a-03-2025"
-  },
-  "grok-3-mini-beta": {
-    "LMArena": "grok-3-mini-beta",
-    "PuterJS": "openrouter:x-ai/grok-3-mini-beta",
-    "OpenRouter": "x-ai/grok-3-mini-beta"
-  },
-  "lmarena-text-gg": {
-    "LMArena": "lmarena-text-gg"
-  },
-  "nova-2-lite": {
-    "LMArena": "nova-2-lite",
-    "PuterJS": "openrouter:amazon/nova-2-lite-v1",
-    "OpenRouter": "amazon/nova-2-lite-v1"
-  },
-  "beluga-0105-1": {
-    "LMArena": "beluga-0105-1"
-  },
-  "eb45-turbo-vl-0906": {
-    "LMArena": "EB45-turbo-vl-0906"
-  },
-  "stephen": {
-    "LMArena": "stephen-v2"
+  "gpt-5-mini-high": {
+    "LMArena": "gpt-5-mini-high"
   },
   "claude-sonnet-4": {
     "LMArena": "claude-sonnet-4-20250514",
-    "PuterJS": "openrouter:anthropic/claude-sonnet-4",
+    "PuterJS": "anthropic:anthropic/claude-sonnet-4",
     "Anthropic": "claude-sonnet-4-latest",
-    "Claude": "claude-sonnet-4-20250514",
-    "OpenRouter": "anthropic/claude-sonnet-4",
-    "Yupp": "claude-sonnet-4-20250514"
+    "ApiAirforce": "claude-sonnet-4-20250514",
+    "OpenRouter": "anthropic/claude-sonnet-4"
   },
-  "gemini-2.5-flash-lite-preview-thinking": {
-    "LMArena": "gemini-2.5-flash-lite-preview-06-17-thinking"
+  "qwen-3-coder-480b-a35b": {
+    "LMArena": "qwen3-coder-480b-a35b-instruct",
+    "PuterJS": "alibaba:qwen/qwen3-coder-480b-a35b-instruct",
+    "ApiAirforce": "qwen3-coder-480b-a35b",
+    "HuggingChat": "Qwen/Qwen3-Coder-480B-A35B-Instruct",
+    "HuggingFaceAPI": "Qwen/Qwen3-Coder-480B-A35B-Instruct"
   },
-  "beluga-0105-2": {
-    "LMArena": "beluga-0105-2"
+  "mistral-medium-2505": {
+    "LMArena": "mistral-medium-2505"
+  },
+  "minimax-m2.1": {
+    "LMArena": "minimax-m2.1-preview",
+    "PuterJS": "minimax:minimax/minimax-m2.1",
+    "ApiAirforce": "minimax-m2.1",
+    "HuggingChat": "MiniMaxAI/MiniMax-M2.1",
+    "Ollama": "minimax-m2.1",
+    "OllamaSwarm": "minimax-m2.1:cloud",
+    "OpenRouter": "minimax/minimax-m2.1"
+  },
+  "qwen-3-30b-a3b-2507": {
+    "LMArena": "qwen3-30b-a3b-instruct-2507",
+    "PuterJS": "openrouter:qwen/qwen3-30b-a3b-instruct-2507",
+    "HuggingFaceAPI": "Qwen/Qwen3-30B-A3B-Instruct-2507",
+    "OpenRouter": "qwen/qwen3-30b-a3b-instruct-2507"
+  },
+  "trinity-large": {
+    "LMArena": "trinity-large"
+  },
+  "qwen-3-235b-a22b": {
+    "LMArena": "qwen3-235b-a22b",
+    "PuterJS": "alibaba:qwen/qwen3-235b-a22b",
+    "ApiAirforce": "qwen3-235b-a22b",
+    "HuggingChat": "Qwen/Qwen3-235B-A22B",
+    "HuggingFaceAPI": "Qwen/Qwen3-235B-A22B",
+    "OpenRouter": "qwen/qwen3-235b-a22b"
+  },
+  "qwen-3-next-80b-a3b-thinking": {
+    "LMArena": "qwen3-next-80b-a3b-thinking",
+    "PuterJS": "alibaba:qwen/qwen3-next-80b-a3b-thinking",
+    "HuggingChat": "Qwen/Qwen3-Next-80B-A3B-Thinking",
+    "OpenRouter": "qwen/qwen3-next-80b-a3b-thinking"
+  },
+  "trinity-large-thinking": {
+    "LMArena": "trinity-large-thinking",
+    "PuterJS": "openrouter:arcee-ai/trinity-large-thinking",
+    "HuggingFaceAPI": "arcee-ai/Trinity-Large-Thinking",
+    "OpenRouter": "arcee-ai/trinity-large-thinking"
+  },
+  "gemma-3-27b-it": {
+    "LMArena": "gemma-3-27b-it",
+    "PuterJS": "openrouter:google/gemma-3-27b-it",
+    "HuggingChat": "google/gemma-3-27b-it",
+    "HuggingFaceAPI": "google/gemma-3-27b-it",
+    "OpenRouter": "google/gemma-3-27b-it"
   },
   "minimax-m1": {
     "LMArena": "minimax-m1",
     "PuterJS": "openrouter:minimax/minimax-m1",
     "OpenRouter": "minimax/minimax-m1"
   },
-  "olmo-3-32b-think": {
-    "LMArena": "olmo-3-32b-think",
-    "PuterJS": "openrouter:allenai/olmo-3-32b-think",
-    "OpenRouter": "allenai/olmo-3-32b-think"
+  "grok-3-mini-high": {
+    "LMArena": "grok-3-mini-high"
   },
-  "dark-dragon": {
-    "LMArena": "dark-dragon"
-  },
-  "x1-turbo-0906": {
-    "LMArena": "x1-turbo-0906"
-  },
-  "amazon-nova-experimental-chat": {
-    "LMArena": "amazon-nova-experimental-chat-11-10"
-  },
-  "mistral-large-3": {
-    "LMArena": "mistral-large-3",
-    "Ollama": "mistral-large-3:675b"
-  },
-  "frame-flow": {
-    "LMArena": "frame-flow"
-  },
-  "grok-4-1-fast-non-reasoning": {
-    "LMArena": "grok-4-1-fast-non-reasoning"
-  },
-  "january26-chatbot1": {
-    "LMArena": "january26-chatbot1"
+  "march26-chatbot1": {
+    "LMArena": "march26-chatbot1"
   },
   "mistral-small-2506": {
-    "LMArena": "mistral-small-2506",
-    "PuterJS": "mistral-small-2506",
-    "Yupp": "mistral-small-2506"
+    "LMArena": "mistral-small-2506"
   },
-  "january26-chatbot2": {
-    "LMArena": "january26-chatbot2"
-  },
-  "beluga-1229-1": {
-    "LMArena": "beluga-1229-1"
-  },
-  "grok-4-0709": {
-    "LMArena": "grok-4-0709"
-  },
-  "beluga-1230-1": {
-    "LMArena": "beluga-1230-1"
-  },
-  "ernie-5.0-preview-1103": {
-    "LMArena": "ernie-5.0-preview-1103"
-  },
-  "gemini-2.5-pro-grounding-exp": {
-    "LMArena": "gemini-2.5-pro-grounding-exp"
-  },
-  "beluga-1128-1": {
-    "LMArena": "beluga-1128-1"
-  },
-  "phantom-1203-1": {
-    "LMArena": "phantom-1203-1"
-  },
-  "phantom-mm-1125-1": {
-    "LMArena": "phantom-mm-1125-1"
-  },
-  "integrated-info": {
-    "LMArena": "integrated-info"
-  },
-  "beluga-1203-1": {
-    "LMArena": "beluga-1203-1"
-  },
-  "master-node": {
-    "LMArena": "master-node"
-  },
-  "amazon.nova-pro": {
-    "LMArena": "amazon.nova-pro-v1:0",
-    "Yupp": "arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-pro-v1:0<>BED"
-  },
-  "kimi-k2-0711": {
-    "LMArena": "kimi-k2-0711-preview"
+  "grok-3-mini-beta": {
+    "LMArena": "grok-3-mini-beta"
   },
   "intellect-3": {
-    "LMArena": "intellect-3",
-    "PuterJS": "openrouter:prime-intellect/intellect-3",
-    "HuggingFaceAPI": "PrimeIntellect/INTELLECT-3-FP8",
-    "HuggingChat": "PrimeIntellect/INTELLECT-3-FP8",
-    "OpenRouter": "prime-intellect/intellect-3"
+    "LMArena": "intellect-3"
   },
-  "raptor-0107": {
-    "LMArena": "raptor-0107"
+  "mercury-2": {
+    "LMArena": "mercury-2",
+    "PuterJS": "openrouter:inception/mercury-2",
+    "OpenRouter": "inception/mercury-2",
+    "PollinationsAI": "mercury"
   },
-  "cogilux": {
-    "LMArena": "cogilux"
+  "ling-flash-2.0": {
+    "LMArena": "ling-flash-2.0"
+  },
+  "minimax-m2": {
+    "LMArena": "minimax-m2-preview",
+    "PuterJS": "minimax:minimax/minimax-m2",
+    "ApiAirforce": "minimax-m2",
+    "HuggingChat": "MiniMaxAI/MiniMax-M2",
+    "OllamaSwarm": "minimax-m2:cloud",
+    "OpenRouter": "minimax/minimax-m2"
+  },
+  "nova-2-lite": {
+    "LMArena": "nova-2-lite",
+    "PuterJS": "openrouter:amazon/nova-2-lite-v1",
+    "OpenRouter": "amazon/nova-2-lite-v1",
+    "PollinationsAI": "nova"
+  },
+  "gpt-5-nano-high": {
+    "LMArena": "gpt-5-nano-high"
+  },
+  "olmo-3.1-32b": {
+    "LMArena": "olmo-3.1-32b-instruct"
+  },
+  "qwen-3-30b-a3b": {
+    "LMArena": "qwen3-30b-a3b",
+    "PuterJS": "openrouter:qwen/qwen3-30b-a3b",
+    "ApiAirforce": "qwen3-30b-a3b",
+    "OpenRouter": "qwen/qwen3-30b-a3b"
+  },
+  "ring-flash-2.0": {
+    "LMArena": "ring-flash-2.0"
+  },
+  "gemma-3n-e4b-it": {
+    "LMArena": "gemma-3n-e4b-it",
+    "PuterJS": "togetherai:google/gemma-3n-e4b-it",
+    "HuggingChat": "google/gemma-3n-E4B-it",
+    "OpenRouter": "google/gemma-3n-e4b-it"
+  },
+  "gpt-oss-20b": {
+    "LMArena": "gpt-oss-20b",
+    "PuterJS": "togetherai:openai/gpt-oss-20b",
+    "ApiAirforce": "gpt-oss-20b",
+    "HuggingChat": "openai/gpt-oss-20b",
+    "HuggingFaceAPI": "openai/gpt-oss-20b",
+    "Ollama": "gpt-oss:20b",
+    "OpenRouter": "openai/gpt-oss-20b"
+  },
+  "nvidia-nemotron-3-nano-30b-a3b": {
+    "LMArena": "nvidia-nemotron-3-nano-30b-a3b-bf16",
+    "HuggingFaceAPI": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16"
+  },
+  "granite-4.1-8b": {
+    "LMArena": "granite-4.1-8b",
+    "PuterJS": "openrouter:ibm-granite/granite-4.1-8b",
+    "OpenRouter": "ibm-granite/granite-4.1-8b"
+  },
+  "mistral-small-3.1-24b-2503": {
+    "LMArena": "mistral-small-3.1-24b-instruct-2503",
+    "HuggingFaceAPI": "mistralai/Mistral-Small-3.1-24B-Instruct-2503"
+  },
+  "ibm-granite-h-small": {
+    "LMArena": "ibm-granite-h-small"
+  },
+  "olmo-3.1-32b-think": {
+    "LMArena": "olmo-3.1-32b-think"
+  },
+  "jebel.1": {
+    "LMArena": "jebel_1"
+  },
+  "scooter": {
+    "LMArena": "scooter"
+  },
+  "jebel.2": {
+    "LMArena": "jebel_2"
+  },
+  "ring-2.5-1t": {
+    "LMArena": "ring-2.5-1t"
+  },
+  "kira-star": {
+    "LMArena": "kira-star"
+  },
+  "segesta": {
+    "LMArena": "segesta"
+  },
+  "tetra-0429-1": {
+    "LMArena": "tetra-0429-1"
+  },
+  "ember": {
+    "LMArena": "ember"
+  },
+  "artemis.1": {
+    "LMArena": "artemis_1"
+  },
+  "artemis.2": {
+    "LMArena": "artemis_2"
+  },
+  "rover": {
+    "LMArena": "rover"
+  },
+  "tetra-0429-2": {
+    "LMArena": "tetra-0429-2"
+  },
+  "tetra-0429-3": {
+    "LMArena": "tetra-0429-3"
+  },
+  "steed-0217": {
+    "LMArena": "steed-0217"
+  },
+  "may26-chatbot3": {
+    "LMArena": "may26-chatbot3"
+  },
+  "kiteki-beta": {
+    "LMArena": "kiteki-beta"
+  },
+  "tetra-0429-4": {
+    "LMArena": "tetra-0429-4"
+  },
+  "tetra-0429-5": {
+    "LMArena": "tetra-0429-5"
+  },
+  "hofburg-1": {
+    "LMArena": "hofburg-1"
+  },
+  "pulse": {
+    "LMArena": "pulse"
+  },
+  "mivan": {
+    "LMArena": "mivan"
+  },
+  "tetra-0429-6": {
+    "LMArena": "tetra-0429-6"
+  },
+  "step-3.7-flash": {
+    "LMArena": "step-3.7-flash",
+    "PuterJS": "openrouter:stepfun/step-3.7-flash",
+    "HuggingChat": "stepfun-ai/Step-3.7-Flash",
+    "HuggingFaceAPI": "stepfun-ai/Step-3.7-Flash",
+    "OpenRouter": "stepfun/step-3.7-flash",
+    "PollinationsAI": "step-flash"
+  },
+  "maylynx-alpha": {
+    "LMArena": "maylynx-alpha"
+  },
+  "cloud-buddy": {
+    "LMArena": "cloud-buddy"
+  },
+  "luxor": {
+    "LMArena": "luxor"
+  },
+  "pisces-0309": {
+    "LMArena": "pisces-0309"
+  },
+  "pakson": {
+    "LMArena": "pakson"
+  },
+  "may-beta": {
+    "LMArena": "may-beta"
+  },
+  "ling-2.5-1t": {
+    "LMArena": "ling-2.5-1t"
+  },
+  "globe.2": {
+    "LMArena": "globe_2"
+  },
+  "dola-seed-2.0-preview-vision": {
+    "LMArena": "dola-seed-2.0-preview-vision"
+  },
+  "mizar-beta": {
+    "LMArena": "mizar-beta"
+  },
+  "beacon-qdn9": {
+    "LMArena": "beacon-qdn9"
+  },
+  "anonymous-1800": {
+    "LMArena": "anonymous-1800"
   },
   "gpt-5-high-no-system-prompt": {
     "LMArena": "gpt-5-high-no-system-prompt"
   },
-  "olmo-3.1-32b": {
-    "LMArena": "olmo-3.1-32b-instruct",
-    "PuterJS": "openrouter:allenai/olmo-3.1-32b-instruct",
-    "HuggingFaceAPI": "allenai/Olmo-3.1-32B-Instruct",
-    "HuggingChat": "allenai/Olmo-3.1-32B-Instruct",
-    "OpenRouter": "allenai/olmo-3.1-32b-instruct"
+  "spider": {
+    "LMArena": "spider"
   },
-  "eb45-vision": {
-    "LMArena": "EB45-vision"
+  "mammoth-newt-0206": {
+    "LMArena": "mammoth-newt-0206"
   },
-  "mistral-medium-2508": {
-    "LMArena": "mistral-medium-2508",
-    "PuterJS": "mistral-medium-2508"
+  "pisces-0226d": {
+    "LMArena": "pisces-0226d"
   },
-  "olmo-3.1-32b-think": {
-    "LMArena": "olmo-3.1-32b-think",
-    "PuterJS": "openrouter:allenai/olmo-3.1-32b-think",
-    "HuggingFaceAPI": "allenai/Olmo-3.1-32B-Think",
-    "HuggingChat": "allenai/Olmo-3.1-32B-Think",
-    "OpenRouter": "allenai/olmo-3.1-32b-think",
-    "Yupp": "allenai/olmo-3.1-32b-think:free<>OPR"
+  "hofburg.2": {
+    "LMArena": "hofburg_2"
   },
-  "fire-bird": {
-    "LMArena": "fire-bird"
+  "solar-open2": {
+    "LMArena": "solar-open2"
   },
-  "beluga-1211-2": {
-    "LMArena": "beluga-1211-2"
+  "pancetta": {
+    "LMArena": "pancetta"
   },
-  "gemini-3-flash (thinking-minimal)": {
-    "LMArena": "gemini-3-flash (thinking-minimal)"
+  "victoria": {
+    "LMArena": "victoria"
   },
-  "lmarena-internal-test-only": {
-    "LMArena": "lmarena-internal-test-only"
+  "pisces-0318-vision": {
+    "LMArena": "pisces-0318-vision"
   },
-  "not-a-new-model": {
-    "LMArena": "not-a-new-model"
+  "myrion": {
+    "LMArena": "myrion"
   },
-  "eb45-turbo": {
-    "LMArena": "EB45-turbo"
+  "march26-chatbot1-public": {
+    "LMArena": "march26-chatbot1-public"
   },
-  "claude-3-7-sonnet-20250219-thinking-32k": {
-    "LMArena": "claude-3-7-sonnet-20250219-thinking-32k"
+  "june-alpha": {
+    "LMArena": "june-alpha"
   },
-  "glm-4.5v": {
-    "LMArena": "glm-4.5v",
-    "PuterJS": "openrouter:z-ai/glm-4.5v",
-    "HuggingFaceAPI": "zai-org/GLM-4.5V",
-    "HuggingChat": "zai-org/GLM-4.5V-FP8",
-    "OpenRouter": "z-ai/glm-4.5v"
+  "tianyi": {
+    "LMArena": "tianyi"
   },
-  "raptor-vision-1015": {
-    "LMArena": "raptor-vision-1015"
+  "maymo-beta": {
+    "LMArena": "maymo-beta"
   },
-  "glm-4.6v": {
-    "LMArena": "glm-4.6v",
-    "PuterJS": "openrouter:z-ai/glm-4.6v",
-    "HuggingFaceAPI": "zai-org/GLM-4.6V",
-    "HuggingChat": "zai-org/GLM-4.6V-FP8",
-    "OpenRouter": "z-ai/glm-4.6v"
+  "maymo-alpha": {
+    "LMArena": "maymo-alpha"
   },
-  "kiwi-do": {
-    "LMArena": "kiwi-do"
+  "pisces-0309-vision": {
+    "LMArena": "pisces-0309-vision"
   },
-  "gpt-5.2-high": {
-    "LMArena": "gpt-5.2-high"
+  "hcx-lm-arena": {
+    "LMArena": "hcx-lm-arena"
+  },
+  "blue-forge": {
+    "LMArena": "blue-forge"
   },
   "anonymous-1111": {
     "LMArena": "anonymous-1111"
   },
-  "claude-opus-4": {
-    "LMArena": "claude-opus-4-20250514",
-    "PuterJS": "openrouter:anthropic/claude-opus-4",
-    "Anthropic": "claude-opus-4-20250522",
-    "OpenRouter": "anthropic/claude-opus-4"
+  "rijks": {
+    "LMArena": "rijks"
   },
-  "gpt-5.2-no-system-prompt": {
-    "LMArena": "gpt-5.2-no-system-prompt"
+  "spark": {
+    "LMArena": "spark"
   },
-  "gpt-5.2-high-no-system-prompt": {
-    "LMArena": "gpt-5.2-high-no-system-prompt"
+  "pisces-0309b": {
+    "LMArena": "pisces-0309b"
   },
-  "glm-4.6v-flash": {
-    "LMArena": "glm-4.6v-flash",
-    "HuggingFaceAPI": "zai-org/GLM-4.6V-Flash",
-    "HuggingChat": "zai-org/GLM-4.6V-Flash"
+  "hofburg.3": {
+    "LMArena": "hofburg_3"
   },
   "leepwal": {
     "LMArena": "leepwal"
@@ -2065,482 +2120,920 @@ model_map = {
   "blackhawk": {
     "LMArena": "blackhawk"
   },
-  "hunyuan-t1": {
-    "LMArena": "hunyuan-t1-20250711"
+  "hearth": {
+    "LMArena": "hearth"
   },
-  "ernie-5.0-preview-1220": {
-    "LMArena": "ernie-5.0-preview-1220"
+  "happy-friday-testing-1": {
+    "LMArena": "happy-friday-testing-1"
   },
-  "beluga-1203-2": {
-    "LMArena": "beluga-1203-2"
+  "scorch": {
+    "LMArena": "scorch"
   },
-  "neo-nucleus": {
-    "LMArena": "neo-nucleus"
-  },
-  "jakiro": {
-    "LMArena": "jakiro"
-  },
-  "december-chatbot3": {
-    "LMArena": "december-chatbot3"
-  },
-  "omg-wow": {
-    "LMArena": "omg-wow"
-  },
-  "beluga-1223-1": {
-    "LMArena": "beluga-1223-1"
-  },
-  "claude-sonnet-4-5-20250929-thinking-32k": {
-    "LMArena": "claude-sonnet-4-5-20250929-thinking-32k"
-  },
-  "proto-think": {
-    "LMArena": "proto-think"
-  },
-  "ernie-5.0-preview-1203": {
-    "LMArena": "ernie-5.0-preview-1203"
-  },
-  "beluga-1223-2": {
-    "LMArena": "beluga-1223-2"
-  },
-  "raptor-1119": {
-    "LMArena": "raptor-1119"
-  },
-  "raptor": {
-    "LMArena": "raptor"
-  },
-  "gemini-2.5-flash-lite-preview25-no-thinking": {
-    "LMArena": "gemini-2.5-flash-lite-preview-09-2025-no-thinking"
-  },
-  "grok-3-mini-high": {
-    "LMArena": "grok-3-mini-high"
-  },
-  "gemini-2.5-flash-preview25": {
-    "LMArena": "gemini-2.5-flash-preview-09-2025",
-    "PuterJS": "openrouter:google/gemini-2.5-flash-preview-09-2025",
-    "OpenRouter": "google/gemini-2.5-flash-preview-09-2025"
-  },
-  "grok-4-fast-reasoning": {
-    "LMArena": "grok-4-fast-reasoning"
-  },
-  "winter-wind": {
-    "LMArena": "winter-wind"
-  },
-  "grok-4-1-fast-reasoning": {
-    "LMArena": "grok-4-1-fast-reasoning"
-  },
-  "longcat-flash-chat": {
-    "LMArena": "longcat-flash-chat",
-    "PuterJS": "openrouter:meituan/longcat-flash-chat",
-    "OpenRouter": "meituan/longcat-flash-chat"
-  },
-  "qwen-3-vl-235b-a22b": {
-    "LMArena": "qwen3-vl-235b-a22b-instruct",
-    "PuterJS": "openrouter:qwen/qwen3-vl-235b-a22b-instruct",
-    "HuggingFaceAPI": "Qwen/Qwen3-VL-235B-A22B-Instruct",
-    "HuggingChat": "Qwen/Qwen3-VL-235B-A22B-Instruct",
-    "OpenRouter": "qwen/qwen3-vl-235b-a22b-instruct",
-    "Yupp": "qwen3-vl-235b-a22b-instruct"
-  },
-  "qwen-3-235b-a22b-no-thinking": {
-    "LMArena": "qwen3-235b-a22b-no-thinking"
-  },
-  "qwen-3-vl-235b-a22b-thinking": {
-    "LMArena": "qwen3-vl-235b-a22b-thinking",
-    "PuterJS": "openrouter:qwen/qwen3-vl-235b-a22b-thinking",
-    "HuggingFaceAPI": "Qwen/Qwen3-VL-235B-A22B-Thinking",
-    "HuggingChat": "Qwen/Qwen3-VL-235B-A22B-Thinking",
-    "OpenRouter": "qwen/qwen3-vl-235b-a22b-thinking",
-    "Yupp": "qwen3-vl-235b-a22b-thinking"
-  },
-  "mimo-7b": {
-    "LMArena": "MiMo-7B"
-  },
-  "claude-opus-4-1": {
-    "LMArena": "claude-opus-4-1-20250805",
-    "PuterJS": "claude-opus-4-1-20250805",
-    "Anthropic": "claude-opus-4-1-latest",
-    "Claude": "claude-opus-4-1-20250805"
-  },
-  "qwen-3-omni-flash": {
-    "LMArena": "qwen3-omni-flash",
-    "ApiAirforce": "qwen3-omni-flash-2025-12-01"
-  },
-  "qwen-3-max-thinking": {
-    "LMArena": "qwen3-max-thinking"
-  },
-  "beluga-1223-4": {
-    "LMArena": "beluga-1223-4"
-  },
-  "beluga-1223-3": {
-    "LMArena": "beluga-1223-3"
-  },
-  "stephen-vision-csfix": {
-    "LMArena": "stephen-vision-csfix"
-  },
-  "claude-opus-4-1-20250805-thinking-16k": {
-    "LMArena": "claude-opus-4-1-20250805-thinking-16k"
-  },
-  "claude-3-5-sonnet": {
-    "LMArena": "claude-3-5-sonnet-20241022",
-    "PuterJS": "claude-3-5-sonnet-20241022",
-    "Anthropic": "claude-3-5-sonnet-latest"
-  },
-  "raptor-1124": {
-    "LMArena": "raptor-1124"
-  },
-  "ling-flash-2.0": {
-    "LMArena": "ling-flash-2.0",
-    "HuggingSpace": "ling-flash-2.0",
-    "BAAI_Ling": "ling-flash-2.0"
-  },
-  "raptor-1123": {
-    "LMArena": "raptor-1123"
-  },
-  "step-3-mini-2511": {
-    "LMArena": "step-3-mini-2511"
+  "beluga-0311-1": {
+    "LMArena": "beluga-0311-1"
   },
   "monster": {
     "LMArena": "monster"
   },
-  "claude-3-7-sonnet": {
-    "LMArena": "claude-3-7-sonnet-20250219",
-    "PuterJS": "claude-3-7-sonnet-20250219",
-    "Anthropic": "claude-3-7-sonnet-20250219",
-    "Yupp": "claude-3-7-sonnet-20250219"
-  },
-  "chatgpt-4o": {
-    "LMArena": "chatgpt-4o-latest-20250326",
-    "PuterJS": "openrouter:openai/chatgpt-4o-latest",
-    "OpenRouter": "openai/chatgpt-4o-latest"
-  },
-  "anonymous-1222": {
-    "LMArena": "anonymous-1222"
-  },
-  "ernie-exp-vl-251016": {
-    "LMArena": "ernie-exp-vl-251016"
-  },
-  "claude-3-5-haiku": {
-    "LMArena": "claude-3-5-haiku-20241022",
-    "Anthropic": "claude-3-5-haiku-latest",
-    "Yupp": "claude-3-5-haiku-20241022"
-  },
-  "qwen-vl-max": {
-    "LMArena": "qwen-vl-max-2025-08-13",
-    "PuterJS": "openrouter:qwen/qwen-vl-max",
-    "OpenRouter": "qwen/qwen-vl-max",
-    "Yupp": "qwen/qwen-vl-max"
-  },
-  "qwen-3-30b-a3b-2507": {
-    "LMArena": "qwen3-30b-a3b-instruct-2507",
-    "PuterJS": "openrouter:qwen/qwen3-30b-a3b-instruct-2507",
-    "HuggingFaceAPI": "Qwen/Qwen3-30B-A3B-Instruct-2507",
-    "HuggingChat": "Qwen/Qwen3-30B-A3B-Instruct-2507",
-    "OpenRouter": "qwen/qwen3-30b-a3b-instruct-2507",
-    "Yupp": "qwen3-30b-a3b-instruct-2507"
-  },
-  "step-3": {
-    "LMArena": "step-3"
-  },
-  "ling-1t": {
-    "LMArena": "ling-1t",
-    "HuggingSpace": "ling-1t",
-    "HuggingFaceAPI": "inclusionAI/Ling-1T",
-    "BAAI_Ling": "ling-1t"
+  "dola-seed-2.0-pro-vision": {
+    "LMArena": "dola-seed-2.0-pro-vision"
   },
   "monterey": {
     "LMArena": "monterey"
   },
-  "sunshine-ai": {
-    "LMArena": "sunshine-ai"
-  },
-  "claude-sonnet-4-20250514-thinking-32k": {
-    "LMArena": "claude-sonnet-4-20250514-thinking-32k"
-  },
-  "ring-flash-2.0": {
-    "LMArena": "ring-flash-2.0",
-    "HuggingSpace": "ring-flash-2.0",
-    "BAAI_Ling": "ring-flash-2.0"
-  },
-  "claude-opus-4-20250514-thinking-16k": {
-    "LMArena": "claude-opus-4-20250514-thinking-16k"
-  },
-  "glm-4.6": {
-    "LMArena": "glm-4.6",
-    "PuterJS": "openrouter:z-ai/glm-4.6:exacto",
-    "HuggingFaceAPI": "zai-org/GLM-4.6",
-    "Ollama": "glm-4.6",
-    "ApiAirforce": "glm-4.6",
-    "HuggingChat": "zai-org/GLM-4.6-FP8",
-    "OpenRouter": "z-ai/glm-4.6:exacto",
-    "Yupp": "z-ai/glm-4.6:exacto<>OPR"
-  },
-  "gauss": {
-    "LMArena": "gauss"
+  "february26-chatbot4": {
+    "LMArena": "february26-chatbot4"
   },
   "whisperfall": {
     "LMArena": "whisperfall"
   },
-  "grok-4.1": {
-    "LMArena": "grok-4.1"
-  },
   "neon": {
     "LMArena": "neon"
   },
-  "mercury": {
-    "LMArena": "mercury",
-    "PuterJS": "openrouter:inception/mercury",
-    "OpenRouter": "inception/mercury",
-    "Yupp": "inception/mercury"
+  "anonymous-1835": {
+    "LMArena": "anonymous-1835"
   },
-  "gpt-5-high": {
-    "LMArena": "gpt-5-high"
+  "mammoth-newt-0226": {
+    "LMArena": "mammoth-newt-0226"
   },
   "viper": {
     "LMArena": "viper"
   },
-  "ernie-5.0-preview-1120": {
-    "LMArena": "ernie-5.0-preview-1120"
-  },
-  "flying-octopus": {
-    "LMArena": "flying-octopus"
-  },
-  "ernie-exp-251023": {
-    "LMArena": "ernie-exp-251023"
-  },
-  "ernie-exp-251027": {
-    "LMArena": "ernie-exp-251027"
+  "anonymous-1825": {
+    "LMArena": "anonymous-1825"
   },
   "nightride-on": {
     "LMArena": "nightride-on-v2"
   },
   "ring-1t": {
     "LMArena": "ring-1t",
-    "HuggingSpace": "ring-1t",
-    "BAAI_Ling": "ring-1t"
+    "HuggingFaceAPI": "inclusionAI/Ring-1T"
   },
-  "ernie-exp-251025": {
-    "LMArena": "ernie-exp-251025"
+  "zephyr": {
+    "LMArena": "zephyr"
   },
-  "grok-4-fast-chat": {
-    "LMArena": "grok-4-fast-chat"
+  "pisces-0318-text": {
+    "LMArena": "pisces-0318-text"
   },
-  "ernie-exp-251026": {
-    "LMArena": "ernie-exp-251026"
-  },
-  "o3": {
-    "LMArena": "o3-2025-04-16",
-    "PuterJS": "openrouter:openai/o3",
-    "GithubCopilot": "o3",
-    "OpenRouter": "openai/o3",
-    "Yupp": "o3"
-  },
-  "raptor-llm-1024": {
-    "LMArena": "raptor-llm-1024"
-  },
-  "newton": {
-    "LMArena": "newton"
-  },
-  "aegis-core": {
-    "LMArena": "aegis-core"
-  },
-  "gpt-5.1-high": {
-    "LMArena": "gpt-5.1-high"
-  },
-  "magistral-medium-2506": {
-    "LMArena": "magistral-medium-2506"
-  },
-  "raptor-vision-1107": {
-    "LMArena": "raptor-vision-1107"
-  },
-  "rain-drop": {
-    "LMArena": "rain-drop"
-  },
-  "grok-4.1-thinking": {
-    "LMArena": "grok-4.1-thinking"
-  },
-  "gpt-5-mini-high": {
-    "LMArena": "gpt-5-mini-high"
-  },
-  "gpt-5-nano-high": {
-    "LMArena": "gpt-5-nano-high"
+  "pisces-0309c": {
+    "LMArena": "pisces-0309c"
   },
   "redwood": {
     "LMArena": "redwood"
   },
-  "gpt-5-high-new-system-prompt": {
-    "LMArena": "gpt-5-high-new-system-prompt"
+  "yivon-beta": {
+    "LMArena": "yivon-beta"
   },
-  "qwen-3-next-80b-a3b-thinking": {
-    "LMArena": "qwen3-next-80b-a3b-thinking",
-    "PuterJS": "openrouter:qwen/qwen3-next-80b-a3b-thinking",
-    "HuggingFaceAPI": "Qwen/Qwen3-Next-80B-A3B-Thinking",
-    "Nvidia": "qwen/qwen3-next-80b-a3b-thinking",
-    "HuggingChat": "Qwen/Qwen3-Next-80B-A3B-Thinking",
-    "OpenRouter": "qwen/qwen3-next-80b-a3b-thinking",
-    "Yupp": "qwen3-next-80b-a3b-thinking"
+  "atlas": {
+    "LMArena": "atlas"
   },
-  "mimo-vl-7b-rl-2508": {
-    "LMArena": "MiMo-VL-7B-RL-2508"
+  "vortex": {
+    "LMArena": "vortex"
+  },
+  "tikal": {
+    "LMArena": "tikal"
+  },
+  "bronze": {
+    "LMArena": "bronze"
+  },
+  "march26-chatbot2": {
+    "LMArena": "march26-chatbot2"
+  },
+  "march26-chatbot3": {
+    "LMArena": "march26-chatbot3"
+  },
+  "karyu": {
+    "LMArena": "karyu"
+  },
+  "botbot2": {
+    "LMArena": "botbot2"
+  },
+  "orion": {
+    "LMArena": "orion"
+  },
+  "pisces-0320": {
+    "LMArena": "pisces-0320"
+  },
+  "duomo-1-hero": {
+    "LMArena": "duomo-1-hero"
+  },
+  "anonymous-1218": {
+    "LMArena": "anonymous-1218"
+  },
+  "zeylu-alpha": {
+    "LMArena": "zeylu-alpha"
+  },
+  "zeylu-beta": {
+    "LMArena": "zeylu-beta"
+  },
+  "clawl": {
+    "LMArena": "clawl"
+  },
+  "ernie-exp-251024": {
+    "LMArena": "ernie-exp-251024"
+  },
+  "minicpm-sala": {
+    "LMArena": "minicpm-sala"
+  },
+  "anonymous-1221": {
+    "LMArena": "anonymous-1221"
+  },
+  "u2": {
+    "LMArena": "u2-preview"
+  },
+  "vierra": {
+    "LMArena": "vierra"
+  },
+  "rotten-apple": {
+    "LMArena": "rotten-apple"
+  },
+  "pisces-0309d": {
+    "LMArena": "pisces-0309d"
+  },
+  "stephen": {
+    "LMArena": "stephen-v2"
+  },
+  "yotta-nexus": {
+    "LMArena": "yotta-nexus"
+  },
+  "queen-bee": {
+    "LMArena": "queen-bee"
+  },
+  "eb45-vision": {
+    "LMArena": "EB45-vision"
+  },
+  "pisces-llm-0130": {
+    "LMArena": "pisces-llm-0130"
+  },
+  "february26-chatbot2": {
+    "LMArena": "february26-chatbot2"
+  },
+  "february26-chatbot3": {
+    "LMArena": "february26-chatbot3"
+  },
+  "clinkz": {
+    "LMArena": "clinkz"
+  },
+  "velo": {
+    "LMArena": "velo"
+  },
+  "dola-seed-2.0-preview-text": {
+    "LMArena": "dola-seed-2.0-preview-text"
+  },
+  "kiwi-do": {
+    "LMArena": "kiwi-do"
+  },
+  "eb45-turbo": {
+    "LMArena": "EB45-turbo"
+  },
+  "raptor-1.8-0120": {
+    "LMArena": "raptor-1.8-0120"
+  },
+  "mistral-medium-3.5": {
+    "LMArena": "mistral-medium-3.5",
+    "OllamaSwarm": "mistral-medium-3.5:latest"
+  },
+  "uros": {
+    "LMArena": "uros"
+  },
+  "cosmic-clotho": {
+    "LMArena": "cosmic-clotho"
+  },
+  "muse-spark": {
+    "LMArena": "muse-spark"
+  },
+  "stephen-vision-csfix": {
+    "LMArena": "stephen-vision-csfix"
+  },
+  "raptor-1123": {
+    "LMArena": "raptor-1123"
+  },
+  "raptor-1124": {
+    "LMArena": "raptor-1124"
+  },
+  "step-3-mini-2511": {
+    "LMArena": "step-3-mini-2511"
+  },
+  "mimera": {
+    "LMArena": "mimera"
+  },
+  "ernie-exp-vl-251016": {
+    "LMArena": "ernie-exp-vl-251016"
+  },
+  "happy-friday-testing-2": {
+    "LMArena": "happy-friday-testing-2"
+  },
+  "ling-1t": {
+    "LMArena": "ling-1t"
+  },
+  "sunshine-ai": {
+    "LMArena": "sunshine-ai"
+  },
+  "ernie-exp-251025": {
+    "LMArena": "ernie-exp-251025"
+  },
+  "ernie-exp-251023": {
+    "LMArena": "ernie-exp-251023"
+  },
+  "flying-octopus": {
+    "LMArena": "flying-octopus"
+  },
+  "ernie-exp-251026": {
+    "LMArena": "ernie-exp-251026"
+  },
+  "ernie-exp-251027": {
+    "LMArena": "ernie-exp-251027"
   },
   "ling-1t-1031": {
     "LMArena": "ling-1t-1031"
   },
-  "kimi-k2-thinking-turbo": {
-    "LMArena": "kimi-k2-thinking-turbo"
+  "morian": {
+    "LMArena": "morian"
   },
-  "raptor-1.8-1208": {
-    "LMArena": "raptor-1.8-1208"
+  "april26-chatbot1": {
+    "LMArena": "april26-chatbot1"
   },
-  "raptor-llm-1205": {
-    "LMArena": "raptor-llm-1205"
+  "april26-chatbot2": {
+    "LMArena": "april26-chatbot2"
   },
-  "hunyuan-image-3.0": {
-    "LMArena": "hunyuan-image-3.0"
+  "hofburg.4": {
+    "LMArena": "hofburg_4"
   },
-  "tangerine": {
-    "LMArena": "tangerine"
+  "hofburg.5": {
+    "LMArena": "hofburg_5"
   },
-  "vidu-q2-image": {
-    "LMArena": "vidu-q2-image"
+  "maelox": {
+    "LMArena": "maelox"
   },
-  "mai-image-1": {
-    "LMArena": "mai-image-1"
+  "pteronura": {
+    "LMArena": "pteronura"
   },
-  "imagen-4.0-fast-generate": {
-    "LMArena": "imagen-4.0-fast-generate-001"
+  "solar-eclipse": {
+    "LMArena": "solar-eclipse"
   },
-  "flux-2-pro": {
-    "LMArena": "flux-2-pro-20251231",
-    "ApiAirforce": "flux-2-pro",
-    "Yupp": "fal-ai/flux-2-pro"
+  "apex-atlas": {
+    "LMArena": "apex-atlas"
   },
-  "recraft": {
-    "LMArena": "recraft-v3",
-    "Yupp": "replicate/recraft-ai/recraft-v3"
+  "anonymous-1815": {
+    "LMArena": "anonymous-1815"
   },
-  "flux-2-flex": {
-    "LMArena": "flux-2-flex-20251231",
-    "ApiAirforce": "flux-2-flex",
-    "Yupp": "fal-ai/flux-2-flex"
+  "moryn": {
+    "LMArena": "moryn"
   },
-  "imagen-3.0-generate": {
-    "LMArena": "imagen-3.0-generate-002"
+  "kizen-alpha": {
+    "LMArena": "kizen-alpha"
   },
-  "gemini-3-pro-image-preview-4k (nano-banana-pro)": {
-    "LMArena": "gemini-3-pro-image-preview-4k (nano-banana-pro)"
+  "may26-chatbot4-public": {
+    "LMArena": "may26-chatbot4-public"
   },
-  "photon": {
-    "LMArena": "photon",
-    "Yupp": "replicate/luma/photon"
+  "grok-4.20-beta1": {
+    "LMArena": "grok-4.20-beta1"
   },
-  "imagen-4.0-ultra-generate": {
-    "LMArena": "imagen-4.0-ultra-generate-001",
-    "Yupp": "imagen-4.0-ultra-generate-001"
+  "fiddle": {
+    "LMArena": "fiddle"
+  },
+  "significant-otter": {
+    "LMArena": "significant-otter"
+  },
+  "gpt-5.5-xhigh": {
+    "LMArena": "gpt-5.5-xhigh"
+  },
+  "delphi": {
+    "LMArena": "delphi"
+  },
+  "tetra-0505-1": {
+    "LMArena": "tetra-0505-1"
+  },
+  "tetra-0505-2": {
+    "LMArena": "tetra-0505-2"
+  },
+  "astral-lachesis": {
+    "LMArena": "astral-lachesis"
+  },
+  "steed-0611": {
+    "LMArena": "steed-0611"
+  },
+  "celestial-atropos": {
+    "LMArena": "celestial-atropos"
+  },
+  "mistral-small-2603": {
+    "LMArena": "mistral-small-2603",
+    "PuterJS": "mistralai:mistralai/mistral-small-2603",
+    "OpenRouter": "mistralai/mistral-small-2603",
+    "PollinationsAI": "mistral"
+  },
+  "april26-chatbot3": {
+    "LMArena": "april26-chatbot3"
+  },
+  "ernie-5.0-preview-1220": {
+    "LMArena": "ernie-5.0-preview-1220"
+  },
+  "miyami": {
+    "LMArena": "miyami"
+  },
+  "olympia": {
+    "LMArena": "olympia"
+  },
+  "petra": {
+    "LMArena": "petra"
+  },
+  "momoda-alpha": {
+    "LMArena": "momoda-alpha"
+  },
+  "momoda-beta": {
+    "LMArena": "momoda-beta"
+  },
+  "luxor-alt": {
+    "LMArena": "luxor-alt"
+  },
+  "mymodel-v2-6-4wld": {
+    "LMArena": "mymodel-v2-6-4wld"
+  },
+  "gpt-5.5-high": {
+    "LMArena": "gpt-5.5-high"
+  },
+  "rc3-vscmodeld-s110-sgl": {
+    "LMArena": "rc3-vscmodeld-s110-sgl"
+  },
+  "may26-chatbot4": {
+    "LMArena": "may26-chatbot4"
+  },
+  "gpt-5-high-new-system-prompt": {
+    "LMArena": "gpt-5-high-new-system-prompt"
+  },
+  "chickadee": {
+    "LMArena": "chickadee"
+  },
+  "soren": {
+    "LMArena": "soren"
+  },
+  "deepseek-v4-pro-thinking": {
+    "LMArena": "deepseek-v4-pro-thinking"
+  },
+  "torin": {
+    "LMArena": "torin"
+  },
+  "varga": {
+    "LMArena": "varga"
+  },
+  "coolers": {
+    "LMArena": "coolers"
+  },
+  "cooler": {
+    "LMArena": "cooler"
+  },
+  "blankies": {
+    "LMArena": "blankies"
+  },
+  "qwen-3-vl-8b-thinking": {
+    "LMArena": "qwen3-vl-8b-thinking",
+    "PuterJS": "openrouter:qwen/qwen3-vl-8b-thinking",
+    "HuggingFaceAPI": "Qwen/Qwen3-VL-8B-Thinking",
+    "OpenRouter": "qwen/qwen3-vl-8b-thinking"
+  },
+  "mekai": {
+    "LMArena": "mekai"
+  },
+  "may26-chatbot1": {
+    "LMArena": "may26-chatbot1"
+  },
+  "fusion": {
+    "LMArena": "fusion",
+    "PuterJS": "openrouter:openrouter/fusion",
+    "OpenRouter": "openrouter/fusion"
+  },
+  "claude-fable-5": {
+    "LMArena": "claude-fable-5",
+    "PuterJS": "anthropic:anthropic/claude-fable-5",
+    "OpenRouter": "anthropic/claude-fable-5"
+  },
+  "tetra-0507-1": {
+    "LMArena": "tetra-0507-1"
+  },
+  "steed-0507": {
+    "LMArena": "steed-0507"
+  },
+  "tetra-0507-4": {
+    "LMArena": "tetra-0507-4"
+  },
+  "tetra-0507-2": {
+    "LMArena": "tetra-0507-2"
+  },
+  "tetra-0507-5": {
+    "LMArena": "tetra-0507-5"
+  },
+  "tetra-0507-3": {
+    "LMArena": "tetra-0507-3"
+  },
+  "artemis.3": {
+    "LMArena": "artemis_3"
+  },
+  "artemis.4": {
+    "LMArena": "artemis_4"
+  },
+  "dark-matter": {
+    "LMArena": "dark-matter"
+  },
+  "mylen": {
+    "LMArena": "mylen"
+  },
+  "grok-4.3-high": {
+    "LMArena": "grok-4.3-high"
+  },
+  "claude-opus-4-8-thinking": {
+    "LMArena": "claude-opus-4-8-thinking"
+  },
+  "gemini-3-flash (thinking-minimal)": {
+    "LMArena": "gemini-3-flash (thinking-minimal)"
+  },
+  "maelis": {
+    "LMArena": "maelis"
+  },
+  "qwen-vl-max": {
+    "LMArena": "qwen-vl-max-2025-08-13",
+    "PuterJS": "openrouter:qwen/qwen-vl-max"
+  },
+  "may26-chatbot2": {
+    "LMArena": "may26-chatbot2"
+  },
+  "qwen-3-vl-8b": {
+    "LMArena": "qwen3-vl-8b-instruct",
+    "PuterJS": "openrouter:qwen/qwen3-vl-8b-instruct",
+    "ApiAirforce": "qwen3-vl-8b",
+    "HuggingChat": "Qwen/Qwen3-VL-8B-Instruct",
+    "HuggingFaceAPI": "Qwen/Qwen3-VL-8B-Instruct",
+    "OpenRouter": "qwen/qwen3-vl-8b-instruct"
+  },
+  "gpt-5.5-dlp-test": {
+    "LMArena": "gpt-5.5-dlp-test"
+  },
+  "grok-4.3": {
+    "LMArena": "grok-4.3",
+    "PuterJS": "azure:x-ai/grok-4.3",
+    "ApiAirforce": "grok-4.3",
+    "OpenRouter": "x-ai/grok-4.3",
+    "PollinationsAI": "grok-large"
+  },
+  "may-alpha": {
+    "LMArena": "may-alpha"
+  },
+  "deepseek-v4-flash-dlp-test": {
+    "LMArena": "deepseek-v4-flash-dlp-test"
+  },
+  "glassy.lagoon": {
+    "LMArena": "glassy_lagoon"
+  },
+  "emerald.lagoon": {
+    "LMArena": "emerald_lagoon"
+  },
+  "gpt-5.5": {
+    "LMArena": "gpt-5.5",
+    "PuterJS": "openai:openai/gpt-5.5",
+    "ApiAirforce": "gpt-5.5",
+    "OpenRouter": "openai/gpt-5.5",
+    "PollinationsAI": "openai-large"
+  },
+  "luna-hope": {
+    "LMArena": "luna-hope"
+  },
+  "mira-sky": {
+    "LMArena": "mira-sky"
+  },
+  "claude-opus-4-8": {
+    "LMArena": "claude-opus-4-8",
+    "PuterJS": "anthropic:anthropic/claude-opus-4-8"
+  },
+  "amazon.nova-pro": {
+    "LMArena": "amazon.nova-pro-v1:0"
+  },
+  "deepseek-v4-flash-thinking": {
+    "LMArena": "deepseek-v4-flash-thinking"
+  },
+  "melyora": {
+    "LMArena": "melyora"
+  },
+  "glm-5v-turbo": {
+    "LMArena": "glm-5v-turbo",
+    "PuterJS": "z-ai:z-ai/glm-5v-turbo",
+    "OpenRouter": "z-ai/glm-5v-turbo"
+  },
+  "gemini-3.1-flash-image-preview (nano-banana-2) [web-search]": {
+    "LMArena": "gemini-3.1-flash-image-preview (nano-banana-2) [web-search]"
+  },
+  "gpt-image-1.5-high-fidelity": {
+    "LMArena": "gpt-image-1.5-high-fidelity"
   },
   "gemini-3-pro-image-preview-2k (nano-banana-pro)": {
     "LMArena": "gemini-3-pro-image-preview-2k (nano-banana-pro)"
   },
+  "nonnas-meatballs-open-weight": {
+    "LMArena": "nonnas-meatballs-open-weight"
+  },
+  "recraft-v4.1-utility-pro": {
+    "LMArena": "recraft-v4.1-utility-pro"
+  },
+  "flux-2-pro": {
+    "LMArena": "flux-2-pro"
+  },
+  "left-bank": {
+    "LMArena": "left-bank"
+  },
   "flux-2-dev": {
-    "LMArena": "flux-2-dev-20251222"
-  },
-  "imagen-4.0-generate": {
-    "LMArena": "imagen-4.0-generate-001",
-    "Yupp": "imagen-4.0-generate-001"
-  },
-  "flux-2-max": {
-    "LMArena": "flux-2-max-20251222"
-  },
-  "gpt-image-1-high-fidelity": {
-    "LMArena": "gpt-image-1-high-fidelity"
-  },
-  "qwen-image-prompt-extend": {
-    "LMArena": "qwen-image-prompt-extend"
-  },
-  "flux-1-kontext-max": {
-    "LMArena": "flux-1-kontext-max"
-  },
-  "qwen-image-edit": {
-    "LMArena": "qwen-image-edit"
-  },
-  "hazel-gen-2": {
-    "LMArena": "hazel-gen-2"
-  },
-  "seededit-3.0": {
-    "LMArena": "seededit-3.0"
-  },
-  "ideogram-v3-quality": {
-    "LMArena": "ideogram-v3-quality",
-    "Yupp": "replicate/ideogram-ai/ideogram-v3-quality"
-  },
-  "hunyuan-image-2.1": {
-    "LMArena": "hunyuan-image-2.1"
-  },
-  "hazel-gen-4": {
-    "LMArena": "hazel-gen-4"
-  },
-  "wan2.5-t2i": {
-    "LMArena": "wan2.5-t2i-preview"
-  },
-  "hidream-e1.1": {
-    "LMArena": "hidream-e1.1"
-  },
-  "reve-v1.1": {
-    "LMArena": "reve-v1.1"
-  },
-  "chatgpt-image (20251216)": {
-    "LMArena": "chatgpt-image-latest (20251216)"
+    "LMArena": "flux-2-dev"
   },
   "seedream-4.5": {
-    "LMArena": "seedream-4.5",
-    "ApiAirforce": "seedream-4.5"
+    "LMArena": "seedream-4.5"
   },
-  "hunyuan-image-3.0-fal": {
-    "LMArena": "hunyuan-image-3.0-fal"
+  "seedream-5.0-lite": {
+    "LMArena": "seedream-5.0-lite"
   },
-  "gpt-image-1-mini": {
-    "LMArena": "gpt-image-1-mini",
-    "Yupp": "gpt-image-1-mini"
+  "recraft-v4.1-pro": {
+    "LMArena": "recraft-v4.1-pro"
   },
-  "qwen-image-edit-2511": {
-    "LMArena": "qwen-image-edit-2511"
+  "imagen-4.0-generate": {
+    "LMArena": "imagen-4.0-generate-001"
   },
-  "reve-v1.1-fast": {
-    "LMArena": "reve-v1.1-fast"
+  "qwen-image-2512": {
+    "LMArena": "qwen-image-2512",
+    "HuggingFaceMedia": "Qwen/Qwen-Image-2512:fal-ai"
   },
-  "gpt-image-1": {
-    "LMArena": "gpt-image-1",
-    "Yupp": "gpt-image-1"
+  "hidream-o1-image": {
+    "LMArena": "hidream-o1-image"
   },
-  "gemini-2.0-flash-preview-image-generation": {
-    "LMArena": "gemini-2.0-flash-preview-image-generation",
-    "Yupp": "gemini-2.0-flash-preview-image-generation"
-  },
-  "gemini-2.5-flash-image-preview (nano-banana)": {
-    "LMArena": "gemini-2.5-flash-image-preview (nano-banana)"
-  },
-  "seedream-3": {
-    "LMArena": "seedream-3",
-    "Yupp": "bytedance/seedream-3"
-  },
-  "seedream-4-high-res-fal": {
-    "LMArena": "seedream-4-high-res-fal"
+  "krea-2-medium": {
+    "LMArena": "krea-2-medium"
   },
   "wan2.5": {
     "LMArena": "wan2.5-preview"
   },
+  "wan2.5-t2i": {
+    "LMArena": "wan2.5-t2i-preview"
+  },
+  "gpt-image-1-high-fidelity": {
+    "LMArena": "gpt-image-1-high-fidelity"
+  },
+  "gpt-image-1": {
+    "LMArena": "gpt-image-1"
+  },
+  "recraft": {
+    "LMArena": "recraft-v3"
+  },
+  "wan2.7-image-pro": {
+    "LMArena": "wan2.7-image-pro"
+  },
+  "krea-2-large": {
+    "LMArena": "krea-2-large"
+  },
+  "wan2.7-image": {
+    "LMArena": "wan2.7-image"
+  },
+  "seedream-3": {
+    "LMArena": "seedream-3"
+  },
+  "z-image": {
+    "LMArena": "z-image",
+    "HuggingFaceMedia": "Tongyi-MAI/Z-Image:fal-ai"
+  },
+  "flux-1-kontext-max": {
+    "LMArena": "flux-1-kontext-max"
+  },
+  "cosmos3-super": {
+    "LMArena": "cosmos3-super"
+  },
   "flux-1-kontext-pro": {
     "LMArena": "flux-1-kontext-pro"
   },
-  "wan2.5-i2i": {
-    "LMArena": "wan2.5-i2i-preview"
+  "imagen-3.0-generate": {
+    "LMArena": "imagen-3.0-generate-002"
   },
-  "flux-1-kontext-dev": {
-    "LMArena": "flux-1-kontext-dev"
+  "cosmos3-super-agentic": {
+    "LMArena": "cosmos3-super-agentic"
+  },
+  "ideogram-v3-quality": {
+    "LMArena": "ideogram-v3-quality"
+  },
+  "photon": {
+    "LMArena": "photon"
   },
   "lucid-origin": {
     "LMArena": "lucid-origin"
   },
-  "gemini-3-pro-image-preview (nano-banana-pro)": {
-    "LMArena": "gemini-3-pro-image-preview (nano-banana-pro)"
+  "flux-1-kontext-dev": {
+    "LMArena": "flux-1-kontext-dev"
+  },
+  "harbor": {
+    "LMArena": "harbor"
+  },
+  "gpt-image-2 (medium)": {
+    "LMArena": "gpt-image-2 (medium)"
+  },
+  "thunder": {
+    "LMArena": "thunder"
+  },
+  "flow-state": {
+    "LMArena": "flow-state"
+  },
+  "citrus": {
+    "LMArena": "citrus"
+  },
+  "habanero": {
+    "LMArena": "habanero"
+  },
+  "spinosaurus": {
+    "LMArena": "spinosaurus"
+  },
+  "flow-state-2": {
+    "LMArena": "flow-state-2"
+  },
+  "kelly": {
+    "LMArena": "kelly"
+  },
+  "flow-state-3": {
+    "LMArena": "flow-state-3"
+  },
+  "hidream-o1-image-1.5": {
+    "LMArena": "hidream-o1-image-1.5"
+  },
+  "nonnos-meatballs-open-weight": {
+    "LMArena": "nonnos-meatballs-open-weight"
+  },
+  "greenbean": {
+    "LMArena": "greenbean"
+  },
+  "waffle": {
+    "LMArena": "waffle"
+  },
+  "flashfennel": {
+    "LMArena": "flashfennel"
+  },
+  "itadori-sv1": {
+    "LMArena": "itadori-sv1"
+  },
+  "pebble-1": {
+    "LMArena": "pebble-1"
+  },
+  "phantom.brush": {
+    "LMArena": "phantom_brush"
+  },
+  "pebble-2": {
+    "LMArena": "pebble-2"
+  },
+  "zen-bear": {
+    "LMArena": "zen-bear-v4"
+  },
+  "auto-bear": {
+    "LMArena": "auto-bear-v2"
+  },
+  "hidream-e1.1": {
+    "LMArena": "hidream-e1.1"
+  },
+  "gcps-fast": {
+    "LMArena": "gcps-fast"
+  },
+  "qwen-image-2.0": {
+    "LMArena": "qwen-image-2.0"
+  },
+  "qwen-image-2.0-pro": {
+    "LMArena": "qwen-image-2.0-pro"
+  },
+  "flashbrown-a": {
+    "LMArena": "flashbrown-a"
+  },
+  "hunyuan-image-3.0-fal": {
+    "LMArena": "hunyuan-image-3.0-fal"
+  },
+  "uni-1.1-max": {
+    "LMArena": "uni-1.1-max"
+  },
+  "uni-1.1": {
+    "LMArena": "uni-1.1"
+  },
+  "soft-shell": {
+    "LMArena": "soft-shell"
+  },
+  "flashbrown-b": {
+    "LMArena": "flashbrown-b"
+  },
+  "instant-ramen": {
+    "LMArena": "instant-ramen"
+  },
+  "text-to-image-autoeval-test": {
+    "LMArena": "text-to-image-autoeval-test"
+  },
+  "chives": {
+    "LMArena": "chives"
+  },
+  "fennel": {
+    "LMArena": "fennel"
+  },
+  "super-cara": {
+    "LMArena": "super-cara"
+  },
+  "frenchfry": {
+    "LMArena": "frenchfry"
+  },
+  "sungod": {
+    "LMArena": "sungod"
+  },
+  "super-gcp": {
+    "LMArena": "super-gcp"
+  },
+  "shakshouka": {
+    "LMArena": "shakshouka"
+  },
+  "ellsworth": {
+    "LMArena": "ellsworth"
+  },
+  "parasaurolophus": {
+    "LMArena": "parasaurolophus"
+  },
+  "spectral.ink": {
+    "LMArena": "spectral_ink"
+  },
+  "babylon": {
+    "LMArena": "babylon"
+  },
+  "seededit-3.0": {
+    "LMArena": "seededit-3.0"
+  },
+  "dialogue": {
+    "LMArena": "dialogue"
+  },
+  "altair": {
+    "LMArena": "altair"
+  },
+  "king-crab": {
+    "LMArena": "king-crab"
+  },
+  "paper-lantern": {
+    "LMArena": "paper-lantern"
+  },
+  "crepe": {
+    "LMArena": "crepe"
+  },
+  "blue-crab": {
+    "LMArena": "blue-crab"
+  },
+  "fennelbaby": {
+    "LMArena": "fennelbaby"
+  },
+  "caudipteryx": {
+    "LMArena": "caudipteryx"
+  },
+  "reve-v1.1-fast": {
+    "LMArena": "reve-v1.1-fast"
+  },
+  "mussaurus": {
+    "LMArena": "mussaurus"
+  },
+  "tyrannosaurus": {
+    "LMArena": "tyrannosaurus"
+  },
+  "jalapeno": {
+    "LMArena": "jalapeno"
+  },
+  "avalon": {
+    "LMArena": "avalon"
+  },
+  "hotate": {
+    "LMArena": "hotate"
+  },
+  "gemini-2.5-flash-image-preview (nano-banana)": {
+    "LMArena": "gemini-2.5-flash-image-preview (nano-banana)"
+  },
+  "archaeopteryx": {
+    "LMArena": "archaeopteryx"
+  },
+  "snow-crab": {
+    "LMArena": "snow-crab"
+  },
+  "grok-imagine-image-quality": {
+    "LMArena": "grok-imagine-image-quality"
+  },
+  "hunyuan-image-2.1": {
+    "LMArena": "hunyuan-image-2.1"
+  },
+  "red-rock": {
+    "LMArena": "red-rock"
+  },
+  "grok-imagine-image": {
+    "LMArena": "grok-imagine-image",
+    "ApiAirforce": "grok-imagine-image"
+  },
+  "dimetrodon": {
+    "LMArena": "dimetrodon"
+  },
+  "phantom.quill": {
+    "LMArena": "phantom_quill"
+  },
+  "qwen-image-edit": {
+    "LMArena": "qwen-image-edit"
+  },
+  "wan2.5-i2i": {
+    "LMArena": "wan2.5-i2i-preview"
+  },
+  "imagen-4.0-ultra-generate": {
+    "LMArena": "imagen-4.0-ultra-generate-001"
+  },
+  "mondrian": {
+    "LMArena": "mondrian"
+  },
+  "wan2.6-t2i": {
+    "LMArena": "wan2.6-t2i"
+  },
+  "imagen-4.0-fast-generate": {
+    "LMArena": "imagen-4.0-fast-generate-001"
+  },
+  "qwen-image-edit-2511": {
+    "LMArena": "qwen-image-edit-2511"
+  },
+  "chatgpt-image-high-fidelity (20251216)": {
+    "LMArena": "chatgpt-image-latest-high-fidelity (20251216)"
+  },
+  "wan2.6-image": {
+    "LMArena": "wan2.6-image"
+  },
+  "qvq-max": {
+    "PuterJS": "alibaba:qwen/qvq-max"
+  },
+  "qwen-flash": {
+    "PuterJS": "alibaba:qwen/qwen-flash"
+  },
+  "qwen-max": {
+    "PuterJS": "openrouter:qwen/qwen-max",
+    "ApiAirforce": "qwen-max"
+  },
+  "qwen-mt-plus": {
+    "PuterJS": "alibaba:qwen/qwen-mt-plus"
+  },
+  "qwen-mt-turbo": {
+    "PuterJS": "alibaba:qwen/qwen-mt-turbo"
+  },
+  "qwen-omni-turbo": {
+    "PuterJS": "alibaba:qwen/qwen-omni-turbo"
+  },
+  "qwen-turbo": {
+    "PuterJS": "openrouter:qwen/qwen-turbo",
+    "ApiAirforce": "qwen-turbo"
+  },
+  "qwen-vl-ocr": {
+    "PuterJS": "alibaba:qwen/qwen-vl-ocr"
+  },
+  "qwen-vl-plus": {
+    "PuterJS": "openrouter:qwen/qwen-vl-plus"
+  },
+  "qwen-2-5-14b": {
+    "PuterJS": "alibaba:qwen/qwen2-5-14b-instruct"
+  },
+  "qwen-2-5-32b": {
+    "PuterJS": "alibaba:qwen/qwen2-5-32b-instruct"
+  },
+  "qwen-2-5-72b": {
+    "PuterJS": "alibaba:qwen/qwen2-5-72b-instruct"
+  },
+  "qwen-2-5-7b": {
+    "PuterJS": "alibaba:qwen/qwen2-5-7b-instruct"
+  },
+  "qwen-2-5-omni-7b": {
+    "PuterJS": "alibaba:qwen/qwen2-5-omni-7b"
+  },
+  "qwen-2-5-vl-72b": {
+    "PuterJS": "alibaba:qwen/qwen2-5-vl-72b-instruct"
+  },
+  "qwen-2-5-vl-7b": {
+    "PuterJS": "alibaba:qwen/qwen2-5-vl-7b-instruct"
+  },
+  "qwen-3-14b": {
+    "PuterJS": [
+      "openrouter:qwen/qwen3-14b:free",
+      "openrouter:qwen/qwen3-14b"
+    ],
+    "ApiAirforce": "qwen3-14b",
+    "HuggingChat": "Qwen/Qwen3-14B",
+    "HuggingFaceAPI": "Qwen/Qwen3-14B",
+    "OpenRouter": "qwen/qwen3-14b"
+  },
+  "qwen-3-coder-flash": {
+    "PuterJS": "alibaba:qwen/qwen3-coder-flash",
+    "OpenRouter": "qwen/qwen3-coder-flash"
+  },
+  "qwen-3-vl-30b-a3b": {
+    "PuterJS": "openrouter:qwen/qwen3-vl-30b-a3b-instruct",
+    "ApiAirforce": "qwen3-vl-30b-a3b",
+    "HuggingChat": "Qwen/Qwen3-VL-30B-A3B-Instruct",
+    "HuggingFaceAPI": "Qwen/Qwen3-VL-30B-A3B-Instruct",
+    "OpenRouter": "qwen/qwen3-vl-30b-a3b-instruct"
+  },
+  "qwq-plus": {
+    "PuterJS": "alibaba:qwen/qwq-plus"
+  },
+  "claude-3-5-sonnet": {
+    "PuterJS": "anthropic:anthropic/claude-3-5-sonnet-20240620",
+    "Anthropic": "claude-3-5-sonnet-latest"
+  },
+  "claude-3-7-sonnet": {
+    "PuterJS": "anthropic:anthropic/claude-3-7-sonnet",
+    "Anthropic": "claude-3-7-sonnet-20250219"
   },
   "claude-3-haiku": {
     "PuterJS": [
@@ -2549,76 +3042,839 @@ model_map = {
       "openrouter:anthropic/claude-3-haiku"
     ],
     "Anthropic": "claude-3-haiku-20240307",
-    "OpenRouter": "anthropic/claude-3-haiku",
-    "Yupp": "claude-3-haiku-20240307"
+    "OpenRouter": "anthropic/claude-3-haiku"
   },
-  "codestral-2508": {
-    "PuterJS": "openrouter:mistralai/codestral-2508",
-    "OpenRouter": "mistralai/codestral-2508",
-    "Yupp": "codestral-2508"
-  },
-  "deepseek-chat": {
-    "PuterJS": [
-      "deepseek-chat",
-      "openrouter:deepseek/deepseek-chat:free",
-      "openrouter:deepseek/deepseek-chat"
-    ],
-    "OpenRouter": "deepseek/deepseek-chat",
-    "Yupp": "deepseek/deepseek-chat"
-  },
-  "deepseek-reasoner": {
-    "PuterJS": "deepseek-reasoner"
-  },
-  "devstral-medium-2507": {
-    "PuterJS": "devstral-medium-2507",
-    "Yupp": "devstral-medium-2507"
-  },
-  "gemini-2.0-flash-lite": {
-    "PuterJS": "openrouter:google/gemini-2.0-flash-lite-001",
-    "OpenRouter": "google/gemini-2.0-flash-lite-001",
-    "Yupp": "gemini-2.0-flash-lite-001"
+  "gpt-5-codex": {
+    "PuterJS": "azure:openai/gpt-5-codex",
+    "ApiAirforce": "gpt-5-codex",
+    "OpenRouter": "openai/gpt-5-codex"
   },
   "gpt-5-mini": {
-    "PuterJS": "openrouter:openai/gpt-5-mini",
-    "GithubCopilot": "gpt-5-mini",
+    "PuterJS": "openai:openai/gpt-5-mini",
     "OpenRouter": "openai/gpt-5-mini",
-    "Yupp": "gpt-5-mini-2025-08-07"
+    "PollinationsAI": "gpt-5.4-mini"
   },
-  "gpt-5.1-chat": {
-    "PuterJS": "openrouter:openai/gpt-5.1-chat",
-    "OpenRouter": "openai/gpt-5.1-chat",
-    "Yupp": "gpt-5.1-chat-latest"
+  "gpt-5-nano": {
+    "PuterJS": "openai:openai/gpt-5-nano",
+    "ApiAirforce": "gpt-5-nano",
+    "OpenRouter": "openai/gpt-5-nano",
+    "PollinationsAI": "openai-fast"
   },
   "gpt-5.1-codex": {
-    "PuterJS": "openrouter:openai/gpt-5.1-codex",
+    "PuterJS": "azure:openai/gpt-5.1-codex",
     "OpenRouter": "openai/gpt-5.1-codex"
+  },
+  "gpt-5.1-codex-mini": {
+    "PuterJS": "azure:openai/gpt-5.1-codex-mini",
+    "ApiAirforce": "gpt-5.1-codex-mini",
+    "OpenRouter": "openai/gpt-5.1-codex-mini"
+  },
+  "gpt-5.2-codex": {
+    "PuterJS": "azure:openai/gpt-5.2-codex",
+    "ApiAirforce": "gpt-5.2-codex",
+    "OpenRouter": "openai/gpt-5.2-codex"
+  },
+  "gpt-5.3-codex": {
+    "PuterJS": "azure:openai/gpt-5.3-codex",
+    "ApiAirforce": "gpt-5.3-codex",
+    "OpenRouter": "openai/gpt-5.3-codex"
+  },
+  "gpt-5.4-nano": {
+    "PuterJS": "azure:openai/gpt-5.4-nano",
+    "ApiAirforce": "gpt-5.4-nano",
+    "OpenRouter": "openai/gpt-5.4-nano",
+    "PollinationsAI": "openai"
+  },
+  "grok-4-1-fast-non-reasoning": {
+    "PuterJS": "azure:x-ai/grok-4-1-fast-non-reasoning",
+    "PollinationsAI": "grok"
+  },
+  "grok-4-1-fast-reasoning": {
+    "PuterJS": "azure:x-ai/grok-4-1-fast-reasoning",
+    "PollinationsAI": "grok-4-20-reasoning"
+  },
+  "grok-4-20-non-reasoning": {
+    "PuterJS": "x-ai:x-ai/grok-4-20-non-reasoning",
+    "PollinationsAI": "grok"
+  },
+  "gemini-2.0-flash-lite": {
+    "PuterJS": "google:google/gemini-2.0-flash-lite"
+  },
+  "gemini-2.5-flash-lite": {
+    "PuterJS": "openrouter:google/gemini-2.5-flash-lite",
+    "Antigravity": "gemini-2.5-flash-lite",
+    "OpenRouter": "google/gemini-2.5-flash-lite",
+    "PollinationsAI": "gemini-fast"
+  },
+  "minimax-m2.1-highspeed": {
+    "PuterJS": "minimax:minimax/minimax-m2.1-highspeed"
+  },
+  "minimax-m2.5-highspeed": {
+    "PuterJS": "minimax:minimax/minimax-m2.5-highspeed"
+  },
+  "minimax-m2.7-highspeed": {
+    "PuterJS": "minimax:minimax/minimax-m2.7-highspeed",
+    "MiniMax": "MiniMax-M2.7-highspeed"
+  },
+  "codestral-2508": {
+    "PuterJS": "mistralai:mistralai/codestral-2508",
+    "OpenRouter": "mistralai/codestral-2508"
+  },
+  "devstral-2512": {
+    "PuterJS": "mistralai:mistralai/devstral-2512",
+    "OpenRouter": "mistralai/devstral-2512"
+  },
+  "magistral-medium-2509": {
+    "PuterJS": "mistralai:mistralai/magistral-medium-2509"
+  },
+  "magistral-small-2509": {
+    "PuterJS": "mistralai:mistralai/magistral-small-2509"
+  },
+  "ministral-14b-2512": {
+    "PuterJS": "mistralai:mistralai/ministral-14b-2512",
+    "OpenRouter": "mistralai/ministral-14b-2512"
+  },
+  "ministral-3b-2512": {
+    "PuterJS": "mistralai:mistralai/ministral-3b-2512",
+    "OpenRouter": "mistralai/ministral-3b-2512"
+  },
+  "ministral-8b-2512": {
+    "PuterJS": "mistralai:mistralai/ministral-8b-2512",
+    "OpenRouter": "mistralai/ministral-8b-2512"
+  },
+  "mistral-large-2512": {
+    "PuterJS": "mistralai:mistralai/mistral-large-2512",
+    "OpenRouter": "mistralai/mistral-large-2512"
+  },
+  "mistral-medium-3-5": {
+    "PuterJS": "mistralai:mistralai/mistral-medium-3-5",
+    "OpenRouter": "mistralai/mistral-medium-3-5"
+  },
+  "open-mistral-nemo-2407": {
+    "PuterJS": "mistralai:mistralai/open-mistral-nemo-2407"
+  },
+  "voxtral-small-2507": {
+    "PuterJS": "mistralai:mistralai/voxtral-small-2507"
+  },
+  "moonshot-v1-128k": {
+    "PuterJS": "moonshotai:moonshotai/moonshot-v1-128k",
+    "ApiAirforce": "moonshot-v1-128k"
+  },
+  "moonshot-v1-128k-vision": {
+    "PuterJS": "moonshotai:moonshotai/moonshot-v1-128k-vision-preview",
+    "ApiAirforce": "moonshot-v1-128k-vision"
+  },
+  "moonshot-v1-32k": {
+    "PuterJS": "moonshotai:moonshotai/moonshot-v1-32k",
+    "ApiAirforce": "moonshot-v1-32k"
+  },
+  "moonshot-v1-32k-vision": {
+    "PuterJS": "moonshotai:moonshotai/moonshot-v1-32k-vision-preview",
+    "ApiAirforce": "moonshot-v1-32k-vision"
+  },
+  "moonshot-v1-8k": {
+    "PuterJS": "moonshotai:moonshotai/moonshot-v1-8k",
+    "ApiAirforce": "moonshot-v1-8k"
+  },
+  "moonshot-v1-8k-vision": {
+    "PuterJS": "moonshotai:moonshotai/moonshot-v1-8k-vision-preview",
+    "ApiAirforce": "moonshot-v1-8k-vision"
+  },
+  "moonshot-v1-auto": {
+    "PuterJS": "moonshotai:moonshotai/moonshot-v1-auto"
+  },
+  "gpt-5.1-chat": {
+    "PuterJS": "openai:openai/gpt-5.1-chat",
+    "ApiAirforce": "gpt-5.1-chat",
+    "OpenRouter": "openai/gpt-5.1-chat"
+  },
+  "gpt-5.2-pro": {
+    "PuterJS": "openai:openai/gpt-5.2-pro",
+    "OpenRouter": "openai/gpt-5.2-pro"
+  },
+  "gpt-5.4-pro": {
+    "PuterJS": "openai:openai/gpt-5.4-pro",
+    "ApiAirforce": "gpt-5.4-pro",
+    "OpenRouter": "openai/gpt-5.4-pro"
+  },
+  "gpt-5.5-pro": {
+    "PuterJS": "openai:openai/gpt-5.5-pro",
+    "OpenRouter": "openai/gpt-5.5-pro"
+  },
+  "o1-pro": {
+    "PuterJS": "openai:openai/o1-pro",
+    "OpenRouter": "openai/o1-pro"
+  },
+  "o3-pro": {
+    "PuterJS": "openai:openai/o3-pro",
+    "OpenRouter": "openai/o3-pro"
+  },
+  "jamba-large-1.7": {
+    "PuterJS": "openrouter:ai21/jamba-large-1.7",
+    "OpenRouter": "ai21/jamba-large-1.7"
+  },
+  "aion-1.0": {
+    "PuterJS": "openrouter:aion-labs/aion-1.0",
+    "OpenRouter": "aion-labs/aion-1.0"
+  },
+  "aion-1.0-mini": {
+    "PuterJS": "openrouter:aion-labs/aion-1.0-mini",
+    "OpenRouter": "aion-labs/aion-1.0-mini"
+  },
+  "aion-2.0": {
+    "PuterJS": "openrouter:aion-labs/aion-2.0",
+    "OpenRouter": "aion-labs/aion-2.0"
+  },
+  "aion-rp-llama-3.1-8b": {
+    "PuterJS": "openrouter:aion-labs/aion-rp-llama-3.1-8b",
+    "OpenRouter": "aion-labs/aion-rp-llama-3.1-8b"
+  },
+  "olmo-3-32b-think": {
+    "PuterJS": "openrouter:allenai/olmo-3-32b-think",
+    "OpenRouter": "allenai/olmo-3-32b-think"
+  },
+  "nova-lite": {
+    "PuterJS": "openrouter:amazon/nova-lite-v1",
+    "OpenRouter": "amazon/nova-lite-v1"
+  },
+  "nova-micro": {
+    "PuterJS": "openrouter:amazon/nova-micro-v1",
+    "OpenRouter": "amazon/nova-micro-v1",
+    "PollinationsAI": "nova-fast"
+  },
+  "nova-premier": {
+    "PuterJS": "openrouter:amazon/nova-premier-v1",
+    "OpenRouter": "amazon/nova-premier-v1"
+  },
+  "nova-pro": {
+    "PuterJS": "openrouter:amazon/nova-pro-v1",
+    "OpenRouter": "amazon/nova-pro-v1"
+  },
+  "magnum-v4-72b": {
+    "PuterJS": "openrouter:anthracite-org/magnum-v4-72b",
+    "OpenRouter": "anthracite-org/magnum-v4-72b"
+  },
+  "claude-opus-4.1": {
+    "PuterJS": "openrouter:anthropic/claude-opus-4.1",
+    "OpenRouter": "anthropic/claude-opus-4.1"
+  },
+  "claude-opus-4.6-fast": {
+    "PuterJS": "openrouter:anthropic/claude-opus-4.6-fast",
+    "OpenRouter": "anthropic/claude-opus-4.6-fast"
+  },
+  "claude-opus-4.7-fast": {
+    "PuterJS": "openrouter:anthropic/claude-opus-4.7-fast",
+    "OpenRouter": "anthropic/claude-opus-4.7-fast"
+  },
+  "claude-opus-4.8-fast": {
+    "PuterJS": "openrouter:anthropic/claude-opus-4.8-fast",
+    "OpenRouter": "anthropic/claude-opus-4.8-fast"
+  },
+  "coder-large": {
+    "PuterJS": "openrouter:arcee-ai/coder-large",
+    "OpenRouter": "arcee-ai/coder-large"
+  },
+  "trinity-mini": {
+    "PuterJS": "openrouter:arcee-ai/trinity-mini",
+    "OpenRouter": "arcee-ai/trinity-mini"
+  },
+  "virtuoso-large": {
+    "PuterJS": "openrouter:arcee-ai/virtuoso-large",
+    "OpenRouter": "arcee-ai/virtuoso-large"
+  },
+  "ernie-4.5-vl-424b-a47b": {
+    "PuterJS": "openrouter:baidu/ernie-4.5-vl-424b-a47b",
+    "OpenRouter": "baidu/ernie-4.5-vl-424b-a47b"
+  },
+  "seed-1.6": {
+    "PuterJS": "openrouter:bytedance-seed/seed-1.6",
+    "OpenRouter": "bytedance-seed/seed-1.6"
+  },
+  "seed-1.6-flash": {
+    "PuterJS": "openrouter:bytedance-seed/seed-1.6-flash",
+    "OpenRouter": "bytedance-seed/seed-1.6-flash"
+  },
+  "seed-2.0-lite": {
+    "PuterJS": "openrouter:bytedance-seed/seed-2.0-lite",
+    "OpenRouter": "bytedance-seed/seed-2.0-lite"
+  },
+  "seed-2.0-mini": {
+    "PuterJS": "openrouter:bytedance-seed/seed-2.0-mini",
+    "OpenRouter": "bytedance-seed/seed-2.0-mini"
+  },
+  "ui-tars-1.5-7b": {
+    "PuterJS": "openrouter:bytedance/ui-tars-1.5-7b",
+    "HuggingFaceAPI": "ByteDance-Seed/UI-TARS-1.5-7B",
+    "OpenRouter": "bytedance/ui-tars-1.5-7b"
+  },
+  "dolphin-mistral-24b-venice-edition": {
+    "PuterJS": "openrouter:cognitivecomputations/dolphin-mistral-24b-venice-edition:free",
+    "HuggingFaceAPI": "dphn/Dolphin-Mistral-24B-Venice-Edition",
+    "OpenRouter": "cognitivecomputations/dolphin-mistral-24b-venice-edition:free"
+  },
+  "command-r24": {
+    "PuterJS": "openrouter:cohere/command-r-08-2024",
+    "HuggingSpace": "command-r-08-2024",
+    "CohereForAI_C4AI_Command": "command-r-08-2024",
+    "HuggingChat": "CohereLabs/c4ai-command-r-08-2024",
+    "OpenRouter": "cohere/command-r-08-2024"
+  },
+  "command-r7b24": {
+    "PuterJS": "openrouter:cohere/command-r7b-12-2024",
+    "HuggingSpace": "command-r7b-12-2024",
+    "CohereForAI_C4AI_Command": "command-r7b-12-2024",
+    "HuggingChat": "CohereLabs/c4ai-command-r7b-12-2024",
+    "HuggingFaceAPI": "CohereLabs/c4ai-command-r7b-12-2024",
+    "OpenRouter": "cohere/command-r7b-12-2024"
+  },
+  "north-mini-code": {
+    "PuterJS": "openrouter:cohere/north-mini-code:free",
+    "OpenRouter": "cohere/north-mini-code:free"
+  },
+  "cogito-v2.1-671b": {
+    "PuterJS": "openrouter:deepcogito/cogito-v2.1-671b",
+    "OpenRouter": "deepcogito/cogito-v2.1-671b"
+  },
+  "deepseek-chat-v3-0324": {
+    "PuterJS": "openrouter:deepseek/deepseek-chat-v3-0324",
+    "OpenRouter": "deepseek/deepseek-chat-v3-0324"
+  },
+  "deepseek-chat-v3.1": {
+    "PuterJS": "openrouter:deepseek/deepseek-chat-v3.1",
+    "OpenRouter": "deepseek/deepseek-chat-v3.1"
+  },
+  "deepseek-r1-0528": {
+    "PuterJS": "openrouter:deepseek/deepseek-r1-0528",
+    "HuggingChat": "deepseek-ai/DeepSeek-R1-0528",
+    "OpenRouter": "deepseek/deepseek-r1-0528"
+  },
+  "deepseek-v3.1-terminus": {
+    "PuterJS": "openrouter:deepseek/deepseek-v3.1-terminus",
+    "ApiAirforce": "deepseek-v3.1-terminus",
+    "HuggingChat": "deepseek-ai/DeepSeek-V3.1-Terminus",
+    "OpenRouter": "deepseek/deepseek-v3.1-terminus"
+  },
+  "deepseek-v3.2-exp": {
+    "PuterJS": "openrouter:deepseek/deepseek-v3.2-exp",
+    "HuggingChat": "deepseek-ai/DeepSeek-V3.2-Exp",
+    "HuggingFaceAPI": "deepseek-ai/DeepSeek-V3.2-Exp",
+    "OpenRouter": "deepseek/deepseek-v3.2-exp"
+  },
+  "gemini-2.5-flash-image": {
+    "PuterJS": "openrouter:google/gemini-2.5-flash-image",
+    "OpenRouter": "google/gemini-2.5-flash-image"
+  },
+  "gemini-2.5-flash-lite-preview25": {
+    "PuterJS": "openrouter:google/gemini-2.5-flash-lite-preview-09-2025",
+    "OpenRouter": "google/gemini-2.5-flash-lite-preview-09-2025"
+  },
+  "gemini-3-pro-image": {
+    "PuterJS": "openrouter:google/gemini-3-pro-image-preview",
+    "OpenRouter": "google/gemini-3-pro-image-preview"
+  },
+  "gemini-3.1-flash-image": {
+    "PuterJS": "openrouter:google/gemini-3.1-flash-image-preview",
+    "OpenRouter": "google/gemini-3.1-flash-image-preview"
+  },
+  "gemini-3.1-pro-preview-customtools": {
+    "PuterJS": "openrouter:google/gemini-3.1-pro-preview-customtools",
+    "ApiAirforce": "gemini-3.1-pro-preview-customtools",
+    "OpenRouter": "google/gemini-3.1-pro-preview-customtools"
+  },
+  "gemma-2-27b-it": {
+    "PuterJS": "openrouter:google/gemma-2-27b-it",
+    "GlhfChat": "hf:google/gemma-2-27b-it",
+    "OpenRouter": "google/gemma-2-27b-it"
+  },
+  "gemma-3-12b-it": {
+    "PuterJS": "openrouter:google/gemma-3-12b-it",
+    "HuggingChat": "google/gemma-3-12b-it",
+    "HuggingFaceAPI": "google/gemma-3-12b-it",
+    "OpenRouter": "google/gemma-3-12b-it"
+  },
+  "gemma-3-4b-it": {
+    "PuterJS": "openrouter:google/gemma-3-4b-it",
+    "HuggingChat": "google/gemma-3-4b-it",
+    "HuggingFaceAPI": "google/gemma-3-4b-it",
+    "OpenRouter": "google/gemma-3-4b-it"
+  },
+  "lyria-3-clip": {
+    "PuterJS": "openrouter:google/lyria-3-clip-preview",
+    "OpenRouter": "google/lyria-3-clip-preview"
+  },
+  "lyria-3-pro": {
+    "PuterJS": "openrouter:google/lyria-3-pro-preview",
+    "OpenRouter": "google/lyria-3-pro-preview"
+  },
+  "mythomax-l2-13b": {
+    "PuterJS": "openrouter:gryphe/mythomax-l2-13b",
+    "OpenRouter": "gryphe/mythomax-l2-13b"
+  },
+  "granite-4.0-h-micro": {
+    "PuterJS": "openrouter:ibm-granite/granite-4.0-h-micro",
+    "OpenRouter": "ibm-granite/granite-4.0-h-micro"
+  },
+  "ling-2.6-1t": {
+    "PuterJS": "openrouter:inclusionai/ling-2.6-1t",
+    "HuggingChat": "inclusionAI/Ling-2.6-1T",
+    "OpenRouter": "inclusionai/ling-2.6-1t"
+  },
+  "ling-2.6-flash": {
+    "PuterJS": "openrouter:inclusionai/ling-2.6-flash",
+    "OpenRouter": "inclusionai/ling-2.6-flash"
+  },
+  "ring-2.6-1t": {
+    "PuterJS": "openrouter:inclusionai/ring-2.6-1t",
+    "OpenRouter": "inclusionai/ring-2.6-1t"
+  },
+  "inflection-3-pi": {
+    "PuterJS": "openrouter:inflection/inflection-3-pi",
+    "OpenRouter": "inflection/inflection-3-pi"
+  },
+  "inflection-3-productivity": {
+    "PuterJS": "openrouter:inflection/inflection-3-productivity",
+    "OpenRouter": "inflection/inflection-3-productivity"
+  },
+  "kat-coder-pro": {
+    "PuterJS": "openrouter:kwaipilot/kat-coder-pro-v2",
+    "OpenRouter": "kwaipilot/kat-coder-pro-v2"
+  },
+  "lfm-2-24b-a2b": {
+    "PuterJS": "openrouter:liquid/lfm-2-24b-a2b",
+    "OpenRouter": "liquid/lfm-2-24b-a2b"
+  },
+  "lfm-2.5-1.2b": {
+    "PuterJS": "openrouter:liquid/lfm-2.5-1.2b-instruct:free",
+    "OpenRouter": "liquid/lfm-2.5-1.2b-instruct:free"
+  },
+  "lfm-2.5-1.2b-thinking": {
+    "PuterJS": "openrouter:liquid/lfm-2.5-1.2b-thinking:free",
+    "OpenRouter": "liquid/lfm-2.5-1.2b-thinking:free"
+  },
+  "weaver": {
+    "PuterJS": "openrouter:mancer/weaver",
+    "OpenRouter": "mancer/weaver"
+  },
+  "phi-4": {
+    "PuterJS": "openrouter:microsoft/phi-4",
+    "HuggingFaceAPI": "microsoft/phi-4",
+    "OllamaSwarm": "phi-4:14b",
+    "OpenRouter": "microsoft/phi-4"
+  },
+  "phi-4-mini": {
+    "PuterJS": "openrouter:microsoft/phi-4-mini-instruct",
+    "HuggingFaceAPI": "microsoft/Phi-4-mini-instruct",
+    "OpenRouter": "microsoft/phi-4-mini-instruct"
+  },
+  "wizardlm-2-8x22b": {
+    "PuterJS": "openrouter:microsoft/wizardlm-2-8x22b",
+    "HuggingChat": "alpindale/WizardLM-2-8x22B",
+    "HuggingFaceAPI": "alpindale/WizardLM-2-8x22B",
+    "OpenRouter": "microsoft/wizardlm-2-8x22b"
+  },
+  "minimax-01": {
+    "PuterJS": "openrouter:minimax/minimax-01",
+    "OpenRouter": "minimax/minimax-01"
+  },
+  "minimax-m2-her": {
+    "PuterJS": "openrouter:minimax/minimax-m2-her",
+    "OpenRouter": "minimax/minimax-m2-her"
+  },
+  "mistral-large-2407": {
+    "PuterJS": "openrouter:mistralai/mistral-large-2407",
+    "OpenRouter": "mistralai/mistral-large-2407"
+  },
+  "mistral-medium-3.1": {
+    "PuterJS": "openrouter:mistralai/mistral-medium-3.1",
+    "OpenRouter": "mistralai/mistral-medium-3.1"
+  },
+  "mistral-saba": {
+    "PuterJS": "openrouter:mistralai/mistral-saba",
+    "OpenRouter": "mistralai/mistral-saba"
+  },
+  "mistral-small-24b-2501": {
+    "PuterJS": "openrouter:mistralai/mistral-small-24b-instruct-2501",
+    "OpenRouter": "mistralai/mistral-small-24b-instruct-2501"
+  },
+  "mistral-small-3.2-24b": {
+    "PuterJS": "openrouter:mistralai/mistral-small-3.2-24b-instruct",
+    "OpenRouter": "mistralai/mistral-small-3.2-24b-instruct"
+  },
+  "mixtral-8x22b": {
+    "PuterJS": "open-mixtral-8x22b",
+    "OpenRouter": "mistralai/mixtral-8x22b-instruct"
+  },
+  "voxtral-small-24b-2507": {
+    "PuterJS": "openrouter:mistralai/voxtral-small-24b-2507",
+    "OpenRouter": "mistralai/voxtral-small-24b-2507"
+  },
+  "kimi-k2-thinking": {
+    "PuterJS": "openrouter:moonshotai/kimi-k2-thinking",
+    "HuggingChat": "moonshotai/Kimi-K2-Thinking",
+    "HuggingFaceAPI": "moonshotai/Kimi-K2-Thinking",
+    "OllamaSwarm": "kimi-k2-thinking:cloud",
+    "OpenRouter": "moonshotai/kimi-k2-thinking"
+  },
+  "morph-v3-fast": {
+    "PuterJS": "openrouter:morph/morph-v3-fast",
+    "OpenRouter": "morph/morph-v3-fast"
+  },
+  "morph-v3-large": {
+    "PuterJS": "openrouter:morph/morph-v3-large",
+    "OpenRouter": "morph/morph-v3-large"
+  },
+  "nex-n2-pro": {
+    "PuterJS": "openrouter:nex-agi/nex-n2-pro",
+    "OpenRouter": "nex-agi/nex-n2-pro"
+  },
+  "hermes-3-llama-3.1-405b": {
+    "PuterJS": "openrouter:nousresearch/hermes-3-llama-3.1-405b:free",
+    "OpenRouter": "nousresearch/hermes-3-llama-3.1-405b"
+  },
+  "hermes-3-llama-3.1-70b": {
+    "PuterJS": "openrouter:nousresearch/hermes-3-llama-3.1-70b",
+    "OpenRouter": "nousresearch/hermes-3-llama-3.1-70b"
+  },
+  "hermes-4-405b": {
+    "PuterJS": "openrouter:nousresearch/hermes-4-405b",
+    "OpenRouter": "nousresearch/hermes-4-405b"
+  },
+  "hermes-4-70b": {
+    "PuterJS": "openrouter:nousresearch/hermes-4-70b",
+    "HuggingFaceAPI": "NousResearch/Hermes-4-70B",
+    "OpenRouter": "nousresearch/hermes-4-70b"
+  },
+  "llama-3.3-nemotron-super-49b-v1.5": {
+    "PuterJS": "openrouter:nvidia/llama-3.3-nemotron-super-49b-v1.5",
+    "OpenRouter": "nvidia/llama-3.3-nemotron-super-49b-v1.5"
+  },
+  "nemotron-3-nano-30b-a3b": {
+    "PuterJS": "openrouter:nvidia/nemotron-3-nano-30b-a3b:free",
+    "OpenRouter": "nvidia/nemotron-3-nano-30b-a3b"
+  },
+  "nemotron-3-super-120b-a12b": {
+    "PuterJS": "openrouter:nvidia/nemotron-3-super-120b-a12b:free",
+    "OpenRouter": "nvidia/nemotron-3-super-120b-a12b"
+  },
+  "nemotron-3-ultra-550b-a55b": {
+    "PuterJS": "togetherai:nvidia/nemotron-3-ultra-550b-a55b",
+    "OpenRouter": "nvidia/nemotron-3-ultra-550b-a55b"
+  },
+  "nemotron-3.5-content-safety": {
+    "PuterJS": "openrouter:nvidia/nemotron-3.5-content-safety:free",
+    "OpenRouter": "nvidia/nemotron-3.5-content-safety:free"
+  },
+  "nemotron-nano-12b-v2-vl": {
+    "PuterJS": "openrouter:nvidia/nemotron-nano-12b-v2-vl:free",
+    "OpenRouter": "nvidia/nemotron-nano-12b-v2-vl:free"
+  },
+  "nemotron-nano-9b": {
+    "PuterJS": "openrouter:nvidia/nemotron-nano-9b-v2:free",
+    "OpenRouter": "nvidia/nemotron-nano-9b-v2:free"
+  },
+  "gpt-3.5-turbo": {
+    "PuterJS": "openrouter:openai/gpt-3.5-turbo-instruct",
+    "OpenRouter": "openai/gpt-3.5-turbo"
+  },
+  "gpt-3.5-turbo-0613": {
+    "PuterJS": "openrouter:openai/gpt-3.5-turbo-0613",
+    "OpenRouter": "openai/gpt-3.5-turbo-0613"
+  },
+  "gpt-3.5-turbo-16k": {
+    "PuterJS": "openrouter:openai/gpt-3.5-turbo-16k",
+    "ApiAirforce": "gpt-3.5-turbo-16k",
+    "OpenRouter": "openai/gpt-3.5-turbo-16k"
+  },
+  "gpt-4-turbo": {
+    "PuterJS": "openrouter:openai/gpt-4-turbo-preview",
+    "ApiAirforce": "gpt-4-turbo",
+    "OpenRouter": "openai/gpt-4-turbo-preview"
+  },
+  "gpt-4o-mini-search": {
+    "PuterJS": "openrouter:openai/gpt-4o-mini-search-preview",
+    "ApiAirforce": "gpt-4o-mini-search",
+    "OpenRouter": "openai/gpt-4o-mini-search-preview"
+  },
+  "gpt-4o-search": {
+    "PuterJS": "openrouter:openai/gpt-4o-search-preview",
+    "ApiAirforce": "gpt-4o-search",
+    "OpenRouter": "openai/gpt-4o-search-preview"
+  },
+  "gpt-5-image": {
+    "PuterJS": "openrouter:openai/gpt-5-image",
+    "OpenRouter": "openai/gpt-5-image"
+  },
+  "gpt-5-image-mini": {
+    "PuterJS": "openrouter:openai/gpt-5-image-mini",
+    "OpenRouter": "openai/gpt-5-image-mini"
+  },
+  "gpt-5-pro": {
+    "PuterJS": "openrouter:openai/gpt-5-pro",
+    "OpenRouter": "openai/gpt-5-pro"
   },
   "gpt-5.1-codex-max": {
     "PuterJS": "openrouter:openai/gpt-5.1-codex-max",
-    "OpenRouter": "openai/gpt-5.1-codex-max",
-    "Yupp": "gpt-5.1-codex-max"
+    "OpenRouter": "openai/gpt-5.1-codex-max"
   },
-  "gpt-5.1-codex-mini": {
-    "PuterJS": "openrouter:openai/gpt-5.1-codex-mini",
-    "OpenRouter": "openai/gpt-5.1-codex-mini"
+  "gpt-5.4-image-2": {
+    "PuterJS": "openrouter:openai/gpt-5.4-image-2",
+    "OpenRouter": "openai/gpt-5.4-image-2"
   },
-  "gpt-5.2-chat": {
-    "PuterJS": "openrouter:openai/gpt-5.2-chat",
-    "OpenRouter": "openai/gpt-5.2-chat",
-    "Yupp": "gpt-5.2-chat-latest"
+  "gpt-audio": {
+    "PuterJS": "openrouter:openai/gpt-audio",
+    "ApiAirforce": "gpt-audio",
+    "OpenRouter": "openai/gpt-audio",
+    "PollinationsAI": "openai-audio-large"
   },
-  "gpt-5.2-pro": {
-    "PuterJS": "openrouter:openai/gpt-5.2-pro",
-    "OpenRouter": "openai/gpt-5.2-pro"
+  "gpt-audio-mini": {
+    "PuterJS": "openrouter:openai/gpt-audio-mini",
+    "OpenRouter": "openai/gpt-audio-mini",
+    "PollinationsAI": "openai-audio"
+  },
+  "gpt-chat": {
+    "PuterJS": "openrouter:openai/gpt-chat-latest",
+    "OpenRouter": "openai/gpt-chat-latest"
+  },
+  "gpt-oss-safeguard-20b": {
+    "PuterJS": "openrouter:openai/gpt-oss-safeguard-20b",
+    "HuggingChat": "openai/gpt-oss-safeguard-20b",
+    "HuggingFaceAPI": "openai/gpt-oss-safeguard-20b",
+    "OpenRouter": "openai/gpt-oss-safeguard-20b"
+  },
+  "o3-deep-research": {
+    "PuterJS": "openrouter:openai/o3-deep-research",
+    "ApiAirforce": "o3-deep-research",
+    "OpenRouter": "openai/o3-deep-research"
+  },
+  "o4-mini-deep-research": {
+    "PuterJS": "openrouter:openai/o4-mini-deep-research",
+    "ApiAirforce": "o4-mini-deep-research",
+    "OpenRouter": "openai/o4-mini-deep-research"
+  },
+  "bodybuilder": {
+    "PuterJS": "openrouter:openrouter/bodybuilder",
+    "OpenRouter": "openrouter/bodybuilder"
+  },
+  "free": {
+    "PuterJS": "openrouter:openrouter/free",
+    "OpenRouter": "openrouter/free"
+  },
+  "owl-alpha": {
+    "PuterJS": "openrouter:openrouter/owl-alpha",
+    "OpenRouter": "openrouter/owl-alpha"
+  },
+  "pareto-code": {
+    "PuterJS": "openrouter:openrouter/pareto-code",
+    "OpenRouter": "openrouter/pareto-code"
+  },
+  "perceptron-mk1": {
+    "PuterJS": "openrouter:perceptron/perceptron-mk1",
+    "OpenRouter": "perceptron/perceptron-mk1"
+  },
+  "sonar-deep-research": {
+    "PuterJS": "openrouter:perplexity/sonar-deep-research",
+    "OpenRouter": "perplexity/sonar-deep-research"
+  },
+  "sonar-pro-search": {
+    "PuterJS": "openrouter:perplexity/sonar-pro-search",
+    "OpenRouter": "perplexity/sonar-pro-search"
+  },
+  "laguna-m.1": {
+    "PuterJS": "openrouter:poolside/laguna-m.1:free",
+    "OpenRouter": "poolside/laguna-m.1"
+  },
+  "laguna-xs.2": {
+    "PuterJS": "openrouter:poolside/laguna-xs.2:free",
+    "OpenRouter": "poolside/laguna-xs.2"
+  },
+  "qwen-3-30b-a3b-thinking-2507": {
+    "PuterJS": "openrouter:qwen/qwen3-30b-a3b-thinking-2507",
+    "OpenRouter": "qwen/qwen3-30b-a3b-thinking-2507"
+  },
+  "qwen-3-coder": {
+    "PuterJS": "openrouter:qwen/qwen3-coder:free",
+    "ApiAirforce": "qwen3-coder",
+    "Ollama": "qwen3-coder:480b",
+    "OllamaSwarm": "qwen3-coder:30b",
+    "OpenRouter": "qwen/qwen3-coder"
+  },
+  "qwen-3-vl-30b-a3b-thinking": {
+    "PuterJS": "openrouter:qwen/qwen3-vl-30b-a3b-thinking",
+    "HuggingChat": "Qwen/Qwen3-VL-30B-A3B-Thinking",
+    "OpenRouter": "qwen/qwen3-vl-30b-a3b-thinking"
+  },
+  "qwen-3-vl-32b": {
+    "PuterJS": "openrouter:qwen/qwen3-vl-32b-instruct",
+    "ApiAirforce": "qwen3-vl-32b",
+    "OpenRouter": "qwen/qwen3-vl-32b-instruct"
+  },
+  "qwen-3.6-flash": {
+    "PuterJS": "openrouter:qwen/qwen3.6-flash",
+    "OpenRouter": "qwen/qwen3.6-flash"
+  },
+  "reka-edge": {
+    "PuterJS": "openrouter:rekaai/reka-edge",
+    "OpenRouter": "rekaai/reka-edge"
+  },
+  "reka-flash-3": {
+    "PuterJS": "openrouter:rekaai/reka-flash-3",
+    "OpenRouter": "rekaai/reka-flash-3"
+  },
+  "relace-apply-3": {
+    "PuterJS": "openrouter:relace/relace-apply-3",
+    "OpenRouter": "relace/relace-apply-3"
+  },
+  "relace-search": {
+    "PuterJS": "openrouter:relace/relace-search",
+    "OpenRouter": "relace/relace-search"
+  },
+  "fugu-ultra": {
+    "PuterJS": "openrouter:sakana/fugu-ultra",
+    "OpenRouter": "sakana/fugu-ultra"
+  },
+  "l3-lunaris-8b": {
+    "PuterJS": "openrouter:sao10k/l3-lunaris-8b",
+    "OpenRouter": "sao10k/l3-lunaris-8b"
+  },
+  "l3.1-70b-hanami-x1": {
+    "PuterJS": "openrouter:sao10k/l3.1-70b-hanami-x1",
+    "OpenRouter": "sao10k/l3.1-70b-hanami-x1"
+  },
+  "l3.1-euryale-70b": {
+    "PuterJS": "openrouter:sao10k/l3.1-euryale-70b",
+    "OpenRouter": "sao10k/l3.1-euryale-70b"
+  },
+  "l3.3-euryale-70b": {
+    "PuterJS": "openrouter:sao10k/l3.3-euryale-70b",
+    "OpenRouter": "sao10k/l3.3-euryale-70b"
+  },
+  "router": {
+    "PuterJS": "openrouter:switchpoint/router",
+    "OpenRouter": "switchpoint/router"
+  },
+  "hunyuan-a13b": {
+    "PuterJS": "openrouter:tencent/hunyuan-a13b-instruct",
+    "OpenRouter": "tencent/hunyuan-a13b-instruct"
+  },
+  "hy3": {
+    "PuterJS": "openrouter:tencent/hy3-preview",
+    "OpenRouter": "tencent/hy3-preview"
+  },
+  "cydonia-24b-v4.1": {
+    "PuterJS": "openrouter:thedrummer/cydonia-24b-v4.1",
+    "OpenRouter": "thedrummer/cydonia-24b-v4.1"
+  },
+  "rocinante-12b": {
+    "PuterJS": "openrouter:thedrummer/rocinante-12b",
+    "OpenRouter": "thedrummer/rocinante-12b"
+  },
+  "skyfall-36b": {
+    "PuterJS": "openrouter:thedrummer/skyfall-36b-v2",
+    "OpenRouter": "thedrummer/skyfall-36b-v2"
+  },
+  "unslopnemo-12b": {
+    "PuterJS": "openrouter:thedrummer/unslopnemo-12b",
+    "OpenRouter": "thedrummer/unslopnemo-12b"
+  },
+  "remm-slerp-l2-13b": {
+    "PuterJS": "openrouter:undi95/remm-slerp-l2-13b",
+    "OpenRouter": "undi95/remm-slerp-l2-13b"
+  },
+  "solar-pro-3": {
+    "PuterJS": "openrouter:upstage/solar-pro-3",
+    "OpenRouter": "upstage/solar-pro-3"
+  },
+  "palmyra-x5": {
+    "PuterJS": "openrouter:writer/palmyra-x5",
+    "OpenRouter": "writer/palmyra-x5"
+  },
+  "grok-4.20": {
+    "PuterJS": "openrouter:x-ai/grok-4.20",
+    "OpenRouter": "x-ai/grok-4.20"
+  },
+  "grok-4.20-multi-agent": {
+    "PuterJS": "openrouter:x-ai/grok-4.20-multi-agent",
+    "ApiAirforce": "grok-4.20-multi-agent",
+    "OpenRouter": "x-ai/grok-4.20-multi-agent"
+  },
+  "grok-build-0.1": {
+    "PuterJS": "openrouter:x-ai/grok-build-0.1",
+    "OpenRouter": "x-ai/grok-build-0.1"
+  },
+  "gemini-flash": {
+    "PuterJS": "openrouter:~google/gemini-flash-latest",
+    "OpenRouter": "~google/gemini-flash-latest"
+  },
+  "gemini-pro": {
+    "PuterJS": "openrouter:~google/gemini-pro-latest",
+    "OpenRouter": "~google/gemini-pro-latest"
+  },
+  "gpt": {
+    "PuterJS": "openrouter:~openai/gpt-latest",
+    "OpenRouter": "~openai/gpt-latest"
+  },
+  "gpt-mini": {
+    "PuterJS": "openrouter:~openai/gpt-mini-latest",
+    "OpenRouter": "~openai/gpt-mini-latest"
+  },
+  "qwen-2-1.5b": {
+    "PuterJS": "togetherai:arize-ai/qwen-2-1.5b-instruct"
+  },
+  "cogito-v2-1-671b": {
+    "PuterJS": "togetherai:deepcogito/cogito-v2-1-671b"
+  },
+  "lfm2-24b-a2b": {
+    "PuterJS": "togetherai:liquidai/lfm2-24b-a2b"
+  },
+  "llama-3.3-70b-turbo": {
+    "PuterJS": "togetherai:meta-llama/llama-3.3-70b-instruct-turbo"
+  },
+  "llama-guard-4-12b": {
+    "PuterJS": "togetherai:meta-llama/llama-guard-4-12b",
+    "HuggingChat": "meta-llama/Llama-Guard-4-12B",
+    "OpenRouter": "meta-llama/llama-guard-4-12b"
+  },
+  "llama-3-8b-lite": {
+    "PuterJS": "togetherai:meta-llama/meta-llama-3-8b-instruct-lite"
+  },
+  "qwen-2.5-7b-turbo": {
+    "PuterJS": "togetherai:qwen/qwen2.5-7b-instruct-turbo"
+  },
+  "qwen-3.5-9b": {
+    "PuterJS": "togetherai:qwen/qwen3.5-9b",
+    "HuggingChat": "Qwen/Qwen3.5-9B",
+    "HuggingFaceAPI": "Qwen/Qwen3.5-9B",
+    "OpenRouter": "qwen/qwen3.5-9b"
   },
   "grok-2-vision": {
-    "PuterJS": "grok-2-vision"
+    "PuterJS": "x-ai:x-ai/grok-2-vision",
+    "ApiAirforce": "grok-2-vision"
+  },
+  "grok-2-vision-1212": {
+    "PuterJS": "x-ai:x-ai/grok-2-vision-1212"
   },
   "grok-3-fast": {
-    "PuterJS": "grok-3-fast"
+    "PuterJS": "x-ai:x-ai/grok-3-fast",
+    "ApiAirforce": "grok-3-fast"
   },
   "grok-3-mini-fast": {
-    "PuterJS": "grok-3-mini-fast"
+    "PuterJS": "x-ai:x-ai/grok-3-mini-fast",
+    "ApiAirforce": "grok-3-mini-fast"
+  },
+  "grok-4-0709": {
+    "PuterJS": "x-ai:x-ai/grok-4-0709"
+  },
+  "grok-4-1-fast": {
+    "PuterJS": "x-ai:x-ai/grok-4-1-fast",
+    "PollinationsAI": "grok"
+  },
+  "grok-4-fast": {
+    "PuterJS": "x-ai:x-ai/grok-4-fast",
+    "ApiAirforce": "grok-4-fast",
+    "PollinationsAI": "grok"
+  },
+  "grok-4-fast-non-reasoning": {
+    "PuterJS": "x-ai:x-ai/grok-4-fast-non-reasoning"
   },
   "grok-beta": {
     "PuterJS": [
@@ -2628,86 +3884,76 @@ model_map = {
       "openrouter:x-ai/grok-3-beta"
     ]
   },
+  "grok-code-fast-1": {
+    "PuterJS": "x-ai:x-ai/grok-code-fast-1",
+    "ApiAirforce": "grok-code-fast-1"
+  },
   "grok-vision-beta": {
-    "PuterJS": "grok-vision-beta"
+    "PuterJS": "x-ai:x-ai/grok-vision-beta"
   },
-  "magistral-medium-2509": {
-    "PuterJS": "magistral-medium-2509",
-    "Yupp": "magistral-medium-2509"
+  "autoglm-phone-multilingual": {
+    "PuterJS": "z-ai:z-ai/autoglm-phone-multilingual"
   },
-  "magistral-small-2509": {
-    "PuterJS": "magistral-small-2509",
-    "Yupp": "magistral-small-2509"
+  "glm-4-32b-0414-128k": {
+    "PuterJS": "z-ai:z-ai/glm-4-32b-0414-128k"
   },
-  "ministral-14b-2512": {
-    "PuterJS": "openrouter:mistralai/ministral-14b-2512",
-    "Nvidia": "mistralai/ministral-14b-instruct-2512",
-    "OpenRouter": "mistralai/ministral-14b-2512",
-    "Yupp": "ministral-14b-2512"
+  "glm-4.5": {
+    "PuterJS": "z-ai:z-ai/glm-4.5",
+    "ApiAirforce": "glm-4.5",
+    "HuggingChat": "zai-org/GLM-4.5",
+    "HuggingFaceAPI": "zai-org/GLM-4.5",
+    "OpenRouter": "z-ai/glm-4.5"
   },
-  "ministral-3b-2512": {
-    "PuterJS": "openrouter:mistralai/ministral-3b-2512",
-    "OpenRouter": "mistralai/ministral-3b-2512",
-    "Yupp": "ministral-3b-2512"
+  "glm-4.5-air": {
+    "PuterJS": "z-ai:z-ai/glm-4.5-air",
+    "ApiAirforce": "glm-4.5-air",
+    "HuggingChat": "zai-org/GLM-4.5-Air",
+    "OpenRouter": "z-ai/glm-4.5-air"
   },
-  "ministral-8b-2512": {
-    "PuterJS": "openrouter:mistralai/ministral-8b-2512",
-    "OpenRouter": "mistralai/ministral-8b-2512"
+  "glm-4.5-airx": {
+    "PuterJS": "z-ai:z-ai/glm-4.5-airx"
   },
-  "mistral-large": {
-    "PuterJS": "openrouter:mistralai/mistral-large",
-    "Nvidia": "mistralai/mistral-large",
-    "OpenRouter": "mistralai/mistral-large"
+  "glm-4.5-flash": {
+    "PuterJS": "z-ai:z-ai/glm-4.5-flash"
   },
-  "o1-pro": {
-    "PuterJS": "openrouter:openai/o1-pro",
-    "OpenRouter": "openai/o1-pro",
-    "Yupp": "o1-pro-2025-03-19"
+  "glm-4.5-x": {
+    "PuterJS": "z-ai:z-ai/glm-4.5-x"
   },
-  "o3-pro": {
-    "PuterJS": "openrouter:openai/o3-pro",
-    "OpenRouter": "openai/o3-pro",
-    "Yupp": "o3-pro-2025-06-10"
+  "glm-4.5v": {
+    "PuterJS": "z-ai:z-ai/glm-4.5v",
+    "HuggingChat": "zai-org/GLM-4.5V-FP8",
+    "HuggingFaceAPI": "zai-org/GLM-4.5V",
+    "OpenRouter": "z-ai/glm-4.5v"
   },
-  "open-mistral-7b": {
-    "PuterJS": "open-mistral-7b",
-    "Yupp": "open-mistral-7b"
+  "glm-4.6": {
+    "PuterJS": "z-ai:z-ai/glm-4.6",
+    "ApiAirforce": "glm-4.6",
+    "HuggingChat": "zai-org/GLM-4.6",
+    "HuggingFaceAPI": "zai-org/GLM-4.6",
+    "OllamaSwarm": "glm-4.6:cloud",
+    "OpenRouter": "z-ai/glm-4.6"
   },
-  "open-mistral-nemo": {
-    "PuterJS": "open-mistral-nemo",
-    "Yupp": "open-mistral-nemo"
+  "glm-4.6v": {
+    "PuterJS": "z-ai:z-ai/glm-4.6v",
+    "HuggingChat": "zai-org/GLM-4.6V-FP8",
+    "OpenRouter": "z-ai/glm-4.6v"
   },
-  "pixtral-large-2411": {
-    "PuterJS": "openrouter:mistralai/pixtral-large-2411",
-    "OpenRouter": "mistralai/pixtral-large-2411"
+  "glm-4.6v-flash": {
+    "PuterJS": "z-ai:z-ai/glm-4.6v-flash",
+    "HuggingChat": "zai-org/GLM-4.6V-Flash"
   },
-  "usage-limited": {
-    "PuterJS": "usage-limited"
+  "glm-4.6v-flashx": {
+    "PuterJS": "z-ai:z-ai/glm-4.6v-flashx"
   },
-  "voxtral-mini-2507": {
-    "PuterJS": "voxtral-mini-2507"
+  "glm-4.7-flashx": {
+    "PuterJS": "z-ai:z-ai/glm-4.7-flashx"
   },
-  "voxtral-small-2507": {
-    "PuterJS": "voxtral-small-2507"
-  },
-  "mixtral-8x22b": {
-    "PuterJS": "open-mixtral-8x22b",
-    "OpenRouter": "mistralai/mixtral-8x22b-instruct"
+  "glm-5-turbo": {
+    "PuterJS": "z-ai:z-ai/glm-5-turbo",
+    "OpenRouter": "z-ai/glm-5-turbo"
   },
   "pixtral-large": {
-    "PuterJS": "pixtral-large-latest",
-    "Yupp": "pixtral-large-latest"
-  },
-  "llama-3.2-1b": {
-    "PuterJS": [
-      "openrouter:meta-llama/llama-3.2-1b-instruct:free",
-      "openrouter:meta-llama/llama-3.2-1b-instruct"
-    ],
-    "HuggingFaceAPI": "meta-llama/Llama-3.2-1B-Instruct",
-    "Nvidia": "meta/llama-3.2-1b-instruct",
-    "HuggingChat": "meta-llama/Llama-3.2-1B-Instruct",
-    "OpenRouter": "meta-llama/llama-3.2-1b-instruct",
-    "Yupp": "meta-llama/llama-3.2-1b-instruct"
+    "PuterJS": "pixtral-large-latest"
   },
   "llama-3.3-8b": {
     "PuterJS": "openrouter:meta-llama/llama-3.3-8b-instruct:free"
@@ -2728,8 +3974,26 @@ model_map = {
   "gemini-2.5-flash-thinking": {
     "PuterJS": "openrouter:google/gemini-2.5-flash-preview:thinking"
   },
+  "gemma-2-9b": {
+    "PuterJS": [
+      "openrouter:google/gemma-2-9b-it:free",
+      "openrouter:google/gemma-2-9b-it"
+    ]
+  },
   "gemma-3-1b": {
     "PuterJS": "openrouter:google/gemma-3-1b-it:free"
+  },
+  "gemma-3-4b": {
+    "PuterJS": [
+      "openrouter:google/gemma-3-4b-it:free",
+      "openrouter:google/gemma-3-4b-it"
+    ]
+  },
+  "gemma-3-12b": {
+    "PuterJS": [
+      "openrouter:google/gemma-3-12b-it:free",
+      "openrouter:google/gemma-3-12b-it"
+    ]
   },
   "hermes-2-pro": {
     "PuterJS": "openrouter:nousresearch/hermes-2-pro-llama-3-8b"
@@ -2752,8 +4016,17 @@ model_map = {
   "phi-3-medium": {
     "PuterJS": "openrouter:microsoft/phi-3-medium-128k-instruct"
   },
+  "phi-4-multimodal": {
+    "PuterJS": "openrouter:microsoft/phi-4-multimodal-instruct"
+  },
   "phi-4-reasoning": {
     "PuterJS": "openrouter:microsoft/phi-4-reasoning:free"
+  },
+  "phi-4-reasoning-plus": {
+    "PuterJS": [
+      "openrouter:microsoft/phi-4-reasoning-plus:free",
+      "openrouter:microsoft/phi-4-reasoning-plus"
+    ]
   },
   "mai-ds-r1": {
     "PuterJS": "openrouter:microsoft/mai-ds-r1:free"
@@ -2764,14 +4037,10 @@ model_map = {
       "claude-3-7-sonnet-latest",
       "openrouter:anthropic/claude-3.7-sonnet",
       "openrouter:anthropic/claude-3.7-sonnet:beta"
-    ],
-    "GithubCopilot": "claude-3.7-sonnet",
-    "OpenRouter": "anthropic/claude-3.7-sonnet:thinking",
-    "Yupp": "anthropic/claude-3.7-sonnet:thinking<>OPR"
+    ]
   },
   "claude-3.7-sonnet-thinking": {
-    "PuterJS": "openrouter:anthropic/claude-3.7-sonnet:thinking",
-    "GithubCopilot": "claude-3.7-sonnet-thinking"
+    "PuterJS": "openrouter:anthropic/claude-3.7-sonnet:thinking"
   },
   "claude-3.5-haiku": {
     "PuterJS": [
@@ -2779,8 +4048,7 @@ model_map = {
       "openrouter:anthropic/claude-3.5-haiku",
       "openrouter:anthropic/claude-3.5-haiku-20241022:beta",
       "openrouter:anthropic/claude-3.5-haiku-20241022"
-    ],
-    "OpenRouter": "anthropic/claude-3.5-haiku-20241022"
+    ]
   },
   "claude-3.5-sonnet": {
     "PuterJS": [
@@ -2791,17 +4059,14 @@ model_map = {
       "openrouter:anthropic/claude-3.5-sonnet-20240620",
       "openrouter:anthropic/claude-3.5-sonnet:beta",
       "openrouter:anthropic/claude-3.5-sonnet"
-    ],
-    "GithubCopilot": "claude-3.5-sonnet",
-    "OpenRouter": "anthropic/claude-3.5-sonnet"
+    ]
   },
   "claude-3-opus": {
     "PuterJS": [
       "openrouter:anthropic/claude-3-opus:beta",
       "openrouter:anthropic/claude-3-opus"
     ],
-    "Anthropic": "claude-3-opus-latest",
-    "Yupp": "claude-3-opus-20240229"
+    "Anthropic": "claude-3-opus-latest"
   },
   "claude-3-sonnet": {
     "PuterJS": [
@@ -2834,54 +4099,87 @@ model_map = {
   "command": {
     "PuterJS": "openrouter:cohere/command"
   },
-  "qwen-vl-plus": {
-    "PuterJS": "openrouter:qwen/qwen-vl-plus",
-    "OpenRouter": "qwen/qwen-vl-plus"
+  "qwen-2.5-vl-7b": {
+    "PuterJS": [
+      "openrouter:qwen/qwen-2.5-vl-7b-instruct:free",
+      "openrouter:qwen/qwen-2.5-vl-7b-instruct"
+    ]
+  },
+  "qwen-3-0.6b": {
+    "PuterJS": "openrouter:qwen/qwen3-0.6b-04-28:free",
+    "ApiAirforce": "qwen3-0.6b",
+    "HuggingFaceAPI": "Qwen/Qwen3-0.6B"
+  },
+  "qwen-3-1.7b": {
+    "PuterJS": "openrouter:qwen/qwen3-1.7b:free",
+    "ApiAirforce": "qwen3-1.7b",
+    "HuggingFaceAPI": "Qwen/Qwen3-1.7B"
+  },
+  "qwen-3-4b": {
+    "PuterJS": "openrouter:qwen/qwen3-4b:free",
+    "ApiAirforce": "qwen3-4b",
+    "HuggingFaceAPI": "Qwen/Qwen3-4B"
+  },
+  "qwen-3-30b": {
+    "PuterJS": [
+      "openrouter:qwen/qwen3-30b-a3b:free",
+      "openrouter:qwen/qwen3-30b-a3b"
+    ]
   },
   "qwen-2.5-coder-7b": {
     "PuterJS": "openrouter:qwen/qwen2.5-coder-7b-instruct",
-    "HuggingFaceAPI": "Qwen/Qwen2.5-Coder-7B",
-    "Nvidia": "qwen/qwen2.5-coder-7b-instruct",
-    "HuggingChat": "Qwen/Qwen2.5-Coder-7B",
-    "OpenRouter": "qwen/qwen2.5-coder-7b-instruct"
+    "HuggingChat": "Qwen/Qwen2.5-Coder-7B-Instruct",
+    "HuggingFaceAPI": "Qwen/Qwen2.5-Coder-7B"
   },
   "qwen-2.5-vl-3b": {
-    "PuterJS": "openrouter:qwen/qwen2.5-vl-3b-instruct:free",
-    "Yupp": "qwen2.5-vl-3b-instruct"
+    "PuterJS": "openrouter:qwen/qwen2.5-vl-3b-instruct:free"
   },
-  "deepseek-prover": {
-    "PuterJS": "openrouter:deepseek/deepseek-prover-v2",
-    "OpenRouter": "deepseek/deepseek-prover-v2"
+  "qwen-2.5-vl-32b": {
+    "PuterJS": [
+      "openrouter:qwen/qwen2.5-vl-32b-instruct:free",
+      "openrouter:qwen/qwen2.5-vl-32b-instruct"
+    ]
+  },
+  "deepseek-prover-v2": {
+    "PuterJS": [
+      "openrouter:deepseek/deepseek-prover-v2:free",
+      "openrouter:deepseek/deepseek-prover-v2"
+    ]
+  },
+  "deepseek-v3-0324": {
+    "PuterJS": [
+      "deepseek-chat",
+      "openrouter:deepseek/deepseek-chat-v3-0324:free",
+      "openrouter:deepseek/deepseek-chat-v3-0324"
+    ],
+    "ApiAirforce": "deepseek-v3-0324",
+    "HuggingChat": "deepseek-ai/DeepSeek-V3-0324",
+    "OllamaSwarm": "lordoliver/DeepSeek-V3-0324:671b-q4_k_m"
   },
   "deepseek-r1-zero": {
     "PuterJS": "openrouter:deepseek/deepseek-r1-zero:free"
   },
   "deepseek-r1-distill-llama-8b": {
     "PuterJS": "openrouter:deepseek/deepseek-r1-distill-llama-8b",
-    "HuggingFaceAPI": "deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
-    "Nvidia": "deepseek-ai/deepseek-r1-distill-llama-8b",
     "HuggingChat": "deepseek-ai/DeepSeek-R1-Distill-Llama-8B"
+  },
+  "deepseek-chat": {
+    "PuterJS": [
+      "deepseek-chat",
+      "openrouter:deepseek/deepseek-chat:free",
+      "openrouter:deepseek/deepseek-chat"
+    ],
+    "DeepSeekAPI": "deepseek-v3",
+    "OpenRouter": "deepseek/deepseek-chat"
   },
   "deepseek-coder": {
     "PuterJS": [
       "openrouter:deepseek/deepseek-coder"
-    ]
-  },
-  "inflection-3-productivity": {
-    "PuterJS": "openrouter:inflection/inflection-3-productivity",
-    "OpenRouter": "inflection/inflection-3-productivity"
-  },
-  "inflection-3-pi": {
-    "PuterJS": "openrouter:inflection/inflection-3-pi",
-    "OpenRouter": "inflection/inflection-3-pi"
+    ],
+    "OllamaSwarm": "deepseek-coder:6.7b"
   },
   "grok-3-beta": {
-    "PuterJS": "openrouter:x-ai/grok-3-beta",
-    "OpenRouter": "x-ai/grok-3-beta"
-  },
-  "sonar-deep-research": {
-    "PuterJS": "openrouter:perplexity/sonar-deep-research",
-    "OpenRouter": "perplexity/sonar-deep-research"
+    "PuterJS": "openrouter:x-ai/grok-3-beta"
   },
   "llama-3.1-sonar-small-online": {
     "PuterJS": "openrouter:perplexity/llama-3.1-sonar-small-128k-online"
@@ -2903,14 +4201,14 @@ model_map = {
       "openrouter:thudm/glm-4-32b:free",
       "openrouter:thudm/glm-4-32b",
       "openrouter:thudm/glm-4-9b:free"
-    ]
+    ],
+    "ApiAirforce": "glm-4"
   },
   "glm-4-32b": {
     "PuterJS": [
       "openrouter:thudm/glm-4-32b:free",
       "openrouter:thudm/glm-4-32b"
-    ],
-    "OpenRouter": "z-ai/glm-4-32b"
+    ]
   },
   "glm-z1-32b": {
     "PuterJS": [
@@ -2926,10 +4224,6 @@ model_map = {
   },
   "glm-z1-rumination-32b": {
     "PuterJS": "openrouter:thudm/glm-z1-rumination-32b"
-  },
-  "minimax": {
-    "PuterJS": "openrouter:minimax/minimax-01",
-    "HailuoAI": "minimax"
   },
   "dolphin-3.0-r1-24b": {
     "PuterJS": "openrouter:cognitivecomputations/dolphin3.0-r1-mistral-24b:free"
@@ -2961,649 +4255,19 @@ model_map = {
   "lfm-40b": {
     "PuterJS": "openrouter:liquid/lfm-40b"
   },
-  "jamba-large-1.7": {
-    "PuterJS": "openrouter:ai21/jamba-large-1.7",
-    "OpenRouter": "ai21/jamba-large-1.7"
-  },
-  "jamba-mini-1.7": {
-    "PuterJS": "openrouter:ai21/jamba-mini-1.7",
-    "OpenRouter": "ai21/jamba-mini-1.7",
-    "Yupp": "jamba-mini-1.7"
-  },
-  "aion-1.0": {
-    "PuterJS": "openrouter:aion-labs/aion-1.0",
-    "OpenRouter": "aion-labs/aion-1.0"
-  },
-  "aion-1.0-mini": {
-    "PuterJS": "openrouter:aion-labs/aion-1.0-mini",
-    "OpenRouter": "aion-labs/aion-1.0-mini"
-  },
-  "aion-rp-llama-3.1-8b": {
-    "PuterJS": "openrouter:aion-labs/aion-rp-llama-3.1-8b",
-    "OpenRouter": "aion-labs/aion-rp-llama-3.1-8b"
-  },
-  "codellama-7b-solidity": {
-    "PuterJS": "openrouter:alfredpros/codellama-7b-instruct-solidity",
-    "OpenRouter": "alfredpros/codellama-7b-instruct-solidity"
-  },
-  "tongyi-deepresearch-30b-a3b": {
-    "PuterJS": "openrouter:alibaba/tongyi-deepresearch-30b-a3b",
-    "OpenRouter": "alibaba/tongyi-deepresearch-30b-a3b"
-  },
-  "olmo-2-0325-32b": {
-    "PuterJS": "openrouter:allenai/olmo-2-0325-32b-instruct",
-    "OpenRouter": "allenai/olmo-2-0325-32b-instruct"
-  },
-  "olmo-3-7b": {
-    "PuterJS": "openrouter:allenai/olmo-3-7b-instruct",
-    "HuggingFaceAPI": "allenai/Olmo-3-7B-Instruct",
-    "HuggingChat": "allenai/Olmo-3-7B-Instruct",
-    "OpenRouter": "allenai/olmo-3-7b-instruct"
-  },
-  "olmo-3-7b-think": {
-    "PuterJS": "openrouter:allenai/olmo-3-7b-think",
-    "HuggingFaceAPI": "allenai/Olmo-3-7B-Think",
-    "HuggingChat": "allenai/Olmo-3-7B-Think",
-    "OpenRouter": "allenai/olmo-3-7b-think"
-  },
-  "goliath-120b": {
-    "PuterJS": "openrouter:alpindale/goliath-120b",
-    "OpenRouter": "alpindale/goliath-120b"
-  },
-  "nova-lite": {
-    "PuterJS": "openrouter:amazon/nova-lite-v1",
-    "OpenRouter": "amazon/nova-lite-v1"
-  },
-  "nova-micro": {
-    "PuterJS": "openrouter:amazon/nova-micro-v1",
-    "OpenRouter": "amazon/nova-micro-v1"
-  },
-  "nova-premier": {
-    "PuterJS": "openrouter:amazon/nova-premier-v1",
-    "OpenRouter": "amazon/nova-premier-v1"
-  },
-  "nova-pro": {
-    "PuterJS": "openrouter:amazon/nova-pro-v1",
-    "OpenRouter": "amazon/nova-pro-v1"
-  },
-  "magnum-v4-72b": {
-    "PuterJS": "openrouter:anthracite-org/magnum-v4-72b",
-    "OpenRouter": "anthracite-org/magnum-v4-72b"
-  },
-  "claude-opus-4.1": {
-    "PuterJS": "openrouter:anthropic/claude-opus-4.1",
-    "OpenRouter": "anthropic/claude-opus-4.1"
-  },
-  "coder-large": {
-    "PuterJS": "openrouter:arcee-ai/coder-large",
-    "OpenRouter": "arcee-ai/coder-large"
-  },
-  "maestro-reasoning": {
-    "PuterJS": "openrouter:arcee-ai/maestro-reasoning",
-    "OpenRouter": "arcee-ai/maestro-reasoning"
-  },
-  "spotlight": {
-    "PuterJS": "openrouter:arcee-ai/spotlight",
-    "OpenRouter": "arcee-ai/spotlight"
-  },
-  "virtuoso-large": {
-    "PuterJS": "openrouter:arcee-ai/virtuoso-large",
-    "OpenRouter": "arcee-ai/virtuoso-large"
-  },
-  "ernie-4.5-21b-a3b": {
-    "PuterJS": "openrouter:baidu/ernie-4.5-21b-a3b",
-    "OpenRouter": "baidu/ernie-4.5-21b-a3b"
-  },
-  "ernie-4.5-21b-a3b-thinking": {
-    "PuterJS": "openrouter:baidu/ernie-4.5-21b-a3b-thinking",
-    "OpenRouter": "baidu/ernie-4.5-21b-a3b-thinking"
-  },
-  "ernie-4.5-300b-a47b": {
-    "PuterJS": "openrouter:baidu/ernie-4.5-300b-a47b",
-    "OpenRouter": "baidu/ernie-4.5-300b-a47b"
-  },
-  "ernie-4.5-vl-28b-a3b": {
-    "PuterJS": "openrouter:baidu/ernie-4.5-vl-28b-a3b",
-    "OpenRouter": "baidu/ernie-4.5-vl-28b-a3b"
-  },
-  "ernie-4.5-vl-424b-a47b": {
-    "PuterJS": "openrouter:baidu/ernie-4.5-vl-424b-a47b",
-    "OpenRouter": "baidu/ernie-4.5-vl-424b-a47b"
-  },
-  "seed-1.6": {
-    "PuterJS": "openrouter:bytedance-seed/seed-1.6",
-    "OpenRouter": "bytedance-seed/seed-1.6"
-  },
-  "seed-1.6-flash": {
-    "PuterJS": "openrouter:bytedance-seed/seed-1.6-flash",
-    "OpenRouter": "bytedance-seed/seed-1.6-flash"
-  },
-  "ui-tars-1.5-7b": {
-    "PuterJS": "openrouter:bytedance/ui-tars-1.5-7b",
-    "OpenRouter": "bytedance/ui-tars-1.5-7b"
-  },
-  "command-r24": {
-    "PuterJS": "openrouter:cohere/command-r-08-2024",
-    "HuggingSpace": "command-r-08-2024",
-    "HuggingFaceAPI": "CohereLabs/c4ai-command-r-08-2024",
-    "Cohere": "command-r-08-2024",
-    "CohereForAI_C4AI_Command": "command-r-08-2024",
-    "HuggingChat": "CohereLabs/c4ai-command-r-08-2024",
-    "OpenRouter": "cohere/command-r-08-2024",
-    "Yupp": "command-r-08-2024"
-  },
-  "command-r7b24": {
-    "PuterJS": "openrouter:cohere/command-r7b-12-2024",
-    "HuggingSpace": "command-r7b-12-2024",
-    "Cohere": "command-r7b-12-2024",
-    "CohereForAI_C4AI_Command": "command-r7b-12-2024",
-    "HuggingChat": "CohereLabs/c4ai-command-r7b-12-2024",
-    "OpenRouter": "cohere/command-r7b-12-2024",
-    "Yupp": "command-r7b-12-2024"
-  },
-  "cogito-v2-preview-llama-109b-moe": {
-    "PuterJS": "openrouter:deepcogito/cogito-v2-preview-llama-109b-moe",
-    "OpenRouter": "deepcogito/cogito-v2-preview-llama-109b-moe"
-  },
-  "cogito-v2-preview-llama-405b": {
-    "PuterJS": "openrouter:deepcogito/cogito-v2-preview-llama-405b",
-    "HuggingChat": "deepcogito/cogito-v2-preview-llama-405B",
-    "OpenRouter": "deepcogito/cogito-v2-preview-llama-405b"
-  },
-  "cogito-v2-preview-llama-70b": {
-    "PuterJS": "openrouter:deepcogito/cogito-v2-preview-llama-70b",
-    "HuggingChat": "deepcogito/cogito-v2-preview-llama-70B",
-    "OpenRouter": "deepcogito/cogito-v2-preview-llama-70b"
-  },
-  "cogito-v2.1-671b": {
-    "PuterJS": "openrouter:deepcogito/cogito-v2.1-671b",
-    "OpenRouter": "deepcogito/cogito-v2.1-671b"
-  },
-  "deepseek-chat-v3-0324": {
-    "PuterJS": "openrouter:deepseek/deepseek-chat-v3-0324",
-    "OpenRouter": "deepseek/deepseek-chat-v3-0324"
-  },
-  "deepseek-chat-v3.1": {
-    "PuterJS": "openrouter:deepseek/deepseek-chat-v3.1",
-    "OpenRouter": "deepseek/deepseek-chat-v3.1"
-  },
-  "deepseek-r1-0528-qwen-3-8b": {
-    "PuterJS": "openrouter:deepseek/deepseek-r1-0528-qwen3-8b",
-    "HuggingFaceAPI": "deepseek-ai/DeepSeek-R1-0528-Qwen3-8B",
-    "HuggingChat": "deepseek-ai/DeepSeek-R1-0528-Qwen3-8B",
-    "OpenRouter": "deepseek/deepseek-r1-0528-qwen3-8b"
-  },
-  "deepseek-v3.2-speciale": {
-    "PuterJS": "openrouter:deepseek/deepseek-v3.2-speciale",
-    "ApiAirforce": "deepseek-v3.2-speciale",
-    "OpenRouter": "deepseek/deepseek-v3.2-speciale"
-  },
-  "llemma.7b": {
-    "PuterJS": "openrouter:eleutherai/llemma_7b",
-    "OpenRouter": "eleutherai/llemma_7b"
-  },
-  "rnj-1": {
-    "PuterJS": "openrouter:essentialai/rnj-1-instruct",
-    "HuggingFaceAPI": "EssentialAI/rnj-1-instruct",
-    "Ollama": "rnj-1:8b",
-    "HuggingChat": "EssentialAI/rnj-1-instruct",
-    "OpenRouter": "essentialai/rnj-1-instruct"
-  },
-  "gemini-2.5-flash-image": {
-    "PuterJS": "openrouter:google/gemini-2.5-flash-image-preview",
-    "OpenRouter": "google/gemini-2.5-flash-image-preview",
-    "Yupp": "gemini-2.5-flash-image"
-  },
-  "gemini-2.5-flash-lite-preview25": {
-    "PuterJS": "openrouter:google/gemini-2.5-flash-lite-preview-09-2025",
-    "OpenRouter": "google/gemini-2.5-flash-lite-preview-09-2025"
-  },
-  "gemini-3-pro-image": {
-    "PuterJS": "openrouter:google/gemini-3-pro-image-preview",
-    "OpenRouter": "google/gemini-3-pro-image-preview"
-  },
-  "gemma-2-27b-it": {
-    "PuterJS": "openrouter:google/gemma-2-27b-it",
-    "Nvidia": "google/gemma-2-27b-it",
-    "GlhfChat": "hf:google/gemma-2-27b-it",
-    "OpenRouter": "google/gemma-2-27b-it"
-  },
-  "gemma-2-9b-it": {
-    "PuterJS": "openrouter:google/gemma-2-9b-it",
-    "HuggingFaceAPI": "google/gemma-2-9b-it",
-    "Nvidia": "google/gemma-2-9b-it",
-    "GlhfChat": "hf:google/gemma-2-9b-it",
-    "HuggingChat": "google/gemma-2-9b-it",
-    "OpenRouter": "google/gemma-2-9b-it"
-  },
-  "mythomax-l2-13b": {
-    "PuterJS": "openrouter:gryphe/mythomax-l2-13b",
-    "OpenRouter": "gryphe/mythomax-l2-13b",
-    "Yupp": "gryphe/mythomax-l2-13b"
-  },
-  "granite-4.0-h-micro": {
-    "PuterJS": "openrouter:ibm-granite/granite-4.0-h-micro",
-    "OpenRouter": "ibm-granite/granite-4.0-h-micro"
-  },
-  "mercury-coder": {
-    "PuterJS": "openrouter:inception/mercury-coder",
-    "ApiAirforce": "mercury-coder",
-    "OpenRouter": "inception/mercury-coder"
-  },
-  "lfm-2.2-6b": {
-    "PuterJS": "openrouter:liquid/lfm-2.2-6b",
-    "OpenRouter": "liquid/lfm-2.2-6b"
-  },
-  "lfm2-8b-a1b": {
-    "PuterJS": "openrouter:liquid/lfm2-8b-a1b",
-    "OpenRouter": "liquid/lfm2-8b-a1b"
-  },
-  "weaver": {
-    "PuterJS": "openrouter:mancer/weaver",
-    "OpenRouter": "mancer/weaver"
-  },
-  "llama-3.2-90b-vision": {
-    "PuterJS": "openrouter:meta-llama/llama-3.2-90b-vision-instruct",
-    "Nvidia": "meta/llama-3.2-90b-vision-instruct",
-    "GlhfChat": "hf:meta-llama/Llama-3.2-90B-Vision-Instruct",
-    "OpenRouter": "meta-llama/llama-3.2-90b-vision-instruct"
-  },
-  "llama-guard-2-8b": {
-    "PuterJS": "openrouter:meta-llama/llama-guard-2-8b",
-    "OpenRouter": "meta-llama/llama-guard-2-8b"
-  },
-  "llama-guard-3-8b": {
-    "PuterJS": "openrouter:meta-llama/llama-guard-3-8b",
-    "HuggingFaceAPI": "meta-llama/Llama-Guard-3-8B",
-    "OpenRouter": "meta-llama/llama-guard-3-8b"
-  },
-  "minimax-01": {
-    "PuterJS": "openrouter:minimax/minimax-01",
-    "OpenRouter": "minimax/minimax-01"
-  },
-  "devstral-medium": {
-    "PuterJS": "openrouter:mistralai/devstral-medium",
-    "OpenRouter": "mistralai/devstral-medium",
-    "Yupp": "devstral-medium-latest"
-  },
-  "devstral-small": {
-    "PuterJS": "openrouter:mistralai/devstral-small",
-    "OpenRouter": "mistralai/devstral-small"
-  },
-  "devstral-small-2505": {
-    "PuterJS": "openrouter:mistralai/devstral-small-2505",
-    "OpenRouter": "mistralai/devstral-small-2505"
-  },
-  "ministral-3b": {
-    "PuterJS": "openrouter:mistralai/ministral-3b",
-    "OpenRouter": "mistralai/ministral-3b"
-  },
-  "ministral-8b": {
-    "PuterJS": "openrouter:mistralai/ministral-8b",
-    "OpenRouter": "mistralai/ministral-8b"
-  },
-  "mistral-7b-v0.1": {
-    "PuterJS": "openrouter:mistralai/mistral-7b-instruct-v0.1",
-    "OpenRouter": "mistralai/mistral-7b-instruct-v0.1"
-  },
-  "mistral-7b-v0.2": {
-    "PuterJS": "openrouter:mistralai/mistral-7b-instruct-v0.2",
-    "HuggingFaceAPI": "mistralai/Mistral-7B-Instruct-v0.2",
-    "Nvidia": "mistralai/mistral-7b-instruct-v0.2",
-    "OpenRouter": "mistralai/mistral-7b-instruct-v0.2"
-  },
-  "mistral-7b-v0.3": {
-    "PuterJS": "openrouter:mistralai/mistral-7b-instruct-v0.3",
-    "HuggingFaceAPI": "mistralai/Mistral-7B-Instruct-v0.3",
-    "Nvidia": "mistralai/mistral-7b-instruct-v0.3",
-    "GlhfChat": "hf:mistralai/Mistral-7B-Instruct-v0.3",
-    "OpenRouter": "mistralai/mistral-7b-instruct-v0.3"
-  },
-  "mistral-large-2407": {
-    "PuterJS": "openrouter:mistralai/mistral-large-2407",
-    "OpenRouter": "mistralai/mistral-large-2407"
-  },
-  "mistral-large-2411": {
-    "PuterJS": "openrouter:mistralai/mistral-large-2411",
-    "OpenRouter": "mistralai/mistral-large-2411"
-  },
-  "mistral-large-2512": {
-    "PuterJS": "openrouter:mistralai/mistral-large-2512",
-    "OpenRouter": "mistralai/mistral-large-2512",
-    "Yupp": "mistral-large-2512"
-  },
-  "mistral-medium-3": {
-    "PuterJS": "openrouter:mistralai/mistral-medium-3",
-    "Nvidia": "mistralai/mistral-medium-3-instruct",
-    "OpenRouter": "mistralai/mistral-medium-3"
-  },
-  "mistral-medium-3.1": {
-    "PuterJS": "openrouter:mistralai/mistral-medium-3.1",
-    "OpenRouter": "mistralai/mistral-medium-3.1"
-  },
-  "mistral-saba": {
-    "PuterJS": "openrouter:mistralai/mistral-saba",
-    "OpenRouter": "mistralai/mistral-saba",
-    "Yupp": "mistral-saba-latest"
-  },
-  "mistral-small-24b-2501": {
-    "PuterJS": "openrouter:mistralai/mistral-small-24b-instruct-2501",
-    "HuggingFaceAPI": "mistralai/Mistral-Small-24B-Instruct-2501",
-    "OpenRouter": "mistralai/mistral-small-24b-instruct-2501"
-  },
-  "mistral-small-3.2-24b": {
-    "PuterJS": "openrouter:mistralai/mistral-small-3.2-24b-instruct",
-    "OpenRouter": "mistralai/mistral-small-3.2-24b-instruct"
-  },
-  "mistral-small-creative": {
-    "PuterJS": "openrouter:mistralai/mistral-small-creative",
-    "ApiAirforce": "mistral-small-creative",
-    "OpenRouter": "mistralai/mistral-small-creative"
-  },
-  "mistral-tiny": {
-    "PuterJS": "openrouter:mistralai/mistral-tiny",
-    "OpenRouter": "mistralai/mistral-tiny",
-    "Yupp": "mistral-tiny-latest"
-  },
-  "pixtral-12b": {
-    "PuterJS": "openrouter:mistralai/pixtral-12b",
-    "OpenRouter": "mistralai/pixtral-12b",
-    "Yupp": "pixtral-12b-latest"
-  },
-  "voxtral-small-24b-2507": {
-    "PuterJS": "openrouter:mistralai/voxtral-small-24b-2507",
-    "OpenRouter": "mistralai/voxtral-small-24b-2507"
-  },
-  "kimi-dev-72b": {
-    "PuterJS": "openrouter:moonshotai/kimi-dev-72b",
-    "HuggingFaceAPI": "moonshotai/Kimi-Dev-72B",
-    "OpenRouter": "moonshotai/kimi-dev-72b"
-  },
-  "morph-v3-fast": {
-    "PuterJS": "openrouter:morph/morph-v3-fast",
-    "OpenRouter": "morph/morph-v3-fast"
-  },
-  "morph-v3-large": {
-    "PuterJS": "openrouter:morph/morph-v3-large",
-    "OpenRouter": "morph/morph-v3-large"
-  },
-  "llama-3.1-lumimaid-8b": {
-    "PuterJS": "openrouter:neversleep/llama-3.1-lumimaid-8b",
-    "OpenRouter": "neversleep/llama-3.1-lumimaid-8b"
-  },
-  "noromaid-20b": {
-    "PuterJS": "openrouter:neversleep/noromaid-20b",
-    "OpenRouter": "neversleep/noromaid-20b"
-  },
-  "deepseek-v3.1-nex-n1": {
-    "PuterJS": "openrouter:nex-agi/deepseek-v3.1-nex-n1",
-    "OpenRouter": "nex-agi/deepseek-v3.1-nex-n1"
-  },
-  "deephermes-3-mistral-24b": {
-    "PuterJS": "openrouter:nousresearch/deephermes-3-mistral-24b-preview",
-    "OpenRouter": "nousresearch/deephermes-3-mistral-24b-preview"
-  },
-  "hermes-2-pro-llama-3-8b": {
-    "PuterJS": "openrouter:nousresearch/hermes-2-pro-llama-3-8b",
-    "HuggingFaceAPI": "NousResearch/Hermes-2-Pro-Llama-3-8B",
-    "HuggingChat": "NousResearch/Hermes-2-Pro-Llama-3-8B",
-    "OpenRouter": "nousresearch/hermes-2-pro-llama-3-8b"
-  },
-  "hermes-3-llama-3.1-70b": {
-    "PuterJS": "openrouter:nousresearch/hermes-3-llama-3.1-70b",
-    "OpenRouter": "nousresearch/hermes-3-llama-3.1-70b"
-  },
-  "hermes-4-405b": {
-    "PuterJS": "openrouter:nousresearch/hermes-4-405b",
-    "HuggingChat": "NousResearch/Hermes-4-405B",
-    "OpenRouter": "nousresearch/hermes-4-405b"
-  },
-  "hermes-4-70b": {
-    "PuterJS": "openrouter:nousresearch/hermes-4-70b",
-    "HuggingFaceAPI": "NousResearch/Hermes-4-70B",
-    "HuggingChat": "NousResearch/Hermes-4-70B",
-    "OpenRouter": "nousresearch/hermes-4-70b"
-  },
-  "llama-3.1-nemotron-ultra-253b": {
-    "PuterJS": "openrouter:nvidia/llama-3.1-nemotron-ultra-253b-v1",
-    "Nvidia": "nvidia/llama-3.1-nemotron-ultra-253b-v1",
-    "HuggingChat": "nvidia/Llama-3_1-Nemotron-Ultra-253B-v1",
-    "OpenRouter": "nvidia/llama-3.1-nemotron-ultra-253b-v1"
-  },
-  "llama-3.3-nemotron-super-49b-v1.5": {
-    "PuterJS": "openrouter:nvidia/llama-3.3-nemotron-super-49b-v1.5",
-    "Nvidia": "nvidia/llama-3.3-nemotron-super-49b-v1.5",
-    "OpenRouter": "nvidia/llama-3.3-nemotron-super-49b-v1.5"
-  },
-  "codex-mini": {
-    "PuterJS": "openrouter:openai/codex-mini",
-    "OpenRouter": "openai/codex-mini",
-    "Yupp": "codex-mini-latest"
-  },
-  "gpt-3.5-turbo": {
-    "PuterJS": "openrouter:openai/gpt-3.5-turbo-instruct",
-    "OpenRouter": "openai/gpt-3.5-turbo-instruct"
-  },
-  "gpt-3.5-turbo-0613": {
-    "PuterJS": "openrouter:openai/gpt-3.5-turbo-0613",
-    "OpenRouter": "openai/gpt-3.5-turbo-0613"
-  },
-  "gpt-3.5-turbo-16k": {
-    "PuterJS": "openrouter:openai/gpt-3.5-turbo-16k",
-    "OpenRouter": "openai/gpt-3.5-turbo-16k"
-  },
-  "gpt-4-0314": {
-    "PuterJS": "openrouter:openai/gpt-4-0314",
-    "OpenRouter": "openai/gpt-4-0314"
-  },
-  "gpt-4-1106": {
-    "PuterJS": "openrouter:openai/gpt-4-1106-preview",
-    "OpenRouter": "openai/gpt-4-1106-preview",
-    "Yupp": "gpt-4-1106-preview"
-  },
-  "gpt-4-turbo": {
-    "PuterJS": "openrouter:openai/gpt-4-turbo-preview",
-    "OpenRouter": "openai/gpt-4-turbo-preview",
-    "Yupp": "gpt-4-turbo"
-  },
-  "gpt-4o-audio": {
-    "PuterJS": "openrouter:openai/gpt-4o-audio-preview",
-    "OpenRouter": "openai/gpt-4o-audio-preview"
-  },
-  "gpt-4o-mini-search": {
-    "PuterJS": "openrouter:openai/gpt-4o-mini-search-preview",
-    "OpenRouter": "openai/gpt-4o-mini-search-preview",
-    "Yupp": "gpt-4o-mini-search-preview-2025-03-11"
-  },
-  "gpt-4o-search": {
-    "PuterJS": "openrouter:openai/gpt-4o-search-preview",
-    "OpenRouter": "openai/gpt-4o-search-preview",
-    "Yupp": "gpt-4o-search-preview-2025-03-11"
-  },
-  "gpt-5-codex": {
-    "PuterJS": "openrouter:openai/gpt-5-codex",
-    "OpenRouter": "openai/gpt-5-codex"
-  },
-  "gpt-5-image": {
-    "PuterJS": "openrouter:openai/gpt-5-image",
-    "OpenRouter": "openai/gpt-5-image"
-  },
-  "gpt-5-image-mini": {
-    "PuterJS": "openrouter:openai/gpt-5-image-mini",
-    "OpenRouter": "openai/gpt-5-image-mini"
-  },
-  "gpt-5-pro": {
-    "PuterJS": "openrouter:openai/gpt-5-pro",
-    "OpenRouter": "openai/gpt-5-pro"
-  },
-  "gpt-oss-safeguard-20b": {
-    "PuterJS": "openrouter:openai/gpt-oss-safeguard-20b",
-    "HuggingFaceAPI": "openai/gpt-oss-safeguard-20b",
-    "Groq": "openai/gpt-oss-safeguard-20b",
-    "HuggingChat": "openai/gpt-oss-safeguard-20b",
-    "OpenRouter": "openai/gpt-oss-safeguard-20b"
-  },
-  "o3-deep-research": {
-    "PuterJS": "openrouter:openai/o3-deep-research",
-    "OpenRouter": "openai/o3-deep-research"
-  },
-  "o4-mini-deep-research": {
-    "PuterJS": "openrouter:openai/o4-mini-deep-research",
-    "OpenRouter": "openai/o4-mini-deep-research"
-  },
-  "internvl3-78b": {
-    "PuterJS": "openrouter:opengvlab/internvl3-78b",
-    "OpenRouter": "opengvlab/internvl3-78b"
-  },
-  "bodybuilder": {
-    "PuterJS": "openrouter:openrouter/bodybuilder",
-    "OpenRouter": "openrouter/bodybuilder"
-  },
-  "sonar-pro-search": {
-    "PuterJS": "openrouter:perplexity/sonar-pro-search",
-    "OpenRouter": "perplexity/sonar-pro-search"
-  },
-  "qwen-3-30b-a3b-thinking-2507": {
-    "PuterJS": "openrouter:qwen/qwen3-30b-a3b-thinking-2507",
-    "HuggingFaceAPI": "Qwen/Qwen3-30B-A3B-Thinking-2507",
-    "HuggingChat": "Qwen/Qwen3-30B-A3B-Thinking-2507",
-    "OpenRouter": "qwen/qwen3-30b-a3b-thinking-2507",
-    "Yupp": "qwen3-30b-a3b-thinking-2507"
-  },
-  "qwen-3-coder-flash": {
-    "PuterJS": "openrouter:qwen/qwen3-coder-flash",
-    "OpenRouter": "qwen/qwen3-coder-flash"
-  },
-  "qwen-3-vl-30b-a3b": {
-    "PuterJS": "openrouter:qwen/qwen3-vl-30b-a3b-instruct",
-    "HuggingFaceAPI": "Qwen/Qwen3-VL-30B-A3B-Instruct",
-    "HuggingChat": "Qwen/Qwen3-VL-30B-A3B-Instruct",
-    "OpenRouter": "qwen/qwen3-vl-30b-a3b-instruct",
-    "Yupp": "qwen3-vl-30b-a3b-instruct"
-  },
-  "qwen-3-vl-30b-a3b-thinking": {
-    "PuterJS": "openrouter:qwen/qwen3-vl-30b-a3b-thinking",
-    "HuggingFaceAPI": "Qwen/Qwen3-VL-30B-A3B-Thinking",
-    "HuggingChat": "Qwen/Qwen3-VL-30B-A3B-Thinking",
-    "OpenRouter": "qwen/qwen3-vl-30b-a3b-thinking",
-    "Yupp": "qwen3-vl-30b-a3b-thinking"
-  },
-  "qwen-3-vl-32b": {
-    "PuterJS": "openrouter:qwen/qwen3-vl-32b-instruct",
-    "HuggingFaceAPI": "Qwen/Qwen3-VL-32B-Instruct",
-    "HuggingChat": "Qwen/Qwen3-VL-32B-Instruct",
-    "OpenRouter": "qwen/qwen3-vl-32b-instruct"
-  },
-  "sorcererlm-8x22b": {
-    "PuterJS": "openrouter:raifle/sorcererlm-8x22b",
-    "OpenRouter": "raifle/sorcererlm-8x22b"
-  },
-  "relace-apply-3": {
-    "PuterJS": "openrouter:relace/relace-apply-3",
-    "OpenRouter": "relace/relace-apply-3"
-  },
-  "relace-search": {
-    "PuterJS": "openrouter:relace/relace-search",
-    "OpenRouter": "relace/relace-search"
-  },
-  "l3-euryale-70b": {
-    "PuterJS": "openrouter:sao10k/l3-euryale-70b",
-    "OpenRouter": "sao10k/l3-euryale-70b"
-  },
-  "l3-lunaris-8b": {
-    "PuterJS": "openrouter:sao10k/l3-lunaris-8b",
-    "OpenRouter": "sao10k/l3-lunaris-8b"
-  },
-  "l3.1-70b-hanami-x1": {
-    "PuterJS": "openrouter:sao10k/l3.1-70b-hanami-x1",
-    "OpenRouter": "sao10k/l3.1-70b-hanami-x1"
-  },
-  "l3.1-euryale-70b": {
-    "PuterJS": "openrouter:sao10k/l3.1-euryale-70b",
-    "OpenRouter": "sao10k/l3.1-euryale-70b"
-  },
-  "l3.3-euryale-70b": {
-    "PuterJS": "openrouter:sao10k/l3.3-euryale-70b",
-    "OpenRouter": "sao10k/l3.3-euryale-70b"
-  },
-  "step3": {
-    "PuterJS": "openrouter:stepfun-ai/step3",
-    "OpenRouter": "stepfun-ai/step3"
-  },
-  "router": {
-    "PuterJS": "openrouter:switchpoint/router",
-    "OpenRouter": "switchpoint/router"
-  },
-  "hunyuan-a13b": {
-    "PuterJS": "openrouter:tencent/hunyuan-a13b-instruct",
-    "OpenRouter": "tencent/hunyuan-a13b-instruct"
-  },
-  "cydonia-24b-v4.1": {
-    "PuterJS": "openrouter:thedrummer/cydonia-24b-v4.1",
-    "OpenRouter": "thedrummer/cydonia-24b-v4.1"
-  },
-  "rocinante-12b": {
-    "PuterJS": "openrouter:thedrummer/rocinante-12b",
-    "OpenRouter": "thedrummer/rocinante-12b"
-  },
-  "skyfall-36b": {
-    "PuterJS": "openrouter:thedrummer/skyfall-36b-v2",
-    "OpenRouter": "thedrummer/skyfall-36b-v2"
-  },
-  "unslopnemo-12b": {
-    "PuterJS": "openrouter:thedrummer/unslopnemo-12b",
-    "OpenRouter": "thedrummer/unslopnemo-12b"
-  },
-  "glm-4.1v-9b-thinking": {
-    "PuterJS": "openrouter:thudm/glm-4.1v-9b-thinking",
-    "HuggingChat": "zai-org/GLM-4.1V-9B-Thinking",
-    "OpenRouter": "thudm/glm-4.1v-9b-thinking"
-  },
-  "remm-slerp-l2-13b": {
-    "PuterJS": "openrouter:undi95/remm-slerp-l2-13b",
-    "OpenRouter": "undi95/remm-slerp-l2-13b"
-  },
-  "grok-4-fast": {
-    "PuterJS": "openrouter:x-ai/grok-4-fast",
-    "OpenRouter": "x-ai/grok-4-fast"
-  },
-  "grok-4.1-fast": {
-    "PuterJS": "openrouter:x-ai/grok-4.1-fast",
-    "OpenRouter": "x-ai/grok-4.1-fast"
-  },
-  "grok-code-fast-1": {
-    "PuterJS": "openrouter:x-ai/grok-code-fast-1",
-    "OpenRouter": "x-ai/grok-code-fast-1"
+  "command-a25": {
+    "HuggingSpace": "command-a-03-2025",
+    "CohereForAI_C4AI_Command": "command-a-03-2025",
+    "HuggingChat": "CohereLabs/c4ai-command-a-03-2025"
   },
   "command-r7b-arabic25": {
     "HuggingSpace": "command-r7b-arabic-02-2025",
-    "Cohere": "command-r7b-arabic-02-2025",
     "CohereForAI_C4AI_Command": "command-r7b-arabic-02-2025",
-    "HuggingChat": "CohereLabs/c4ai-command-r7b-arabic-02-2025",
-    "Yupp": "command-r7b-arabic-02-2025"
+    "HuggingChat": "CohereLabs/c4ai-command-r7b-arabic-02-2025"
   },
   "flux-kontext-dev": {
     "HuggingSpace": "flux-kontext-dev",
     "BlackForestLabs_Flux1KontextDev": "flux-kontext-dev"
-  },
-  "janus-pro-7b-image": {
-    "HuggingSpace": "janus-pro-7b-image",
-    "DeepseekAI_JanusPro7b": "janus-pro-7b-image"
-  },
-  "ling": {
-    "HuggingSpace": "ling-1t",
-    "BAAI_Ling": "ling-1t"
-  },
-  "ling-mini-2.0": {
-    "HuggingSpace": "ling-mini-2.0",
-    "BAAI_Ling": "ling-mini-2.0"
-  },
-  "ring-mini-2.0": {
-    "HuggingSpace": "ring-mini-2.0",
-    "BAAI_Ling": "ring-mini-2.0"
-  },
-  "perplexity": {
-    "Perplexity": "perplexity"
   },
   "pplx_pro": {
     "Perplexity": "pplx_pro"
@@ -3613,718 +4277,453 @@ model_map = {
   }
 }
 models_count = {
-  "default": 15,
-  "gpt-4": 8,
-  "gpt-4o": 9,
-  "gpt-4o-mini": 6,
+  "default": 11,
+  "gpt-4": 10,
+  "gpt-4o": 8,
+  "gpt-4o-mini": 5,
+  "gpt-4o-mini-tts": 2,
   "o1": 9,
-  "o1-mini": 4,
+  "o1-mini": 3,
   "o3-mini": 6,
   "o3-mini-high": 4,
-  "o4-mini": 7,
+  "o4-mini": 5,
   "o4-mini-high": 3,
-  "gpt-4.1": 7,
-  "gpt-4.1-mini": 5,
+  "gpt-4.1": 5,
+  "gpt-4.1-mini": 4,
   "gpt-4.1-nano": 4,
   "gpt-4.5": 2,
-  "gpt-oss-120b": 15,
-  "dall-e-3": 7,
+  "gpt-oss-120b": 10,
+  "smart": 3,
+  "reasoning": 2,
+  "study": 4,
+  "search": 3,
+  "dall-e-3": 6,
   "gpt-image": 3,
-  "llama-2-7b": 2,
-  "llama-2-70b": 3,
-  "llama-3-8b": 7,
-  "llama-3-70b": 8,
-  "llama-3.1-8b": 11,
-  "llama-3.1-70b": 9,
-  "llama-3.1-405b": 6,
-  "llama-3.2-1b": 6,
-  "llama-3.2-3b": 9,
+  "meta-ai": 2,
+  "llama-2-70b": 2,
+  "llama-3-8b": 6,
+  "llama-3-70b": 5,
+  "llama-3.1-8b": 8,
+  "llama-3.1-70b": 6,
+  "llama-3.1-405b": 3,
+  "llama-3.2-3b": 6,
   "llama-3.2-11b": 5,
-  "llama-3.2-90b": 3,
-  "llama-3.3-70b": 13,
-  "llama-4-scout": 6,
-  "llama-4-maverick": 5,
-  "mistral-7b": 4,
-  "mixtral-8x7b": 4,
+  "llama-3.2-90b": 2,
+  "llama-3.3-70b": 9,
+  "llama-4-scout": 4,
+  "llama-4-maverick": 4,
   "mistral-nemo": 5,
-  "mistral-small-24b": 2,
-  "mistral-small-3.1-24b": 5,
+  "mistral-small-3.1-24b": 3,
   "hermes-2-dpo": 2,
-  "phi-4": 6,
-  "phi-4-multimodal": 7,
-  "phi-4-reasoning-plus": 3,
-  "wizardlm-2-8x22b": 5,
-  "gemini-1.5-flash": 2,
-  "gemini-1.5-pro": 2,
-  "gemini-2.0-flash": 8,
+  "phi-3.5-mini": 4,
+  "gemini-2.0-flash": 4,
   "gemini-2.0-flash-thinking": 2,
-  "gemini-2.5-flash": 9,
-  "gemini-2.5-pro": 10,
-  "gemma-2-9b": 2,
-  "gemma-2-27b": 6,
-  "gemma-3-4b": 2,
-  "gemma-3-12b": 2,
-  "gemma-3-27b": 3,
-  "command-r": 3,
+  "gemini-2.5-flash": 8,
+  "gemini-2.5-pro": 9,
+  "gemini-3.1-pro": 6,
+  "gemini-3.1-flash-lite": 6,
+  "gemini-3.5-flash": 6,
+  "gemma-2-27b": 5,
+  "gemma-3-27b": 2,
+  "command-r": 4,
   "command-r-plus": 7,
   "command-r7b": 3,
   "command-a": 4,
-  "qwen-1.5-7b": 3,
-  "qwen-2-72b": 7,
+  "qwen-2-72b": 5,
   "qwen-2-vl-7b": 3,
-  "qwen-2.5-7b": 8,
-  "qwen-2.5-72b": 9,
-  "qwen-2.5-coder-32b": 11,
-  "qwen-2.5-max": 2,
-  "qwen-2.5-vl-72b": 6,
-  "qwen-3-235b": 7,
-  "qwen-3-32b": 9,
-  "qwen-3-30b": 4,
-  "qwen-3-14b": 7,
-  "qwen-3-4b": 5,
-  "qwen-3-1.7b": 4,
-  "qwen-3-0.6b": 3,
-  "qwq-32b": 12,
-  "deepseek-v3": 4,
-  "deepseek-r1": 13,
-  "deepseek-r1-distill-llama-70b": 8,
-  "deepseek-r1-distill-qwen-1.5b": 4,
-  "deepseek-r1-distill-qwen-14b": 6,
-  "deepseek-r1-distill-qwen-32b": 7,
-  "deepseek-prover-v2": 2,
-  "deepseek-v3-0324": 4,
-  "deepseek-r1-0528": 7,
-  "janus-pro-7b": 2,
+  "qwen-2.5-7b": 7,
+  "qwen-2.5-72b": 7,
+  "qwen-2.5-coder-32b": 8,
+  "qwen-2.5-vl-72b": 5,
+  "qwen-3-235b": 2,
+  "qwen-3-32b": 6,
+  "qwq-32b": 7,
+  "deepseek-v3": 2,
+  "deepseek-r1": 12,
+  "deepseek-r1-distill-llama-70b": 5,
+  "deepseek-r1-distill-qwen-1.5b": 3,
+  "deepseek-r1-distill-qwen-14b": 3,
   "grok-2": 2,
-  "grok-3": 4,
-  "grok-3-mini": 3,
-  "kimi-k2": 12,
-  "sonar": 4,
+  "grok-3": 3,
+  "kimi-k2": 7,
+  "sonar": 3,
   "sonar-pro": 3,
   "sonar-reasoning": 2,
   "sonar-reasoning-pro": 3,
   "r1-1776": 3,
   "nemotron-70b": 5,
-  "lfm-40b": 3,
   "sdxl-turbo": 5,
-  "sd-3.5-large": 6,
+  "sd-3.5-large": 5,
   "flux": 8,
   "flux-pro": 3,
-  "flux-dev": 9,
-  "flux-schnell": 7,
-  "flux-kontext": 4,
-  "grok-3-mini-high": 2,
-  "chatgpt-4o-latest": 3,
-  "amazon-nova-lite-v1.0": 2,
-  "gemini-exp-1206": 2,
-  "grok-2-mini": 2,
-  "gemini-exp-1114": 2,
-  "llama-3.1-nemotron-70b": 5,
-  "qwen-plus-0125": 2,
-  "aya-expanse-8b": 2,
-  "granite-3.0-8b": 2,
-  "claude-3-5-sonnet": 3,
-  "glm-4-plus": 2,
-  "gemma-1.1-7b-it": 2,
-  "glm-4-0116": 2,
-  "gemini-1.5-flash-002": 2,
-  "command-r24": 8,
-  "olmo-7b": 2,
-  "qwen2.5-plus-1127": 2,
-  "llama-3.1-nemotron-51b": 2,
-  "gpt-4-0125": 2,
-  "gemma-3-12b-it": 7,
-  "oasst-pythia-12b": 2,
-  "fastchat-t5-3b": 2,
-  "claude-3-opus": 3,
-  "claude-instant-1": 2,
-  "claude-2.0": 3,
-  "deepseek-v2.5": 2,
-  "ministral-8b-2410": 3,
-  "mistral-next": 2,
-  "mistral-7b-instruct-v0.2": 3,
-  "claude-2.1": 3,
-  "gemma-2-9b-it": 6,
-  "deepseek": 7,
-  "gemini-2.0-flash-thinking-exp-1219": 2,
-  "internlm2.5-20b": 2,
-  "gemini-2.0-flash-thinking-exp": 3,
-  "claude-1": 2,
-  "claude-3-sonnet": 2,
-  "yi-1.5-34b": 2,
-  "guanaco-33b": 2,
-  "gemini-1.5-pro-001": 2,
-  "gemini-2.0-flash-lite": 3,
-  "mistral-large-2407": 2,
-  "gemma-2-2b-it": 4,
-  "glm-4-0520": 2,
-  "mistral-medium": 2,
-  "amazon-nova-micro-v1.0": 2,
-  "gpt-4-0314": 2,
-  "gemma-2b-it": 2,
-  "gemini-2.0-flash-001": 3,
-  "nemotron-4-340b": 2,
-  "llama-4-maverick-17b-128e": 5,
-  "gpt-3.5-turbo-1106": 2,
-  "gpt-3.5-turbo-0314": 2,
-  "reka-core": 2,
-  "llama-4-scout-17b-16e": 4,
-  "mistral-large-2402": 2,
-  "koala-13b": 2,
-  "gemma-3-27b-it": 10,
-  "snowflake-arctic": 2,
-  "smollm2-1.7b": 2,
-  "gemini-1.5-pro-exp-0801": 2,
-  "llama-3.1-tulu-3-70b": 2,
-  "phi-3-mini-128k": 2,
-  "claude-3-7-sonnet": 4,
-  "wizardlm-13b": 2,
-  "deepseek-v2.5-1210": 2,
-  "pplx-7b-online": 2,
-  "llama-13b": 2,
-  "bard-jan-24-gemini-pro": 2,
-  "gemini-pro": 2,
-  "reka-flash": 3,
-  "phi-3-small-8k": 2,
-  "qwen-3235b-a22b": 5,
-  "claude-3-haiku": 4,
-  "gemma-2-27b-it": 4,
-  "gpt-4-1106": 3,
-  "mpt-30b": 2,
-  "chatglm3-6b": 2,
-  "deepseek-coder-v2-0724": 2,
-  "mistral-small-24b-instruct-2501": 2,
-  "dolly-v2-12b": 2,
-  "gemma-3-4b-it": 6,
-  "gemini-1.5-pro-exp-0827": 2,
-  "yi-lightning": 2,
-  "qwen1.5-110b": 2,
-  "claude-3-7-sonnet-20250219-thinking-32k": 3,
-  "jamba-1.5-mini": 2,
-  "palm-2": 2,
-  "llama-3.1-405b-instruct": 2,
-  "granite-3.1-2b": 2,
-  "pplx-70b-online": 2,
-  "athene-v2": 2,
-  "yi-large": 2,
-  "athene-70b-0725": 2,
-  "qwen1.5-32b": 2,
-  "mixtral-8x7b-instruct-v0.1": 2,
-  "gemma-1.1-2b-it": 2,
-  "qwen2.5-coder-32b": 4,
-  "stripedhyena-nous-7b": 2,
-  "phi-3-medium-4k": 2,
-  "starling-lm-7b-alpha": 2,
-  "mixtral-8x22b-instruct-v0.1": 2,
-  "qwen1.5-14b": 2,
-  "alpaca-13b": 2,
-  "qwen-max-0919": 2,
-  "gemini-1.5-flash-001": 2,
-  "granite-3.0-2b": 2,
-  "gemini-2.0-pro-exp": 2,
-  "gemma-7b-it": 2,
-  "gemini-1.5-pro-api-0409": 2,
-  "reka-flash-21b-20240226-online": 2,
-  "qwen-14b": 3,
-  "openchat-3.5": 2,
-  "vicuna-33b": 2,
-  "deepseek-llm-67b": 2,
-  "claude-3-5-haiku": 3,
-  "gemini-1.5-flash-8b-001": 2,
-  "gpt-3.5-turbo-0125": 2,
-  "chatglm2-6b": 2,
-  "zephyr-orpo-141b-a35b-v0.1": 2,
-  "gemini-advanced-0514": 2,
-  "gemma-2-9b-it-simpo": 2,
-  "gpt-4-turbo": 3,
-  "mistral-large-2411": 2,
-  "deepseek-coder": 2,
-  "falcon-180b": 2,
-  "yi-34b": 2,
-  "gemini-1.5-pro-002": 2,
-  "openhermes-2.5-mistral-7b": 3,
-  "solar-10.7b-instruct-v1.0": 2,
-  "zephyr-7b-alpha": 2,
-  "codellama-70b": 2,
-  "vicuna-13b": 2,
-  "qwen-plus-0828": 2,
-  "glm-4-plus-0111": 2,
-  "hunyuan-standard-256k": 2,
-  "jamba-1.5-large": 2,
-  "wizardlm-70b": 2,
-  "gemini-exp-1121": 2,
-  "gemini-2.0-flash-exp": 3,
-  "qwen1.5-72b": 2,
-  "gemini-1.5-flash-8b-exp-0827": 2,
-  "zephyr-7b-beta": 2,
-  "qwen1.5-7b": 2,
-  "codellama-34b": 3,
-  "o3": 5,
-  "rwkv-4-raven-14b": 2,
-  "chatglm-6b": 2,
-  "deepseek-v2-api-0628": 2,
-  "llama2-70b-steerlm": 2,
-  "openchat-3.5-0106": 3,
-  "qwen-max-0428": 2,
-  "phi-3-mini-4k": 2,
-  "gemini-pro-dev-api": 2,
-  "stablelm-tuned-alpha-7b": 2,
-  "mistral-medium-2505": 2,
-  "phi-3-mini-4k-instruct-june-2024": 2,
-  "amazon-nova-pro-v1.0": 2,
-  "qwen2.5-72b": 3,
-  "granite-3.1-8b": 2,
-  "gemini-1.5-flash-exp-0827": 2,
-  "gpt-4-0613": 2,
-  "tulu-2-dpo-70b": 2,
-  "vicuna-7b": 2,
-  "gpt4all-13b-snoozy": 2,
-  "aya-expanse-32b": 2,
-  "llama-3.1-tulu-3-8b": 2,
-  "dbrx-instruct": 2,
-  "qwen2.5-max": 2,
-  "dolphin-2.2.1-mistral-7b": 2,
-  "step-2-16k-exp-202412": 2,
-  "command-r-plus24": 7,
-  "yi-lightning-lite": 2,
-  "reka-flash-21b": 2,
-  "mpt-7b": 2,
-  "llama-2-13b": 2,
-  "gpt-3.5-turbo-0613": 2,
-  "starling-lm-7b-beta": 3,
-  "qwen1.5-4b": 2,
-  "nous-hermes-2-mixtral-8x7b-dpo": 2,
-  "qwen-272b": 2,
-  "early-grok-3": 2,
-  "claude-3.7-sonnet": 4,
-  "claude-3.7-sonnet-thinking": 2,
-  "gemini-2.0-pro": 2,
+  "flux-dev": 8,
+  "flux-schnell": 6,
+  "flux-kontext": 2,
+  "auto": 2,
+  "gpt-5.2": 6,
+  "gpt-5.1": 5,
+  "gpt-5": 9,
+  "gpt-5-thinking": 2,
+  "gpt-5.4": 4,
+  "gpt-5.4-mini": 4,
+  "mercury": 2,
+  "qwen-coder": 2,
+  "mistral": 2,
+  "gemini-3-flash": 8,
+  "deepseek": 9,
+  "gemma": 3,
+  "grok": 3,
+  "grok-4-20-reasoning": 2,
+  "claude-opus-4.6": 3,
+  "claude-opus-4.7": 3,
+  "perplexity": 2,
+  "kimi": 3,
+  "nova": 2,
+  "minimax-m2.7": 10,
+  "minimax": 3,
+  "mistral-large": 2,
+  "step-3.5-flash": 8,
+  "grok-4": 4,
+  "grok-3-mini": 3,
+  "qwen-3.7-plus": 4,
+  "qwen-3.7-max": 4,
+  "qwen-3.6-plus": 4,
+  "qwen-3.6-max": 3,
+  "qwen-3.6-27b": 6,
+  "qwen-3.5-plus": 3,
+  "qwen-3.6-35b-a3b": 7,
+  "qwen-3.5-flash": 4,
+  "qwen-3.5-397b-a17b": 8,
+  "qwen-3.5-122b-a10b": 6,
+  "qwen-3.5-27b": 6,
+  "qwen-3.5-35b-a3b": 6,
+  "qwen-3-max": 6,
   "qwen-plus": 4,
-  "claude-3.5-sonnet": 3,
-  "qwen-2.5-plus": 2,
-  "qwen-max": 4,
-  "qwen-2.5-vl-32b": 5,
-  "nemotron-49b": 3,
-  "mistral-large": 3,
-  "pixtral-large": 2,
-  "nemotron-253b": 3,
-  "tulu-3-70b": 2,
-  "claude-3.5-haiku": 2,
-  "deepseek-v2": 2,
-  "deepseek-coder-v2": 2,
-  "nemotron-51b": 2,
-  "glm-4": 3,
-  "tulu-3-8b": 2,
-  "codestral": 2,
-  "qwen-1.5-110b": 2,
-  "qwen-1.5-72b": 2,
-  "gemma-2-2b": 2,
-  "qwen-vl-max": 4,
-  "mixtral-8x22b": 2,
-  "qwen-1.5-32b": 2,
-  "qwen-1.5-14b": 3,
-  "qwen-1.5-4b": 2,
-  "phi-3-medium": 3,
-  "phi-3-small": 2,
-  "phi-3-mini": 3,
-  "tulu-2-70b": 2,
-  "deepseek-67b": 2,
-  "openhermes-2.5-7b": 2,
-  "gpt-3.5-turbo": 2,
-  "llama-3.3-70b-instruct": 4,
-  "llama-4-maverick-17b-128e-instruct": 5,
-  "qwen-332b": 3,
-  "hermes-3-405b": 1,
-  "gpt-oss-20b": 12,
-  "glm-4.5": 6,
-  "qwen-3235b-a22b-thinking-2507": 2,
-  "qwen-3coder-480b-a35b": 2,
-  "glm-4.5-air": 7,
-  "qwen-3235b-a22b-instruct-2507": 2,
-  "qwen-330b-a3b": 4,
-  "devstral-small-2507": 3,
-  "llama-3.2-11b-vision": 5,
-  "llama-3.1-nemotron-70b-instruct": 3,
-  "phi-3.5-mini": 5,
+  "qwen-3-coder-plus": 3,
+  "qwen-3-vl-plus": 2,
+  "qwen-3-omni-flash": 3,
+  "grok-4.1-fast": 2,
+  "glm-5.2": 10,
+  "kimi-k2.7-code": 10,
+  "nvidia-nemotron-3-ultra-550b-a55b": 4,
+  "nemotron-3-nano-omni-30b-a3b-reasoning": 3,
+  "deepseek-v4-flash": 11,
+  "deepseek-v4-pro": 11,
+  "kimi-k2.6": 10,
+  "mimo-v2.5": 5,
+  "mimo-v2.5-pro": 7,
+  "glm-5.1": 10,
+  "gemma-4-26b-a4b-it": 6,
+  "gemma-4-31b-it": 6,
+  "nvidia-nemotron-3-super-120b-a12b": 2,
+  "glm-5": 9,
+  "minimax-m2.5": 9,
+  "qwen-3-max-thinking": 4,
+  "kimi-k2.5": 9,
+  "glm-4.7-flash": 7,
+  "deepseek-v3.2": 8,
+  "qwythos-9b-claude-mythos-5-1m": 2,
+  "vibethinker-3b": 2,
+  "ornith-1.0-9b": 2,
+  "fastcontext-1.0-4b-sft": 2,
+  "qwable-9b-claude-fable-5": 2,
+  "qwable-5-27b-coder": 2,
+  "gemma-4-26b-a4b-styletune": 2,
+  "nvidia-nemotron-3-ultra-550b-a55b-nvfp4": 3,
+  "fastcontext-1.0-4b-rl": 2,
+  "qwen-3-8b": 6,
+  "qwen-3.6-27b-aeon-ultimate-uncensored": 2,
+  "qwen-3-coder-30b-a3b": 6,
+  "qwen-3-coder-next": 7,
+  "llama-3.2-1b": 4,
+  "z-image-engineer": 2,
+  "llama-3.2-11b-vision": 4,
+  "command-r-plus24": 5,
+  "deepseek-r1-distill-qwen-32b": 3,
+  "llama-3.1-nemotron-70b": 2,
+  "krea-2-turbo": 2,
+  "ideogram-4": 2,
+  "z-image-turbo": 2,
+  "ideogram.4.turbotime.lora": 2,
+  "krea-2-lora-retroanime": 2,
+  "llama-3": 4,
+  "moonshotai/Kimi-K2-Instruct": 3,
+  "qvq-72b": 3,
   "stable-diffusion-3.5-large": 3,
   "sdxl-1.0": 3,
-  "claude-opus-4": 4,
-  "command-a25": 6,
-  "claude-sonnet-4": 6,
-  "gemma-3n-e4b-it": 6,
-  "mistral-small-2506": 3,
-  "qwen-3-8b": 7,
-  "deepseek-chat": 3,
-  "gpt-4o-mini-audio": 2,
-  "flux-1.1-pro": 2,
-  "gpt-5-nano": 4,
-  "gpt-5": 8,
-  "qwen-314b": 2,
-  "qwen-3coder-30b-a3b": 2,
-  "qwen-turbo": 3,
-  "glm-4-32b": 2,
-  "mistral-nemo-2407": 2,
-  "qwen-3-235b-a22b": 7,
-  "qwen-3-30b-a3b": 9,
-  "qwen-3-coder-30b-a3b": 8,
-  "deepcoder-14b": 3,
-  "dolphin-mistral-24b-venice-edition": 6,
-  "qwerky-72b": 3,
-  "gemma-3n-e2b-it": 5,
-  "mai-ds-r1": 3,
-  "mistral-small-24b-2501": 3,
-  "glm-z1-32b": 2,
-  "chatgpt-4o": 3,
-  "solar-10.7b-v1.0": 2,
-  "mixtral-8x7b-v0.1": 2,
-  "phi-3-mini-4k-june-2024": 2,
-  "mistral-7b-v0.2": 4,
-  "dbrx": 2,
-  "mixtral-8x22b-v0.1": 2,
-  "qwen-2.5-plus-1127": 2,
-  "llama-2-70b-steerlm": 2,
-  "gemini-1.5-flash-8b": 2,
-  "qwen-3-235b-a22b-thinking-2507": 7,
-  "qwen-3-coder-480b-a35b": 5,
-  "qwen-3-235b-a22b-2507": 6,
-  "qwen-image": 3,
-  "claude-opus-4-1": 4,
-  "gpt-5-mini": 4,
-  "gpt-5-chat": 5,
-  "gpt-4o-mini-audio-preview": 3,
-  "meta-ai": 2,
-  "wizardlm-2-7b": 2,
-  "codegemma-7b": 2,
-  "gemma-1.1-7b": 2,
-  "blackboxai": 2,
-  "qwen-2.5": 2,
-  "qwen-2.5-1m": 2,
-  "deepseek-r1-turbo": 2,
-  "deepseek-prover-v2-671b": 2,
-  "deepseek-v3-0324-turbo": 2,
-  "deepseek-r1-0528-turbo": 2,
-  "dolphin-2.6": 2,
-  "dolphin-2.9": 2,
-  "airoboros-70b": 2,
-  "lzlv-70b": 2,
-  "auto": 2,
-  "gpt-5-instant": 2,
-  "gpt-5-thinking": 2,
-  "gemini-2.5-flash-lite": 4,
-  "mistral-small-cloudflare": 2,
-  "nova-micro-v1": 2,
-  "grok-4": 3,
-  "glm-4.5v": 5,
-  "deepseek-r1-0528-qwen-3-8b": 4,
-  "kimi-dev-72b": 3,
-  "flux-krea-dev": 3,
-  "llama-3": 3,
-  "qvq-72b": 3,
-  "seedream-3": 2,
-  "mistral-small": 2,
-  "devstral-small": 2,
-  "minimax": 2,
-  "deepseek-coder-6.7b": 2,
-  "falcon-7b": 2,
-  "gemma-7b": 2,
-  "flux-kontext-dev": 2,
-  "janus-pro-7b-image": 2,
-  "gemma-2b": 2,
-  "qwen-2.5-14b-1m": 2,
-  "glm-4.1v-9b-thinking": 3,
-  "qwq-32b-arliai-rpr": 4,
-  "dolphin3.0-mistral-24b": 2,
-  "dolphin3.0-r1-mistral-24b": 2,
-  "deepseek-chat-v3-0324": 2,
-  "devstral-small-2505": 2,
-  "mistral-small-3.2-24b": 2,
-  "kimi-vl-a3b-thinking": 2,
-  "deephermes-3-llama-3-8b": 2,
-  "llama-3.1-nemotron-ultra-253b": 4,
-  "qwen-3-coder": 6,
-  "reka-flash-3": 2,
-  "sarvam-m": 3,
-  "shisa-v2-llama-3.3-70b": 2,
-  "hunyuan-a13b": 2,
-  "deepseek-r1t-chimera": 3,
-  "deepseek-r1t2-chimera": 4,
-  "hermes-3-llama-3.1-405b": 3,
-  "qwen-3-coder-480b-a35b-turbo": 2,
-  "olmocr-7b-0725": 2,
-  "llama-4-maverick-17b-128e-turbo": 2,
-  "mistral-small-3.2-24b-2506": 2,
-  "llama-guard-4-12b": 6,
-  "claude-4-opus": 2,
-  "claude-4-sonnet": 2,
-  "llama-3.3-70b-turbo": 2,
-  "qwen-3-4b-thinking-2507": 3,
-  "qwen-3-4b-2507": 3,
-  "baichuan-m2-32b": 2,
-  "smollm3-3b": 2,
-  "stable-diffusion-xl-base-1.0": 2,
-  "mistral-small-3.1-24b-2503": 4,
-  "grok-3-mini-beta": 3,
-  "magistral-medium-2506": 4,
-  "minimax-m1": 3,
-  "o1-pro": 3,
-  "ministral-3b": 2,
-  "ministral-8b": 2,
-  "mistral-tiny": 3,
-  "pixtral-large-2411": 2,
-  "codestral-2508": 3,
-  "pixtral-12b": 3,
-  "mistral-saba": 3,
-  "grok-vision-beta": 2,
-  "gpt-4o-search": 3,
-  "gpt-4o-mini-search": 3,
-  "command": 2,
-  "qwen-vl-plus": 2,
-  "qwen-2.5-vl-7b": 6,
-  "qwen-2.5-coder-7b": 5,
-  "deepseek-prover": 2,
-  "deepseek-r1-distill-llama-8b": 4,
-  "inflection-3-productivity": 2,
-  "inflection-3-pi": 2,
-  "grok-3-beta": 2,
-  "sonar-deep-research": 2,
-  "lfm-7b": 2,
-  "lfm-3b": 2,
-  "llama-guard-3-8b": 3,
-  "mistral-7b-v0.1": 2,
-  "command-r7b24": 7,
-  "command-r7b-arabic25": 5,
-  "grok": 2,
-  "flux-kontext-pro": 2,
-  "deepseek-chat-v3.1": 2,
-  "gemini-2.5-flash-image": 3,
-  "llama-3.3-8b": 3,
-  "deepseek-v3.1": 5,
-  "hermes-4-70b": 4,
-  "command-a-translate25": 2,
-  "hermes-4-405b": 3,
-  "qwen-3-30b-a3b-2507": 6,
-  "tinyllama-1.1b-chat-v1.0": 2,
-  "compass-flux.1": 2,
-  "raena-qwen-image": 2,
-  "boreal-qwen-image": 2,
-  "mistral-medium-2508": 2,
-  "flux-dev-lora": 2,
-  "study": 3,
-  "": 2,
-  "grok-2-image": 2,
-  "qwen-3-max": 5,
-  "qwen-3-coder-plus": 4,
-  "glm-4.6": 8,
-  "tongyi-deepresearch-30b-a3b": 2,
-  "kat-coder-pro": 4,
-  "longcat-flash-chat": 3,
-  "nemotron-nano-12b-v2-vl": 4,
-  "nemotron-nano-9b": 3,
-  "minimax-m2": 8,
-  "kimi-k2-thinking": 9,
-  "deepseek-ocr": 2,
-  "deepseek-v3.2-exp": 5,
-  "deepseek-v3.1-terminus": 6,
-  "qwen-3-next-80b-a3b": 9,
-  "kimi-k2-0905": 10,
-  "moonshotai/Kimi-K2-Instruct": 6,
-  "apertus-8b-2509": 2,
-  "fibo": 2,
-  "qwen-image-lightning": 2,
-  "claude-sonnet-4-5": 5,
-  "qwen-3-vl-235b-a22b": 6,
-  "gemini-2.5-flash-preview25": 3,
-  "claude-haiku-4-5": 5,
-  "qwen-3-vl-235b-a22b-thinking": 6,
-  "qwen-3-next-80b-a3b-thinking": 7,
-  "amazon-nova-experimental-chat": 2,
-  "qwen-3-vl-8b-thinking": 3,
-  "qwen-3-vl-8b": 5,
-  "mercury": 4,
-  "gpt-5.1": 4,
-  "ring-1t": 3,
-  "imagen-4.0-ultra-generate": 2,
-  "imagen-4.0-generate": 2,
-  "gpt-image-1-mini": 2,
-  "ideogram-v3-quality": 2,
-  "photon": 2,
-  "recraft": 2,
-  "gemini-2.0-flash-preview-image-generation": 2,
-  "claude-haiku-4.5": 3,
-  "claude-sonnet-4.5": 3,
-  "open-mistral-7b": 2,
-  "open-mistral-nemo": 2,
-  "open-mistral-nemo-2407": 2,
-  "mistral-large-pixtral-2411": 2,
-  "magistral-medium-2509": 2,
-  "magistral-small-2509": 2,
-  "qwen-2.5-vl-3b": 2,
-  "gpt-5.2": 5,
-  "gemini-3-flash": 6,
-  "claude-opus-4.5": 3,
-  "gemini-3-pro": 8,
-  "glm-4.7": 9,
-  "minimax-m2.7": 9,
-  "minimax-m2.7-highspeed": 9,
-  "minimax-m2.1": 9,
-  "turbo": 2,
-  "gpt-image-1.5": 3,
-  "z-image": 3,
-  "trinity-mini": 3,
-  "devstral-2512": 4,
-  "nemotron-3-nano-30b-a3b": 6,
-  "tng-r1t-chimera": 3,
-  "mimo-v2-flash": 9,
-  "deepseek-v3.2": 10,
-  "nvidia-nemotron-3-nano-30b-a3b": 3,
-  "qwen-image-2512": 4,
-  "z-image-turbo": 2,
-  "flux.2-dev-turbo": 2,
+  "claude-opus-4-6": 2,
+  "claude-opus-4-7": 2,
+  "gemini-3-pro": 2,
+  "gpt-5.2-chat": 4,
+  "claude-sonnet-4-6": 2,
   "claude-opus-4-5": 2,
-  "deepseek-v3.2-thinking": 2,
-  "nova-2-lite": 3,
-  "olmo-3-32b-think": 3,
-  "mistral-large-3": 2,
-  "amazon.nova-pro": 2,
-  "intellect-3": 5,
-  "olmo-3.1-32b": 5,
-  "olmo-3.1-32b-think": 6,
-  "glm-4.6v": 5,
-  "glm-4.6v-flash": 3,
-  "qwen-3-omni-flash": 2,
-  "ling-flash-2.0": 3,
-  "ling-1t": 4,
-  "ring-flash-2.0": 3,
-  "flux-2-pro": 3,
-  "flux-2-flex": 3,
-  "seedream-4.5": 2,
-  "gpt-image-1": 2,
-  "devstral-medium-2507": 2,
-  "gpt-5.1-chat": 3,
+  "claude-sonnet-4-5": 5,
+  "gpt-5.3-chat": 4,
+  "minimax-m3": 10,
+  "claude-opus-4-1": 4,
+  "glm-4.7": 7,
+  "o3": 4,
+  "gpt-5-chat": 4,
+  "qwen-3-235b-a22b-2507": 5,
+  "kimi-k2-0905": 5,
+  "kimi-k2-0711": 2,
+  "mistral-large-3": 4,
+  "qwen-3-vl-235b-a22b": 6,
+  "claude-opus-4": 5,
+  "claude-haiku-4-5": 4,
+  "mistral-medium-2508": 2,
+  "qwen-3-next-80b-a3b": 6,
+  "qwen-3-235b-a22b-thinking-2507": 4,
+  "qwen-3-vl-235b-a22b-thinking": 4,
+  "claude-sonnet-4": 5,
+  "qwen-3-coder-480b-a35b": 5,
+  "minimax-m2.1": 7,
+  "qwen-3-30b-a3b-2507": 4,
+  "qwen-3-235b-a22b": 6,
+  "qwen-3-next-80b-a3b-thinking": 4,
+  "trinity-large-thinking": 4,
+  "gemma-3-27b-it": 5,
+  "minimax-m1": 3,
+  "mercury-2": 4,
+  "minimax-m2": 6,
+  "nova-2-lite": 4,
+  "qwen-3-30b-a3b": 4,
+  "gemma-3n-e4b-it": 4,
+  "gpt-oss-20b": 7,
+  "nvidia-nemotron-3-nano-30b-a3b": 2,
+  "granite-4.1-8b": 3,
+  "mistral-small-3.1-24b-2503": 2,
+  "step-3.7-flash": 6,
+  "ring-1t": 2,
+  "mistral-medium-3.5": 2,
+  "mistral-small-2603": 4,
+  "qwen-3-vl-8b-thinking": 4,
+  "fusion": 3,
+  "claude-fable-5": 3,
+  "qwen-vl-max": 2,
+  "qwen-3-vl-8b": 6,
+  "grok-4.3": 5,
+  "gpt-5.5": 5,
+  "claude-opus-4-8": 2,
+  "glm-5v-turbo": 3,
+  "qwen-image-2512": 2,
+  "z-image": 2,
+  "grok-imagine-image": 2,
+  "qwen-max": 2,
+  "qwen-turbo": 2,
+  "qwen-3-14b": 5,
+  "qwen-3-coder-flash": 2,
+  "qwen-3-vl-30b-a3b": 5,
+  "claude-3-5-sonnet": 2,
+  "claude-3-7-sonnet": 2,
+  "claude-3-haiku": 3,
+  "gpt-5-codex": 3,
+  "gpt-5-mini": 3,
+  "gpt-5-nano": 4,
   "gpt-5.1-codex": 2,
-  "gpt-5.1-codex-max": 3,
-  "gpt-5.1-codex-mini": 2,
-  "gpt-5.2-chat": 3,
-  "gpt-5.2-pro": 2,
-  "ministral-14b-2512": 4,
-  "ministral-3b-2512": 3,
+  "gpt-5.1-codex-mini": 3,
+  "gpt-5.2-codex": 3,
+  "gpt-5.3-codex": 3,
+  "gpt-5.4-nano": 4,
+  "grok-4-1-fast-non-reasoning": 2,
+  "grok-4-1-fast-reasoning": 2,
+  "grok-4-20-non-reasoning": 2,
+  "gemini-2.5-flash-lite": 4,
+  "minimax-m2.7-highspeed": 2,
+  "codestral-2508": 2,
+  "devstral-2512": 2,
+  "ministral-14b-2512": 2,
+  "ministral-3b-2512": 2,
   "ministral-8b-2512": 2,
-  "o3-pro": 3,
+  "mistral-large-2512": 2,
+  "mistral-medium-3-5": 2,
+  "moonshot-v1-128k": 2,
+  "moonshot-v1-128k-vision": 2,
+  "moonshot-v1-32k": 2,
+  "moonshot-v1-32k-vision": 2,
+  "moonshot-v1-8k": 2,
+  "moonshot-v1-8k-vision": 2,
+  "gpt-5.1-chat": 3,
+  "gpt-5.2-pro": 2,
+  "gpt-5.4-pro": 3,
+  "gpt-5.5-pro": 2,
+  "o1-pro": 2,
+  "o3-pro": 2,
   "jamba-large-1.7": 2,
-  "jamba-mini-1.7": 3,
   "aion-1.0": 2,
   "aion-1.0-mini": 2,
+  "aion-2.0": 2,
   "aion-rp-llama-3.1-8b": 2,
-  "codellama-7b-solidity": 2,
-  "olmo-2-0325-32b": 2,
-  "olmo-3-7b": 4,
-  "olmo-3-7b-think": 4,
-  "goliath-120b": 2,
+  "olmo-3-32b-think": 2,
   "nova-lite": 2,
-  "nova-micro": 2,
+  "nova-micro": 3,
   "nova-premier": 2,
   "nova-pro": 2,
   "magnum-v4-72b": 2,
   "claude-opus-4.1": 2,
+  "claude-opus-4.6-fast": 2,
+  "claude-opus-4.7-fast": 2,
+  "claude-opus-4.8-fast": 2,
   "coder-large": 2,
-  "maestro-reasoning": 2,
-  "spotlight": 2,
+  "trinity-mini": 2,
   "virtuoso-large": 2,
-  "ernie-4.5-21b-a3b": 2,
-  "ernie-4.5-21b-a3b-thinking": 2,
-  "ernie-4.5-300b-a47b": 2,
-  "ernie-4.5-vl-28b-a3b": 2,
   "ernie-4.5-vl-424b-a47b": 2,
   "seed-1.6": 2,
   "seed-1.6-flash": 2,
-  "ui-tars-1.5-7b": 2,
-  "cogito-v2-preview-llama-109b-moe": 2,
-  "cogito-v2-preview-llama-405b": 3,
-  "cogito-v2-preview-llama-70b": 3,
+  "seed-2.0-lite": 2,
+  "seed-2.0-mini": 2,
+  "ui-tars-1.5-7b": 3,
+  "dolphin-mistral-24b-venice-edition": 3,
+  "command-r24": 5,
+  "command-r7b24": 6,
+  "north-mini-code": 2,
   "cogito-v2.1-671b": 2,
-  "deepseek-v3.2-speciale": 3,
-  "llemma.7b": 2,
-  "rnj-1": 5,
+  "deepseek-chat-v3-0324": 2,
+  "deepseek-chat-v3.1": 2,
+  "deepseek-r1-0528": 3,
+  "deepseek-v3.1-terminus": 4,
+  "deepseek-v3.2-exp": 4,
+  "gemini-2.5-flash-image": 2,
   "gemini-2.5-flash-lite-preview25": 2,
   "gemini-3-pro-image": 2,
-  "mythomax-l2-13b": 3,
+  "gemini-3.1-flash-image": 2,
+  "gemini-3.1-pro-preview-customtools": 3,
+  "gemma-2-27b-it": 3,
+  "gemma-3-12b-it": 4,
+  "gemma-3-4b-it": 4,
+  "lyria-3-clip": 2,
+  "lyria-3-pro": 2,
+  "mythomax-l2-13b": 2,
   "granite-4.0-h-micro": 2,
-  "mercury-coder": 3,
-  "lfm-2.2-6b": 2,
-  "lfm2-8b-a1b": 2,
+  "ling-2.6-1t": 3,
+  "ling-2.6-flash": 2,
+  "ring-2.6-1t": 2,
+  "inflection-3-pi": 2,
+  "inflection-3-productivity": 2,
+  "kat-coder-pro": 2,
+  "lfm-2-24b-a2b": 2,
+  "lfm-2.5-1.2b": 2,
+  "lfm-2.5-1.2b-thinking": 2,
   "weaver": 2,
-  "llama-3.2-90b-vision": 4,
-  "llama-guard-2-8b": 2,
+  "phi-4": 4,
+  "phi-4-mini": 3,
+  "wizardlm-2-8x22b": 4,
   "minimax-01": 2,
-  "devstral-medium": 3,
-  "mistral-7b-v0.3": 5,
-  "mistral-large-2512": 3,
-  "mistral-medium-3": 3,
+  "minimax-m2-her": 2,
+  "mistral-large-2407": 2,
   "mistral-medium-3.1": 2,
-  "mistral-small-creative": 3,
+  "mistral-saba": 2,
+  "mistral-small-24b-2501": 2,
+  "mistral-small-3.2-24b": 2,
+  "mixtral-8x22b": 2,
   "voxtral-small-24b-2507": 2,
+  "kimi-k2-thinking": 5,
   "morph-v3-fast": 2,
   "morph-v3-large": 2,
-  "llama-3.1-lumimaid-8b": 2,
-  "noromaid-20b": 2,
-  "deepseek-v3.1-nex-n1": 2,
-  "deephermes-3-mistral-24b": 2,
-  "hermes-2-pro-llama-3-8b": 4,
+  "nex-n2-pro": 2,
+  "hermes-3-llama-3.1-405b": 2,
   "hermes-3-llama-3.1-70b": 2,
-  "llama-3.3-nemotron-super-49b-v1.5": 3,
-  "codex-mini": 3,
-  "gpt-3.5-turbo-16k": 2,
-  "gpt-4o-audio": 2,
-  "gpt-5-codex": 2,
+  "hermes-4-405b": 2,
+  "hermes-4-70b": 3,
+  "llama-3.3-nemotron-super-49b-v1.5": 2,
+  "nemotron-3-nano-30b-a3b": 2,
+  "nemotron-3-super-120b-a12b": 2,
+  "nemotron-3-ultra-550b-a55b": 2,
+  "nemotron-3.5-content-safety": 2,
+  "nemotron-nano-12b-v2-vl": 2,
+  "nemotron-nano-9b": 2,
+  "gpt-3.5-turbo": 2,
+  "gpt-3.5-turbo-0613": 2,
+  "gpt-3.5-turbo-16k": 3,
+  "gpt-4-turbo": 3,
+  "gpt-4o-mini-search": 3,
+  "gpt-4o-search": 3,
   "gpt-5-image": 2,
   "gpt-5-image-mini": 2,
   "gpt-5-pro": 2,
-  "gpt-oss-safeguard-20b": 5,
-  "o3-deep-research": 2,
-  "o4-mini-deep-research": 2,
-  "internvl3-78b": 2,
+  "gpt-5.1-codex-max": 2,
+  "gpt-5.4-image-2": 2,
+  "gpt-audio": 4,
+  "gpt-audio-mini": 3,
+  "gpt-chat": 2,
+  "gpt-oss-safeguard-20b": 4,
+  "o3-deep-research": 3,
+  "o4-mini-deep-research": 3,
   "bodybuilder": 2,
+  "free": 2,
+  "owl-alpha": 2,
+  "pareto-code": 2,
+  "perceptron-mk1": 2,
+  "sonar-deep-research": 2,
   "sonar-pro-search": 2,
-  "qwen-3-30b-a3b-thinking-2507": 5,
-  "qwen-3-coder-flash": 2,
-  "qwen-3-vl-30b-a3b": 5,
-  "qwen-3-vl-30b-a3b-thinking": 5,
-  "qwen-3-vl-32b": 4,
-  "sorcererlm-8x22b": 2,
+  "laguna-m.1": 2,
+  "laguna-xs.2": 2,
+  "qwen-3-30b-a3b-thinking-2507": 2,
+  "qwen-3-coder": 5,
+  "qwen-3-vl-30b-a3b-thinking": 3,
+  "qwen-3-vl-32b": 3,
+  "qwen-3.6-flash": 2,
+  "reka-edge": 2,
+  "reka-flash-3": 2,
   "relace-apply-3": 2,
   "relace-search": 2,
-  "l3-euryale-70b": 2,
+  "fugu-ultra": 2,
   "l3-lunaris-8b": 2,
   "l3.1-70b-hanami-x1": 2,
   "l3.1-euryale-70b": 2,
   "l3.3-euryale-70b": 2,
-  "step3": 2,
   "router": 2,
+  "hunyuan-a13b": 2,
+  "hy3": 2,
   "cydonia-24b-v4.1": 2,
   "rocinante-12b": 2,
   "skyfall-36b": 2,
   "unslopnemo-12b": 2,
   "remm-slerp-l2-13b": 2,
-  "grok-4-fast": 2,
-  "grok-4.1-fast": 2,
+  "solar-pro-3": 2,
+  "palmyra-x5": 2,
+  "grok-4.20": 2,
+  "grok-4.20-multi-agent": 3,
+  "grok-build-0.1": 2,
+  "gemini-flash": 2,
+  "gemini-pro": 2,
+  "gpt": 2,
+  "gpt-mini": 2,
+  "llama-guard-4-12b": 3,
+  "qwen-3.5-9b": 4,
+  "grok-2-vision": 2,
+  "grok-3-fast": 2,
+  "grok-3-mini-fast": 2,
+  "grok-4-1-fast": 2,
+  "grok-4-fast": 3,
   "grok-code-fast-1": 2,
-  "ling": 2,
-  "ling-mini-2.0": 2,
-  "ring-mini-2.0": 2
+  "glm-4.5": 5,
+  "glm-4.5-air": 4,
+  "glm-4.5v": 4,
+  "glm-4.6": 6,
+  "glm-4.6v": 3,
+  "glm-4.6v-flash": 2,
+  "glm-5-turbo": 2,
+  "claude-3-opus": 2,
+  "claude-3-sonnet": 2,
+  "qwen-3-0.6b": 3,
+  "qwen-3-1.7b": 3,
+  "qwen-3-4b": 3,
+  "qwen-2.5-coder-7b": 3,
+  "deepseek-v3-0324": 4,
+  "deepseek-r1-distill-llama-8b": 2,
+  "deepseek-chat": 3,
+  "deepseek-coder": 2,
+  "glm-4": 2,
+  "command-a25": 3,
+  "command-r7b-arabic25": 3,
+  "flux-kontext-dev": 2
 }
 parents = {
   "HuggingSpace": [
-    "BAAI_Ling",
     "BlackForestLabs_Flux1Dev",
     "BlackForestLabs_Flux1KontextDev",
     "CohereForAI_C4AI_Command",
-    "DeepseekAI_JanusPro7b",
-    "Microsoft_Phi_4_Multimodal",
-    "Qwen_Qwen_2_5",
-    "Qwen_Qwen_2_5M",
-    "Qwen_Qwen_2_5_Max",
-    "Qwen_Qwen_2_72B",
-    "Qwen_Qwen_3",
     "StabilityAI_SD35Large"
   ],
   "Copilot": [
@@ -4342,1278 +4741,713 @@ parents = {
     "OpenaiAccount"
   ],
   "PollinationsAI": [
+    "PollinationsAudio",
     "PollinationsImage"
   ]
 }
 model_aliases = {
-  "openai": "gpt-5-mini",
-  "gpt-4o-mini-2024-07-18": "gpt-4o-mini",
-  "openai-audio": "PollinationsAudio:openai-audio",
+  "": "default",
+  "Copilot": "dall-e-3",
+  "openrouter:openai/gpt-4": "gpt-4",
+  "openai/gpt-4": "gpt-4",
+  "openrouter:openai/gpt-4o-2024-11-20": "gpt-4o",
+  "openai/gpt-4o": "gpt-4o",
+  "openrouter:openai/gpt-4o-mini-2024-07-18": "gpt-4o-mini",
+  "openai/gpt-4o-mini-2024-07-18": "gpt-4o-mini",
   "coral": "gpt-4o-mini-tts",
   "Think Deeper": "o1",
+  "openai:openai/o1": "o1",
+  "openai/o1": "o1",
+  "openai:openai/o1-mini": "o1-mini",
+  "openai:openai/o3-mini": "o3-mini",
+  "o3-mini-2025-01-31": "o3-mini",
+  "openai/o3-mini": "o3-mini",
   "openrouter:openai/o3-mini-high": "o3-mini-high",
-  "openai-reasoning": "o4-mini",
+  "openai/o3-mini-high": "o3-mini-high",
   "o4-mini-2025-04-16": "o4-mini",
+  "openai:openai/o4-mini": "o4-mini",
+  "openai/o4-mini": "o4-mini",
   "openrouter:openai/o4-mini-high": "o4-mini-high",
-  "openai-large": "gpt-5.2",
+  "openai/o4-mini-high": "o4-mini-high",
   "gpt-4-1": "gpt-4.1",
   "gpt-4.1-2025-04-14": "gpt-4.1",
+  "openai:openai/gpt-4.1": "gpt-4.1",
+  "openai/gpt-4.1": "gpt-4.1",
   "gpt-4-1-mini": "gpt-4.1-mini",
   "gpt-4.1-mini-2025-04-14": "gpt-4.1-mini",
-  "openai-fast": "gpt-5-nano",
-  "gpt-4.1-nano-2025-04-14": "gpt-4.1-nano",
+  "openai:openai/gpt-4.1-mini": "gpt-4.1-mini",
+  "openai/gpt-4.1-mini": "gpt-4.1-mini",
+  "openai:openai/gpt-4.1-nano": "gpt-4.1-nano",
+  "openai/gpt-4.1-nano": "gpt-4.1-nano",
   "gpt-4-5": "gpt-4.5",
+  "openai:openai/gpt-4.5-preview": "gpt-4.5",
   "openai/gpt-oss-120b": "gpt-oss-120b",
+  "togetherai:openai/gpt-oss-120b": "gpt-oss-120b",
+  "gpt-oss:120b": "gpt-oss-120b",
+  "Study": "study",
   "gptimage": "gpt-image",
-  "@cf/meta/llama-2-7b-chat-int8": "llama-2-7b",
-  "llama-2-7b-chat": "llama-2-7b",
   "openrouter:meta-llama/llama-2-70b-chat": "llama-2-70b",
-  "@hf/meta-llama/meta-llama-3-8b-instruct": "llama-3-8b",
-  "llama-3-8b-instruct": "llama-3-8b",
-  "meta-llama/Meta-Llama-3-8B-Instruct": "llama-3-8b",
   "openrouter:meta-llama/llama-3-8b-instruct": "llama-3-8b",
-  "llama-3-70b-instruct": "llama-3-70b",
+  "meta-llama/Meta-Llama-3-8B-Instruct": "llama-3-8b",
+  "meta-llama/llama-3-8b-instruct": "llama-3-8b",
+  "llama-3-8b-instruct": "llama-3-8b",
   "openrouter:meta-llama/llama-3-70b-instruct": "llama-3-70b",
-  "meta-llama/Meta-Llama-3.1-8B-Instruct": "llama-3.1-8b",
-  "@cf/meta/llama-3.1-8b-instruct-fp8": "llama-3.1-8b",
-  "llama-3.1-8b-instruct": "llama-3.1-8b",
+  "meta-llama/Meta-Llama-3-70B-Instruct": "llama-3-70b",
+  "llama-3-70b-instruct": "llama-3-70b",
+  "meta/meta-llama-3-70b-instruct": "llama-3-70b",
+  "meta-llama/Llama-3.1-8B": "llama-3.1-8b",
+  "llama3.1-8b": "llama-3.1-8b",
+  "hf:meta-llama/Llama-3.1-8B-Instruct": "llama-3.1-8b",
   "meta-llama/Llama-3.1-8B-Instruct": "llama-3.1-8b",
-  "llama-3.1-70b-instruct": "llama-3.1-70b",
+  "meta-llama/llama-3.1-8b-instruct": "llama-3.1-8b",
   "openrouter:meta-llama/llama-3.1-70b-instruct": "llama-3.1-70b",
-  "@cf/meta/llama-3.2-1b-instruct": "llama-3.2-1b",
-  "llama-3.2-1b-instruct": "llama-3.2-1b",
-  "llama-3.2-3b-instruct": "llama-3.2-3b",
+  "llama3.1-70b": "llama-3.1-70b",
+  "hf:meta-llama/Llama-3.1-70B-Instruct": "llama-3.1-70b",
+  "meta-llama/Llama-3.1-70B-Instruct": "llama-3.1-70b",
+  "meta-llama/llama-3.1-70b-instruct": "llama-3.1-70b",
+  "hf:meta-llama/Llama-3.1-405B-Instruct": "llama-3.1-405b",
   "meta-llama/Llama-3.2-3B-Instruct": "llama-3.2-3b",
-  "@cf/meta/llama-3.2-3b-instruct": "llama-3.2-3b",
+  "hf:meta-llama/Llama-3.2-3B-Instruct": "llama-3.2-3b",
+  "meta-llama/llama-3.2-3b-instruct": "llama-3.2-3b",
   "meta-llama/Llama-3.2-11B-Vision-Instruct": "llama-3.2-11b-vision",
-  "meta-llama/Llama-3.2-90B-Vision-Instruct": "llama-3.2-90b",
-  "openrouter:meta-llama/llama-3.2-90b-vision-instruct": "llama-3.2-90b-vision",
+  "openrouter:meta-llama/llama-3.2-90b-vision-instruct": "llama-3.2-90b",
   "meta-llama/Llama-3.3-70B-Instruct": "llama-3",
-  "llama3.3-70b-instruct-fp8": "llama-3.3-70b",
-  "llama": "llama-3.3-70b",
-  "@cf/meta/llama-3.3-70b-instruct-fp8-fast": "llama-3.3-70b",
-  "meta-llama/Llama-4-Scout-17B-16E-Instruct": "llama-4-scout-17b-16e",
-  "llama-4-scout-17b-16e-instruct": "llama-4-scout-17b-16e",
-  "llamascout": "llama-4-scout",
-  "@cf/meta/llama-4-scout-17b-16e-instruct": "llama-4-scout",
-  "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8": "llama-4-maverick-17b-128e",
-  "llama-4-maverick-17b-128e-instruct-fp8": "llama-4-maverick-17b-128e",
-  "llama-4-maverick-03-26-experimental": "llama-4-maverick",
+  "hf:meta-llama/Llama-3.3-70B-Instruct": "llama-3.3-70b",
+  "meta-llama/llama-3.3-70b-instruct": "llama-3.3-70b",
+  "llama": "llama-",
+  "meta-llama/llama-4-scout": "llama-4-scout",
+  "meta-llama/llama-4-maverick": "llama-4-maverick",
   "mistralai/Mistral-Nemo-Instruct-2407": "mistral-nemo-2407",
-  "mistralai/Mistral-Small-3.1-24B-Instruct-2503": "mistral-small-3.1-24b-2503",
-  "mistral": "mistral-small",
-  "@cf/mistralai/mistral-small-3.1-24b-instruct": "mistral-small-3.1-24b",
+  "mistral-nemo:latest": "mistral-nemo",
+  "mistralai/mistral-nemo": "mistral-nemo",
+  "mistral-small": "mistral-small-3.1-24b",
+  "openrouter:mistralai/mistral-small-3.1-24b-instruct": "mistral-small-3.1-24b",
+  "mistralai/mistral-small-3.1-24b-instruct": "mistral-small-3.1-24b",
   "openrouter:nousresearch/nous-hermes-2-mixtral-8x7b-dpo": "hermes-2-dpo",
-  "microsoft/phi-4": "phi-4",
-  "phi": "phi-4",
-  "openrouter:microsoft/phi-4": "phi-4",
-  "openrouter:microsoft/phi-4-multimodal-instruct": "phi-4-multimodal",
-  "microsoft/phi-4-reasoning-plus": "phi-4-reasoning-plus",
-  "microsoft/WizardLM-2-7B": "wizardlm-2-7b",
-  "microsoft/WizardLM-2-8x22B": "wizardlm-2-8x22b",
-  "openrouter:microsoft/wizardlm-2-8x22b": "wizardlm-2-8x22b",
-  "openrouter:google/gemini-pro-1.5": "gemini-1.5-pro",
-  "gemini-2.5-flash-preview-04-17": "gemini-2.5-flash",
-  "google/gemini-2.5-flash": "gemini-2.5-flash",
+  "microsoft/Phi-3.5-mini-instruct": "phi-3.5-mini",
+  "openrouter:microsoft/phi-3.5-mini-128k-instruct": "phi-3.5-mini",
+  "gemini-2.0-flash-001": "gemini-2.0-flash",
   "openrouter:google/gemini-2.5-flash-preview": "gemini-2.5-flash",
-  "gemini-2.5-pro-preview-05-06": "gemini-2.5-pro",
-  "google/gemini-2.5-pro": "gemini-2.5-pro",
-  "google/codegemma-7b-it": "codegemma-7b",
-  "google/gemma-1.1-7b-it": "gemma-1.1-7b",
-  "google/gemma-2-9b-it": "gemma-2-9b-it",
+  "google/gemini-2.5-flash": "gemini-2.5-flash",
+  "google/gemini-2.5-pro-preview-05-06": "gemini-2.5-pro",
+  "openrouter:google/gemini-3.1-pro-preview": "gemini-3.1-pro",
+  "google/gemini-3.1-pro-preview": "gemini-3.1-pro",
+  "gemini-3.1-flash-lite-preview": "gemini-3.1-flash-lite",
+  "openrouter:google/gemini-3.1-flash-lite-preview": "gemini-3.1-flash-lite",
+  "google/gemini-3.1-flash-lite-preview": "gemini-3.1-flash-lite",
+  "openrouter:google/gemini-3.5-flash": "gemini-3.5-flash",
+  "google/gemini-3.5-flash": "gemini-3.5-flash",
   "google/gemma-2-27b-it": "gemma-2-27b-it",
   "openrouter:google/gemma-2-27b-it": "gemma-2-27b-it",
-  "google/gemma-3-4b-it": "gemma-3-4b-it",
-  "google/gemma-3-12b-it": "gemma-3-12b-it",
-  "@cf/google/gemma-3-12b-it": "gemma-3-12b",
-  "google/gemma-3-27b-it": "gemma-3-27b-it",
   "command-r-08-2024": "command-r24",
+  "command-r:35b": "command-r",
   "CohereForAI/c4ai-command-r-plus-08-2024": "command-r-plus24",
+  "command-r-plus:104b": "command-r-plus",
   "openrouter:cohere/command-r7b-12-2024": "command-r7b24",
   "command-a-03-2025": "command-a25",
   "openrouter:cohere/command-a": "command-a",
-  "@cf/qwen/qwen1.5-7b-chat-awq": "qwen-1.5-7b",
-  "qwen1.5-7b-chat": "qwen-1.5-7b",
-  "qwen-qwen2-72b-instruct": "qwen-2-72b",
-  "qwen2-72b-instruct": "qwen-2-72b",
+  "cohere/command-a": "command-a",
   "Qwen/Qwen2-72B-Instruct": "qwen-2-72b",
   "openrouter:qwen/qwen-2-72b-instruct": "qwen-2-72b",
   "Qwen/Qwen2-VL-7B-Instruct": "qwen-2-vl-7b",
-  "qwen-qwen2-5": "qwen-2.5",
-  "qwen2.5-72b-instruct": "qwen-2.5-72b",
+  "Qwen/Qwen2.5-7B-Instruct": "qwen-2.5-7b",
+  "hf:Qwen/Qwen2.5-7B-Instruct": "qwen-2.5-7b",
+  "Qwen/Qwen2.5-7B": "qwen-2.5-7b",
+  "qwen/qwen-2.5-7b-instruct": "qwen-2.5-7b",
   "Qwen/Qwen2.5-Coder-32B-Instruct": "qwen-2.5-coder-32b",
-  "qwen-coder": "qwen-3-coder",
-  "qwen25-coder-32b-instruct": "qwen-25-coder-32b",
-  "qwen2.5-coder-32b-instruct": "qwen-2.5-coder-32b",
-  "@cf/qwen/qwen2.5-coder-32b-instruct": "qwen-2.5-coder-32b",
-  "qwen-2.5-1m-demo": "qwen-2.5-1m",
-  "qwen-qwen2-5-max": "qwen-2.5-max",
-  "qwen2.5-vl-72b-instruct": "qwen-2.5-vl-72b",
-  "Qwen/Qwen3-235B-A22B": "qwen-3-235b-a22b",
-  "qwen3-235b-a22b": "qwen-3-235b-a22b",
-  "Qwen/Qwen3-32B": "qwen-3-32b",
-  "qwen3-32b-fp8": "qwen-3-32b",
+  "hf:Qwen/Qwen2.5-72B-Instruct": "qwen-2.5-72b",
+  "qwen/qwen-2.5-72b-instruct": "qwen-2.5-72b",
+  "hf:Qwen/Qwen2.5-Coder-32B-Instruct": "qwen-2.5-coder-32b",
+  "qwen/qwen-2.5-coder-32b-instruct": "qwen-2.5-coder-32b",
+  "Qwen/Qwen2.5-VL-72B-Instruct": "qwen-2.5-vl-72b",
+  "qwen/qwen2.5-vl-72b-instruct": "qwen-2.5-vl-72b",
   "qwen3-32b": "qwen-3-32b",
-  "Qwen/Qwen3-30B-A3B": "qwen-3-30b-a3b",
-  "qwen3-30b-a3b": "qwen-3-30b-a3b",
-  "Qwen/Qwen3-14B": "qwen-3-14b",
-  "qwen3-14b": "qwen-3-14b",
-  "qwen3-4b": "qwen-3-4b",
-  "openrouter:qwen/qwen3-4b:free": "qwen-3-4b",
-  "qwen3-1.7b": "qwen-3-1.7b",
-  "openrouter:qwen/qwen3-1.7b:free": "qwen-3-1.7b",
-  "qwen3-0.6b": "qwen-3-0.6b",
-  "openrouter:qwen/qwen3-0.6b-04-28:free": "qwen-3-0.6b",
+  "Qwen/Qwen3-32B": "qwen-3-32b",
+  "qwen/qwen3-32b": "qwen-3-32b",
   "Qwen/QwQ-32B": "qwq-32b",
-  "qwq-32b-preview": "qwq-32b",
-  "@cf/qwen/qwq-32b": "qwq-32b",
+  "hf:Qwen/QwQ-32B-Preview": "qwq-32b",
   "openrouter:deepseek/deepseek-v3-base:free": "deepseek-v3",
   "deepseek-reasoning": "deepseek-r1",
   "deepseek-ai/DeepSeek-R1": "deepseek-r1",
-  "deepseek-ai/DeepSeek-R1-Turbo": "deepseek-r1-turbo",
+  "deepseek-r1:7b": "deepseek-r1",
+  "deepseek/deepseek-r1": "deepseek-r1",
+  "v3": "deepseek",
   "deepseek-ai/DeepSeek-R1-Distill-Llama-70B": "deepseek-r1-distill-llama-70b",
+  "deepseek/deepseek-r1-distill-llama-70b": "deepseek-r1-distill-llama-70b",
   "openrouter:deepseek/deepseek-r1-distill-qwen-1.5b": "deepseek-r1-distill-qwen-1.5b",
-  "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B": "deepseek-r1-distill-qwen-32b",
-  "deepseek-ai/DeepSeek-Prover-V2-671B": "deepseek-prover-v2-671b",
-  "deepseek-ai/DeepSeek-V3-0324": "deepseek-v3-0324",
-  "deepseek-ai/DeepSeek-V3-0324-Turbo": "deepseek-v3-0324-turbo",
-  "deepseek-ai/DeepSeek-R1-0528": "deepseek-r1-0528",
-  "deepseek-ai/DeepSeek-R1-0528-Turbo": "deepseek-r1-0528-turbo",
-  "grok-2-2024-08-13": "grok-2",
-  "grok-3-preview-02-24": "grok-3",
-  "openrouter:x-ai/grok-3-mini-beta": "grok-3-mini-beta",
-  "moonshotai/Kimi-K2-Instruct": "kimi-k2",
+  "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B": "deepseek-r1-distill-qwen-1.5b",
+  "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B": "deepseek-r1-distill-qwen-14b",
+  "x-ai:x-ai/grok-3": "grok-3",
+  "openrouter:moonshotai/kimi-k2": "kimi-k2",
+  "kimi-k2:1t-cloud": "kimi-k2",
+  "moonshotai/kimi-k2": "kimi-k2",
   "openrouter:perplexity/sonar": "sonar",
+  "perplexity/sonar": "sonar",
   "openrouter:perplexity/sonar-pro": "sonar-pro",
+  "perplexity/sonar-pro": "sonar-pro",
   "openrouter:perplexity/sonar-reasoning": "sonar-reasoning",
   "openrouter:perplexity/sonar-reasoning-pro": "sonar-reasoning-pro",
+  "perplexity/sonar-reasoning-pro": "sonar-reasoning-pro",
   "openrouter:perplexity/r1-1776": "r1-1776",
   "nvidia/Llama-3.1-Nemotron-70B-Instruct-HF": "llama-3.1-nemotron-70b",
-  "openrouter:nvidia/llama-3.1-nemotron-70b-instruct": "llama-3.1-nemotron-70b",
-  "cognitivecomputations/dolphin-2.6-mixtral-8x7b": "dolphin-2.6",
-  "cognitivecomputations/dolphin-2.9.1-llama-3-70b": "dolphin-2.9",
-  "deepinfra/airoboros-70b": "airoboros-70b",
-  "lizpreciatior/lzlv_70b_fp16_hf": "lzlv-70b",
-  "openrouter:liquid/lfm-40b": "lfm-40b",
+  "openrouter:nvidia/llama-3.1-nemotron-70b-instruct": "nemotron-70b",
   "stabilityai/sdxl-turbo": "sdxl-turbo",
-  "turbo": "PollinationsAI:turbo",
+  "turbo": "sdxl-turbo",
   "stabilityai/stable-diffusion-3.5-large": "stable-diffusion-3.5-large",
   "stabilityai-stable-diffusion-3-5-large": "sd-3.5-large",
   "black-forest-labs/FLUX.1-dev": "flux-dev",
   "black-forest-labs-flux-1-dev": "flux-dev",
   "black-forest-labs/FLUX.1-schnell": "flux-schnell",
-  "kontext": "PollinationsAI:kontext",
-  "glm": "glm-4.7",
-  "llama-fast-roblox": "llama-3.2-1b",
-  "llama-roblox": "llama-3.1-8b",
-  "mistral-nemo-roblox": "mistral-nemo-2407",
-  "mistral-roblox": "mistral-small-cloudflare",
-  "openai-roblox": "PollinationsAI:openai-roblox",
-  "qwen": "PollinationsAI:qwen",
-  "bidara": "PollinationsAI:bidara",
-  "hypnosis-tracy": "PollinationsAI:hypnosis-tracy",
-  "midijourney": "PollinationsAI:midijourney",
-  "mirexa": "PollinationsAI:mirexa",
-  "rtist": "PollinationsAI:rtist",
-  "sur": "PollinationsAI:sur",
-  "unity": "PollinationsAI:unity",
-  "alloy": "PollinationsAI:alloy",
-  "echo": "PollinationsAI:echo",
-  "fable": "PollinationsAI:fable",
-  "onyx": "PollinationsAI:onyx",
-  "nova": "PollinationsAI:nova",
-  "shimmer": "PollinationsAI:shimmer",
-  "verse": "PollinationsAI:verse",
-  "ballad": "PollinationsAI:ballad",
-  "ash": "PollinationsAI:ash",
-  "sage": "PollinationsAI:sage",
-  "amuch": "PollinationsAI:amuch",
-  "dan": "PollinationsAI:dan",
-  "chatgpt-4o-latest-20250326": "chatgpt-4o",
-  "qwen1.5-14b-chat": "qwen-1.5-14b",
-  "phi-3-mini-4k-instruct": "phi-3-mini-4k",
-  "claude-3-5-sonnet-20241022": "claude-3-5-sonnet",
-  "dbrx-instruct-preview": "dbrx-instruct",
-  "c4ai-aya-expanse-8b": "aya-expanse-8b",
-  "claude-3-7-sonnet-20250219": "claude-3-7-sonnet",
-  "athene-v2-chat": "athene-v2",
-  "qwen1.5-72b-chat": "qwen-1.5-72b",
-  "openrouter:rekaai/reka-flash-3:free": "reka-flash",
-  "olmo-7b-instruct": "olmo-7b",
-  "@hf/thebloke/openhermes-2.5-mistral-7b-awq": "openhermes-2.5-mistral-7b",
-  "gemini-2.0-flash-thinking-exp-01-21": "gemini-2.0-flash-thinking-exp",
-  "smollm2-1.7b-instruct": "smollm2-1.7b",
-  "mpt-30b-chat": "mpt-30b",
-  "gemini-2.0-flash-lite-preview-02-05": "gemini-2.0-flash-lite",
-  "yi-34b-chat": "yi-34b",
-  "o3-2025-04-16": "o3",
-  "gemini-2.0-pro-exp-02-05": "gemini-2.0-pro-exp",
-  "RWKV-4-Raven-14B": "rwkv-4-raven-14b",
-  "@hf/thebloke/zephyr-7b-beta-awq": "zephyr-7b-beta",
-  "qwen1.5-4b-chat": "qwen-1.5-4b",
-  "internlm2_5-20b-chat": "internlm2.5-20b",
-  "granite-3.1-2b-instruct": "granite-3.1-2b",
-  "codellama-34b-instruct": "codellama-34b",
-  "reka-flash-21b-20240226": "reka-flash-21b",
-  "phi-3-small-8k-instruct": "phi-3-small",
-  "phi-3-mini-128k-instruct": "phi-3-mini-128k",
-  "command-r-plus-08-2024": "command-r-plus24",
-  "@cf/openchat/openchat-3.5-0106": "openchat-3.5-0106",
-  "qwen-14b-chat": "qwen-14b",
-  "granite-3.0-2b-instruct": "granite-3.0-2b",
-  "gemini-1.5-pro-api-0409-preview": "gemini-1.5-pro-api-0409",
-  "deepseek-llm-67b-chat": "deepseek-67b",
-  "gpt-4-1106-preview": "gpt-4-1106",
-  "zephyr-orpo-141b-A35b-v0.1": "zephyr-orpo-141b-a35b-v0.1",
-  "llama-3.1-nemotron-51b-instruct": "nemotron-51b",
-  "mistralai/Mistral-7B-Instruct-v0.2": "mistral-7b-v0.2",
-  "llama-3.1-405b-instruct-bf16": "llama-3.1-405b-instruct",
-  "deepseek-ai/DeepSeek-V3": "deepseek",
-  "llama2-70b-steerlm-chat": "llama-2-70b-steerlm",
-  "claude-3-opus-20240229": "claude-3-opus",
-  "llama-2-13b-chat": "llama-2-13b",
-  "@hf/thebloke/llama-2-13b-chat-awq": "llama-2-13b",
-  "granite-3.0-8b-instruct": "granite-3.0-8b",
-  "falcon-180b-chat": "falcon-180b",
-  "claude-3-5-haiku-20241022": "claude-3-5-haiku",
-  "gpt-4-turbo-2024-04-09": "gpt-4-turbo",
-  "claude-3-sonnet-20240229": "claude-3-sonnet",
-  "grok-2-mini-2024-08-13": "grok-2-mini",
-  "@hf/nexusflow/starling-lm-7b-beta": "starling-lm-7b-beta",
-  "codellama-70b-instruct": "codellama-70b",
-  "c4ai-aya-expanse-32b": "aya-expanse-32b",
-  "qwen1.5-32b-chat": "qwen-1.5-32b",
-  "granite-3.1-8b-instruct": "granite-3.1-8b",
-  "snowflake-arctic-instruct": "snowflake-arctic",
-  "mpt-7b-chat": "mpt-7b",
-  "claude-3-haiku-20240307": "claude-3-haiku",
-  "gpt-4-0125-preview": "gpt-4-0125",
-  "phi-3-medium-4k-instruct": "phi-3-medium",
-  "qwen1.5-110b-chat": "qwen-1.5-110b",
-  "yi-1.5-34b-chat": "yi-1.5-34b",
-  "openrouter:anthropic/claude-3.7-sonnet:thinking": "claude-3.7-sonnet-thinking",
-  "openrouter:qwen/qwen-plus": "qwen-plus",
-  "qwen-max-2025-01-25": "qwen-max",
-  "openrouter:qwen/qwen-max": "qwen-max",
-  "qwen2.5-vl-32b-instruct": "qwen-2.5-vl-32b",
-  "llama-3.3-nemotron-49b-super-v1": "nemotron-49b",
-  "llama-3.1-nemotron-ultra-253b-v1": "nemotron-253b",
-  "openrouter:nvidia/llama-3.1-nemotron-ultra-253b-v1:free": "nemotron-253b",
-  "codestral-2405": "codestral",
-  "openrouter:qwen/qwen-vl-max": "qwen-vl-max",
-  "@cf/qwen/qwen1.5-14b-chat-awq": "qwen-1.5-14b",
-  "openrouter:microsoft/phi-3-medium-128k-instruct": "phi-3-medium",
-  "openrouter:microsoft/phi-3-mini-128k-instruct": "phi-3-mini",
-  "deepseek-llama3.3-70b": "deepseek-llama-3.3-70b",
-  "apriel-5b-instruct": "apriel-5b",
-  "openrouter:nousresearch/hermes-3-llama-3.1-405b": "hermes-3-405b",
-  "openai/gpt-oss-20b": "gpt-oss-20b",
-  "Qwen/Qwen3-Coder-480B-A35B-Instruct-Turbo": "qwen-3-coder-480b-a35b-turbo",
-  "allenai/olmOCR-7B-0725-FP8": "olmocr-7b-0725",
-  "zai-org/GLM-4.5": "glm-4.5",
-  "Qwen/Qwen3-235B-A22B-Thinking-2507": "qwen-3-235b-a22b-thinking-2507",
-  "Qwen/Qwen3-Coder-480B-A35B-Instruct": "qwen-3-coder-480b-a35b",
-  "zai-org/GLM-4.5-Air": "glm-4.5-air",
-  "Qwen/Qwen3-235B-A22B-Instruct-2507": "qwen-3-235b-a22b-2507",
-  "meta-llama/Llama-4-Maverick-17B-128E-Instruct-Turbo": "llama-4-maverick-17b-128e-turbo",
-  "mistralai/Devstral-Small-2507": "devstral-small-2507",
-  "mistralai/Mistral-Small-3.2-24B-Instruct-2506": "mistral-small-3.2-24b-2506",
-  "meta-llama/Llama-Guard-4-12B": "llama-guard-4-12b",
-  "anthropic/claude-4-opus": "claude-4-opus",
-  "anthropic/claude-4-sonnet": "claude-4-sonnet",
-  "meta-llama/Llama-3.3-70B-Instruct-Turbo": "llama-3.3-70b-turbo",
-  "Qwen/Qwen3-Coder-30B-A3B-Instruct": "qwen-3-coder-30b-a3b",
-  "Qwen/Qwen3-4B-Thinking-2507": "qwen-3-4b-thinking-2507",
-  "Qwen/Qwen3-4B-Instruct-2507": "qwen-3-4b-2507",
-  "HuggingFaceTB/SmolLM3-3B": "smollm3-3b",
-  "Qwen/Qwen3-8B": "qwen-3-8b",
-  "Qwen/Qwen3-4B": "qwen-3-4b",
-  "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8": "qwen-3-coder-480b-a35b",
-  "TinyLlama/TinyLlama-1.1B-Chat-v1.0": "tinyllama-1.1b-chat-v1.0",
-  "dphn/Dolphin-Mistral-24B-Venice-Edition": "dolphin-mistral-24b-venice-edition",
-  "Qwen/Qwen3-1.7B": "qwen-3-1.7b",
-  "@cf/meta/llama-3.2-11b-vision-instruct": "llama-3.2-11b-vision",
-  "microsoft/Phi-3.5-mini-instruct": "phi-3.5-mini",
-  "openrouter:microsoft/phi-3.5-mini-128k-instruct": "phi-3.5-mini",
-  "Qwen/Qwen-Image": "qwen-image",
-  "black-forest-labs/FLUX.1-Krea-dev": "flux-krea-dev",
-  "QuantStack/FLUX.1-Krea-dev-GGUF": "flux-krea-dev-gguf",
-  "nunchaku-tech/nunchaku-flux.1-krea-dev": "nunchaku-flux-krea-dev",
-  "city96/Qwen-Image-gguf": "qwen-image-gguf",
-  "MintLab/FLUX-Krea-BLAZE": "flux-krea-blaze",
-  "kpsss34/Stable-Diffusion-3.5-Small-Preview1": "stable-diffusion-3.5-small-preview1",
-  "stabilityai/stable-diffusion-xl-base-1.0": "sdxl-1.0",
-  "stable-diffusion-v1-5/stable-diffusion-v1-5": "stable-diffusion-v1-5",
-  "Qwen/QVQ-72B-Preview": "qvq-72b",
-  "Wan-AI/Wan2.2-TI2V-5B": "wan2.2-ti2v-5b",
-  "Wan-AI/Wan2.2-T2V-A14B": "wan2.2-t2v-a14b",
-  "Wan-AI/Wan2.2-T2V-A14B-Diffusers": "wan2.2-t2v-a14b-diffusers",
-  "tencent/HunyuanVideo": "hunyuanvideo",
-  "Wan-AI/Wan2.1-T2V-14B": "wan2.1-t2v-14b",
-  "Wan-AI/Wan2.1-T2V-1.3B": "wan2.1-t2v-1.3b",
-  "genmo/mochi-1-preview": "mochi-1",
-  "Lightricks/LTX-Video-0.9.7-dev": "ltx-video-0.9.7-dev",
-  "claude-opus-4-20250514": "claude-opus-4",
-  "amazon.nova-pro-v1:0": "amazon.nova-pro",
-  "gemini-2.5-flash-lite-preview-06-17-thinking": "gemini-2.5-flash-lite-preview-thinking",
-  "amazon-nova-experimental-chat-05-14": "amazon-nova-experimental-chat",
-  "X-preview": "x",
-  "stephen-v2": "stephen",
-  "claude-sonnet-4-20250514": "claude-sonnet-4",
-  "qwen3-235b-a22b-no-thinking": "qwen-3-235b-a22b-no-thinking",
-  "hunyuan-turbos-20250416": "hunyuan-turbos",
-  "ernie-x1-turbo-32k-preview": "ernie-x1-turbo-32k",
-  "kimi-k2-0711-preview": "kimi-k2-0711",
-  "imagen-4.0-ultra-generate-preview-06-06": "imagen-4.0-ultra-generate",
-  "ideogram-v2": "ideogram",
-  "recraft-v3": "recraft",
-  "imagen-4.0-generate-preview-06-06": "imagen-4.0-generate",
-  "openrouter:meta-llama/llama-3.3-8b-instruct:free": "llama-3.3-8b",
-  "openrouter:google/gemini-flash-1.5-8b": "gemini-1.5-8b-flash",
-  "openrouter:google/gemini-2.5-flash-preview:thinking": "gemini-2.5-flash-thinking",
-  "openrouter:google/gemma-3-1b-it:free": "gemma-3-1b",
-  "openrouter:openai/gpt-4o-search-preview": "gpt-4o-search",
-  "openrouter:openai/gpt-4o-mini-search-preview": "gpt-4o-mini-search",
-  "openrouter:mistralai/mistral-saba": "mistral-saba",
-  "openrouter:nousresearch/hermes-2-pro-llama-3-8b": "hermes-2-pro-llama-3-8b",
-  "openrouter:nousresearch/hermes-3-llama-3.1-70b": "hermes-3-llama-3.1-70b",
-  "openrouter:nousresearch/deephermes-3-llama-3-8b-preview:free": "deephermes-3-8b",
-  "openrouter:nousresearch/deephermes-3-mistral-24b-preview:free": "deephermes-3-24b",
-  "openrouter:microsoft/phi-4-reasoning:free": "phi-4-reasoning",
-  "openrouter:microsoft/mai-ds-r1:free": "mai-ds-r1",
-  "openrouter:cohere/command": "command",
-  "openrouter:qwen/qwen-vl-plus": "qwen-vl-plus",
-  "openrouter:qwen/qwen-turbo": "qwen-turbo",
-  "openrouter:qwen/qwen2.5-coder-7b-instruct": "qwen-2.5-coder-7b",
-  "openrouter:qwen/qwen2.5-vl-3b-instruct:free": "qwen-2.5-vl-3b",
-  "openrouter:deepseek/deepseek-r1-zero:free": "deepseek-r1-zero",
-  "openrouter:deepseek/deepseek-r1-distill-llama-8b": "deepseek-r1-distill-llama-8b",
-  "openrouter:inflection/inflection-3-productivity": "inflection-3-productivity",
-  "openrouter:inflection/inflection-3-pi": "inflection-3-pi",
-  "openrouter:x-ai/grok-3-beta": "grok-3-beta",
-  "openrouter:perplexity/sonar-deep-research": "sonar-deep-research",
-  "openrouter:perplexity/llama-3.1-sonar-small-128k-online": "llama-3.1-sonar-small-online",
-  "openrouter:perplexity/llama-3.1-sonar-large-128k-online": "llama-3.1-sonar-large-online",
-  "openrouter:thudm/glm-4-9b:free": "glm-4-9b",
-  "openrouter:thudm/glm-z1-9b:free": "glm-z1-9b",
-  "openrouter:thudm/glm-z1-rumination-32b": "glm-z1-rumination-32b",
-  "openrouter:minimax/minimax-01": "minimax-01",
-  "openrouter:cognitivecomputations/dolphin3.0-r1-mistral-24b:free": "dolphin-3.0-r1-24b",
-  "openrouter:cognitivecomputations/dolphin3.0-mistral-24b:free": "dolphin-3.0-24b",
-  "openrouter:cognitivecomputations/dolphin-mixtral-8x22b": "dolphin-8x22b",
-  "openrouter:agentica-org/deepcoder-14b-preview:free": "deepcoder-14b",
-  "openrouter:moonshotai/kimi-vl-a3b-thinking:free": "kimi-vl-thinking",
-  "openrouter:moonshotai/moonlight-16b-a3b-instruct:free": "moonlight-16b",
-  "openrouter:featherless/qwerky-72b:free": "qwerky-72b",
-  "openrouter:liquid/lfm-7b": "lfm-7b",
-  "openrouter:liquid/lfm-3b": "lfm-3b",
-  "@hf/thebloke/deepseek-coder-6.7b-base-awq": "deepseek-coder-6.7b-base",
-  "@hf/thebloke/deepseek-coder-6.7b-instruct-awq": "deepseek-coder-6.7b",
-  "@cf/deepseek-ai/deepseek-math-7b-instruct": "deepseek-math-7b",
-  "@cf/deepseek-ai/deepseek-r1-distill-qwen-32b": "deepseek-distill-qwen-32b",
-  "@cf/tiiuae/falcon-7b-instruct": "falcon-7b",
-  "@hf/google/gemma-7b-it": "gemma-7b",
-  "@hf/nousresearch/hermes-2-pro-mistral-7b": "hermes-2-pro-mistral-7b",
-  "@cf/meta/llama-2-7b-chat-fp16": "llama-2-7b-fp16",
-  "@cf/meta/llama-guard-3-8b": "llama-guard-3-8b",
-  "@hf/thebloke/llamaguard-7b-awq": "llamaguard-7b",
-  "@hf/thebloke/mistral-7b-instruct-v0.1-awq": "mistral-7b-v0.1",
-  "@hf/mistral/mistral-7b-instruct-v0.2": "mistral-7b-v0.2",
-  "@hf/thebloke/neural-chat-7b-v3-1-awq": "neural-7b-v3-1",
-  "@cf/microsoft/phi-2": "phi-2",
-  "@cf/qwen/qwen1.5-0.5b-chat": "qwen1.5-0.5b",
-  "@cf/qwen/qwen1.5-1.8b-chat": "qwen-1.5-1.8b",
-  "@cf/defog/sqlcoder-7b-2": "sqlcoder-7b-2",
-  "@cf/tinyllama/tinyllama-1.1b-chat-v1.0": "tinyllama-1.1b-v1.0",
-  "@cf/thebloke/discolm-german-7b-v1-awq": "discolm-german-7b-v1",
-  "@cf/fblgit/una-cybertron-7b-v2-bf16": "una-cybertron-7b-v2-bf16",
-  "command-r7b-12-2024": "command-r7b24",
-  "command-r7b-arabic-02-2025": "command-r7b-arabic25",
-  "Copilot": "dall-e-3",
-  "microsoft/Phi-4-multimodal-instruct": "phi-4-multimodal",
-  "claude-3-5-sonnet-20240620": "claude-3-5-sonnet",
-  "gpt-4o-mini-audio-preview": "gpt-4o-mini-audio",
-  "gemini": "gemini-3-flash",
-  "geminisearch": "PollinationsAI:geminisearch",
-  "nova-fast": "nova-micro-v1",
-  "flux.1-kontext-pro": "flux-kontext-pro",
-  "zai-org/CogVideoX-5b": "cogvideox-5b",
-  "gpt-5-chat": "gpt-5",
-  "gpt-4o-free": "gpt-4o",
-  "gpt-oss-120b-free": "gpt-oss-120b",
-  "gemini-2.0-flash-free": "gemini-2.0-flash",
-  "gemini-2.5-flash-free": "gemini-2.5-flash",
-  "grok-3-free": "grok-3",
-  "flymy-ai/qwen-image-realism-lora": "qwen-image-realism-lora",
-  "lodestones/Chroma1-HD": "chroma1-hd",
-  "qwen3-coder-plus": "qwen-3-coder-plus",
-  "qwen3-coder-30b-a3b-instruct": "qwen-3-coder-30b-a3b",
-  "qwen-plus-2025-01-25": "qwen-plus",
-  "qwen-turbo-2025-02-11": "qwen-turbo",
-  "GLM-4.5": "glm-4.5",
-  "GLM-4.5-Air": "glm-4.5-air",
-  "GLM-4-32B": "glm-4-32b",
-  "GLM-4.1V-9B-Thinking": "glm-4.1v-9b-thinking",
-  "Z1-Rumination": "z1-rumination",
-  "Z1-32B": "z1-32b",
-  "llama-3.1-405b-instruct-fp8": "llama-3.1-405b-instruct",
-  "o1-2024-12-17": "o1",
-  "meta-llama/llama-3.1-405b-instruct": "llama-3.1-405b",
-  "meta-llama/llama-3.2-3b-instruct": "llama-3.2-3b",
-  "meta-llama/llama-3.3-70b-instruct": "llama-3.3-70b",
-  "llama-3.3-70b-instruct": "llama-3.3-70b",
-  "llama-4-maverick-17b-128e-instruct": "llama-4-maverick-17b-128e",
-  "mistralai/mistral-7b-instruct": "mistral-7b",
-  "mistral-7b-instruct-v0.2": "mistral-7b-v0.2",
-  "mixtral-8x7b-instruct-v0.1": "mixtral-8x7b-v0.1",
-  "mistralai/mistral-nemo": "mistral-nemo",
-  "mistral-small-24b-instruct-2501": "mistral-small-24b-2501",
-  "mistralai/mistral-small-3.1-24b-instruct": "mistral-small-3.1-24b",
-  "mistral-small-3.1-24b-instruct-2503": "mistral-small-3.1-24b-2503",
-  "gemini-1.5-flash-002": "gemini-1.5-flash",
-  "gemini-1.5-pro-002": "gemini-1.5-pro",
-  "gemini-2.0-flash-001": "gemini-2.0-flash",
-  "qwen/qwen-2.5-72b-instruct": "qwen-2.5-72b",
-  "qwen/qwen-2.5-coder-32b-instruct": "qwen-2.5-coder-32b",
-  "qwen2.5-max": "qwen-2.5-max",
-  "qwen/qwen2.5-vl-72b-instruct": "qwen-2.5-vl-72b",
-  "qwen/qwen3-14b": "qwen-3-14b",
-  "qwen/qwen3-4b": "qwen-3-4b",
-  "qwen/qwq-32b": "qwq-32b",
-  "deepseek/deepseek-r1": "deepseek-r1",
-  "deepseek/deepseek-r1-distill-llama-70b": "deepseek-r1-distill-llama-70b",
-  "deepseek/deepseek-r1-distill-qwen-14b": "deepseek-r1-distill-qwen-14b",
-  "deepseek/deepseek-r1-0528": "deepseek-r1-0528",
-  "moonshotai/kimi-k2": "kimi-k2",
-  "llama-3.1-nemotron-70b-instruct": "llama-3.1-nemotron-70b",
-  "qwen/qwen3-235b-a22b": "qwen-3-235b-a22b",
-  "qwen/qwen3-30b-a3b": "qwen-3-30b-a3b",
-  "qwen-max-latest": "qwen-max",
-  "qwen2.5-omni-7b": "qwen-2.5-omni-7b",
-  "qwen/qwen2.5-vl-32b-instruct": "qwen-2.5-vl-32b",
-  "qwen2.5-14b-instruct-1m": "qwen-2.5-14b-1m",
-  "z-ai/glm-4.5-air": "glm-4.5-air",
-  "agentica-org/deepcoder-14b-preview": "deepcoder-14b",
-  "arliai/qwq-32b-arliai-rpr-v1": "qwq-32b-arliai-rpr",
-  "cognitivecomputations/dolphin-mistral-24b-venice-edition": "dolphin-mistral-24b-venice-edition",
-  "cognitivecomputations/dolphin3.0-mistral-24b": "dolphin3.0-mistral-24b",
-  "cognitivecomputations/dolphin3.0-r1-mistral-24b": "dolphin3.0-r1-mistral-24b",
-  "deepseek/deepseek-chat-v3-0324": "deepseek-chat-v3-0324",
-  "deepseek/deepseek-r1-0528-qwen3-8b": "deepseek-r1-0528-qwen-3-8b",
-  "featherless/qwerky-72b": "qwerky-72b",
-  "google/gemini-2.0-flash-exp": "gemini-2.0-flash-exp",
-  "google/gemma-3n-e2b-it": "gemma-3n-e2b-it",
-  "google/gemma-3n-e4b-it": "gemma-3n-e4b-it",
-  "meta-llama/llama-3.2-11b-vision-instruct": "llama-3.2-11b-vision",
-  "microsoft/mai-ds-r1": "mai-ds-r1",
-  "mistralai/devstral-small-2505": "devstral-small-2505",
-  "mistralai/mistral-small-24b-instruct-2501": "mistral-small-24b-2501",
-  "mistralai/mistral-small-3.2-24b-instruct": "mistral-small-3.2-24b",
-  "moonshotai/kimi-dev-72b": "kimi-dev-72b",
-  "moonshotai/kimi-vl-a3b-thinking": "kimi-vl-a3b-thinking",
-  "nousresearch/deephermes-3-llama-3-8b-preview": "deephermes-3-llama-3-8b",
-  "nvidia/llama-3.1-nemotron-ultra-253b-v1": "llama-3.1-nemotron-ultra-253b",
-  "qwen/qwen3-8b": "qwen-3-8b",
-  "qwen/qwen3-coder": "qwen-3-coder",
-  "rekaai/reka-flash-3": "reka-flash-3",
-  "sarvamai/sarvam-m": "sarvam-m",
-  "shisa-ai/shisa-v2-llama3.3-70b": "shisa-v2-llama-3.3-70b",
-  "tencent/hunyuan-a13b-instruct": "hunyuan-a13b",
-  "thudm/glm-z1-32b": "glm-z1-32b",
-  "tngtech/deepseek-r1t-chimera": "deepseek-r1t-chimera",
-  "tngtech/deepseek-r1t2-chimera": "deepseek-r1t2-chimera",
-  "reka-core-20240904": "reka-core",
-  "solar-10.7b-instruct-v1.0": "solar-10.7b-v1.0",
-  "phi-3-mini-4k-instruct-june-2024": "phi-3-mini-4k-june-2024",
-  "reka-flash-20240904": "reka-flash",
-  "deepseek-coder-v2": "deepseek-coder",
-  "mixtral-8x22b-instruct-v0.1": "mixtral-8x22b",
-  "qwen2.5-plus-1127": "qwen-2.5-plus",
-  "nemotron-4-340b-instruct": "nemotron-4-340b",
-  "gemini-1.5-flash-8b-001": "gemini-1.5-flash-8b",
-  "QuantStack/Qwen-Image-Distill-GGUF": "qwen-image-distill-gguf",
-  "imagen-3.0-generate-002": "imagen-3.0-generate",
-  "gpt-5-chat-latest": "gpt-5-chat",
-  "devstral-small-latest": "devstral-small",
-  "magistral-medium-latest": "magistral-medium",
-  "magistral-small-latest": "magistral-small",
-  "mistral-moderation-latest": "mistral-moderation",
-  "mistral-ocr-latest": "mistral-ocr",
-  "qwen3-235b-a22b-thinking-2507": "qwen-3-235b-a22b-thinking-2507",
-  "qwen3-coder-480b-a35b-instruct": "qwen-3-coder-480b-a35b",
-  "qwen3-235b-a22b-instruct-2507": "qwen-3-235b-a22b-2507",
-  "lightx2v/Qwen-Image-Lightning": "qwen-image-lightning",
-  "qwen3-30b-a3b-instruct-2507": "qwen-3-30b-a3b-2507",
-  "claude-opus-4-1-20250805": "claude-opus-4-1",
-  "Bailing-Lite-250220": "bailing-lite-250220",
-  "EB45-vision": "eb45-vision",
-  "hunyuan-t1-20250711": "hunyuan-t1",
-  "gpt-oss:120b": "gpt-oss-120b",
-  "llama3.1-8b": "llama-3.1-8b",
-  "llama3.1-70b": "llama-3.1-70b",
-  "meta-llama/Llama-3.2-3B-Instruct-Turbo": "llama-3.2-3b",
-  "meta-llama/Llama-3.2-11B-Vision-Instruct-Turbo": "llama-3.2-11b",
-  "meta-llama/Llama-3.2-90B-Vision-Instruct-Turbo": "llama-3.2-90b",
-  "mistralai/Mixtral-8x7B-Instruct-v0.1": "mixtral-8x7b",
-  "mixtral-8x7b-32768": "mixtral-8x7b",
-  "mistralai/Mistral-Small-24B-Instruct-2501": "mistral-small-24b-2501",
-  "NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO": "hermes-2-dpo",
-  "google/gemma-2b-it": "gemma-2b",
-  "google/gemma-3n-E4B-it": "gemma-3n-e4b",
-  "Qwen/Qwen2-VL-72B-Instruct": "qwen-2-vl-72b",
-  "Qwen/Qwen2.5-7B-Instruct-Turbo": "qwen-2.5-7b",
-  "Qwen/Qwen2.5-72B-Instruct-Turbo": "qwen-2.5-72b",
-  "Qwen/Qwen2.5-VL-72B-Instruct": "qwen-2.5-vl-72b",
-  "Qwen/Qwen3-32B-FP8": "qwen-3-32b",
-  "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B": "deepseek-r1-distill-qwen-1.5b",
-  "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B": "deepseek-r1-distill-qwen-14b",
-  "perplexity-ai/r1-1776": "r1-1776",
-  "black-forest-labs/FLUX.1-redux": "flux-redux",
-  "black-forest-labs/FLUX.1-depth": "flux-depth",
-  "black-forest-labs/FLUX.1-canny": "flux-canny",
-  "black-forest-labs/FLUX.1-dev-lora": "flux-dev-lora",
-  "GPT-5": "gpt-5",
-  "roblox-rp": "llama-roblox",
-  "elixposearch": "PollinationsAI:elixposearch",
-  "claude": "claude-3-5-haiku",
-  "gpt-4o-mini-image-free": "gpt-4o-mini-image",
-  "gpt-4o-research-free": "gpt-4o-research",
-  "grok-4-expert-free": "grok-4-expert",
-  "grok-4-free": "grok-4",
-  "GLM-4.5V": "glm-4.5v",
-  "zai-org/GLM-4.5V": "glm-4.5v",
-  "glm-4-flash": "\u4efb\u52a1\u4e13\u7528",
-  "deepseek-ai/DeepSeek-R1-0528-Qwen3-8B": "deepseek-r1-0528-qwen-3-8b",
-  "gpt-oss:20b": "gpt-oss-20b",
-  "qwen-vl-max-2025-08-13": "qwen-vl-max",
-  "baichuan-inc/Baichuan-M2-32B": "baichuan-m2-32b",
-  "Arrexel/pattern-diffusion": "pattern-diffusion",
-  "nunchaku-tech/nunchaku-qwen-image": "nunchaku-qwen-image",
-  "stepfun-ai/NextStep-1-Large": "nextstep-1-large",
-  "KBlueLeaf/HDM-xut-340M-anime": "hdm-xut-340m-anime",
-  "EB45-turbo": "eb45-turbo",
-  "black-forest-labs/FLUX.1-kontext-dev": "flux-kontext-dev",
-  "openai/gpt-4": "gpt-4",
-  "openai/gpt-4o:extended": "gpt-4o",
-  "openai/gpt-4o-mini-2024-07-18": "gpt-4o-mini",
-  "o1-preview": "o1",
-  "openai/o1": "o1",
-  "openai/o1-mini-2024-09-12": "o1-mini",
-  "openai/o3-mini": "o3-mini",
-  "openai/o3-mini-high": "o3-mini-high",
-  "openai/o4-mini": "o4-mini",
-  "openai/o4-mini-high": "o4-mini-high",
-  "openai/gpt-4.1": "gpt-4.1",
-  "openai/gpt-4.1-mini": "gpt-4.1-mini",
-  "openai/gpt-4.1-nano": "gpt-4.1-nano",
-  "llama2-7b": "llama-2-7b",
-  "meta/llama2-70b": "llama-2-70b",
-  "llama-2-70b-chat": "llama-2-70b",
-  "llama3-8b": "llama-3-8b",
-  "unsloth/llama-3-8b-Instruct": "llama-3-8b",
-  "meta/llama3-8b-instruct": "llama-3-8b",
-  "meta-llama/llama-3-8b-instruct": "llama-3-8b",
-  "llama3-70b": "llama-3-70b",
-  "meta-llama/Meta-Llama-3-70B-Instruct": "llama-3-70b",
-  "meta/llama3-70b-instruct": "llama-3-70b",
-  "meta-llama/llama-3-70b-instruct": "llama-3-70b",
-  "meta/meta-llama-3-70b-instruct": "llama-3-70b",
-  "hf:meta-llama/Llama-3.1-8B-Instruct": "llama-3.1-8b",
-  "nvidia/Llama-3.1-8B-Instruct-FP8": "llama-3.1-8b",
-  "meta/llama-3.1-8b-instruct": "llama-3.1-8b",
-  "meta-llama/llama-3.1-8b-instruct": "llama-3.1-8b",
-  "hf:meta-llama/Llama-3.1-70B-Instruct": "llama-3.1-70b",
-  "meta-llama/Llama-3.1-70B-Instruct": "llama-3.1-70b",
-  "meta/llama-3.1-70b-instruct": "llama-3.1-70b",
-  "meta-llama/llama-3.1-70b-instruct": "llama-3.1-70b",
-  "hf:meta-llama/Llama-3.1-405B-Instruct": "llama-3.1-405b",
-  "meta/llama-3.1-405b-instruct": "llama-3.1-405b",
-  "meta-llama/llama-3.1-405b-instruct:free": "llama-3.1-405b",
-  "llama3.2-1b": "llama-3.2-1b",
-  "meta/llama-3.2-1b-instruct": "llama-3.2-1b",
-  "meta-llama/llama-3.2-1b-instruct": "llama-3.2-1b",
-  "llama3.2-3b": "llama-3.2-3b",
-  "hf:meta-llama/Llama-3.2-3B-Instruct": "llama-3.2-3b",
-  "meta/llama-3.2-3b-instruct": "llama-3.2-3b",
-  "meta-llama/llama-3.2-3b-instruct:free": "llama-3.2-3b",
-  "llama3.3-70b": "llama-3.3-70b",
-  "hf:meta-llama/Llama-3.3-70B-Instruct": "llama-3.3-70b",
-  "meta/llama-3.3-70b-instruct": "llama-3.3-70b",
-  "meta-llama/llama-3.3-70b-instruct:free": "llama-3.3-70b",
-  "llama4-scout": "llama-4-scout",
-  "meta-llama/llama-4-scout": "llama-4-scout",
-  "llama4-maverick": "llama-4-maverick",
-  "meta-llama/llama-4-maverick": "llama-4-maverick",
-  "mistralai/mistral-7b-instruct:free": "mistral-7b",
-  "mistralai/mixtral-8x7b-instruct": "mixtral-8x7b",
-  "mistralai/mistral-nemo:free": "mistral-nemo",
-  "mistralai/mistral-small-24b-instruct": "mistral-small-24b",
-  "mistralai/mistral-small-3.1-24b-instruct:free": "mistral-small-3.1-24b",
-  "microsoft/phi-4-multimodal-instruct": "phi-4-multimodal",
-  "microsoft/wizardlm-2-8x22b": "wizardlm-2-8x22b",
-  "google/gemini-2.0-flash-001": "gemini-2.0-flash",
-  "google/gemini-2.5-pro-preview-05-06": "gemini-2.5-pro",
-  "google/codegemma-7b": "codegemma-7b",
-  "google/gemma-2b": "gemma-2b",
-  "cohere/command-r": "command-r",
-  "cohere/command-r-plus": "command-r-plus",
-  "cohere/command-a": "command-a",
-  "qwen/qwen-2-72b-instruct": "qwen-2-72b",
-  "qwen2.5": "qwen-2.5",
-  "qwen2.5-7b": "qwen-2.5-7b",
-  "hf:Qwen/Qwen2.5-7B-Instruct": "qwen-2.5-7b",
-  "unsloth/Qwen2.5-7B-Instruct": "qwen-2.5-7b",
-  "qwen/qwen2.5-7b-instruct": "qwen-2.5-7b",
-  "qwen/qwen-2.5-7b-instruct": "qwen-2.5-7b",
-  "qwen2.5-72b": "qwen-2.5-72b",
-  "hf:Qwen/Qwen2.5-72B-Instruct": "qwen-2.5-72b",
-  "qwen/qwen-2.5-72b-instruct:free": "qwen-2.5-72b",
-  "hf:Qwen/Qwen2.5-Coder-32B-Instruct": "qwen-2.5-coder-32b",
-  "qwen/qwen2.5-coder-32b-instruct": "qwen-2.5-coder-32b",
-  "qwen/qwen-2.5-coder-32b-instruct:free": "qwen-2.5-coder-32b",
-  "qwen/qwen2.5-vl-72b-instruct:free": "qwen-2.5-vl-72b",
-  "qwen3-235b": "qwen-3-235b",
-  "qwen/qwen3-32b": "qwen-3-32b",
-  "qwen3-30b": "qwen-3-30b",
-  "qwen/qwen3-14b:free": "qwen-3-14b",
-  "qwen/qwen3-4b:free": "qwen-3-4b",
-  "hf:Qwen/QwQ-32B-Preview": "qwq-32b",
-  "qwen/qwq-32b:free": "qwq-32b",
-  "DeepSeek-R1": "deepseek-r1",
-  "deepseek-ai/deepseek-r1": "deepseek-r1",
-  "deepseek/deepseek-r1:free": "deepseek-r1",
-  "deepseek/deepseek-r1-distill-llama-70b:free": "deepseek-r1-distill-llama-70b",
-  "deepseek/deepseek-r1-distill-qwen-1.5b": "deepseek-r1-distill-qwen-1.5b",
-  "deepseek-ai/deepseek-r1-distill-qwen-14b": "deepseek-r1-distill-qwen-14b",
-  "deepseek/deepseek-r1-distill-qwen-14b:free": "deepseek-r1-distill-qwen-14b",
-  "deepseek-ai/deepseek-r1-distill-qwen-32b": "deepseek-r1-distill-qwen-32b",
-  "deepseek/deepseek-r1-distill-qwen-32b": "deepseek-r1-distill-qwen-32b",
-  "deepseek-ai/deepseek-r1-0528": "deepseek-r1-0528",
-  "deepseek/deepseek-r1-0528:free": "deepseek-r1-0528",
-  "x-ai/grok-3": "grok-3",
-  "moonshotai/kimi-k2-instruct": "kimi-k2",
-  "moonshotai/kimi-k2:free": "kimi-k2",
-  "perplexity/sonar": "sonar",
-  "perplexity/sonar-pro": "sonar-pro",
-  "perplexity/sonar-reasoning": "sonar-reasoning",
-  "perplexity/sonar-reasoning-pro": "sonar-reasoning-pro",
-  "perplexity/r1-1776": "r1-1776",
-  "liquid/lfm-40b": "lfm-40b",
+  "kontext": "flux-kontext",
   "openrouter/auto": "auto",
-  "openai/gpt-5-chat": "gpt-5-chat",
-  "google/gemini-2.5-flash-lite-preview-06-17": "gemini-2.5-flash-lite",
-  "meta-llama/llama-4-scout-17b-16e-instruct": "llama-4-scout-17b-16e",
-  "meta/llama-4-scout-17b-16e-instruct": "llama-4-scout-17b-16e",
-  "openai/o3": "o3",
-  "Qwen/Qwen3-235B-A22B-FP8": "qwen-3-235b-a22b",
-  "qwen/qwen3-235b-a22b:free": "qwen-3-235b-a22b",
-  "qwen/qwen3-30b-a3b:free": "qwen-3-30b-a3b",
-  "qwen/qwen-max": "qwen-max",
-  "qwen/qwen-plus": "qwen-plus",
-  "qwen/qwen-turbo": "qwen-turbo",
-  "Qwen/Qwen2.5-VL-32B-Instruct": "qwen-2.5-vl-32b",
-  "qwen/qwen2.5-vl-32b-instruct:free": "qwen-2.5-vl-32b",
-  "Qwen/Qwen2.5-14B-Instruct-1M": "qwen-2.5-14b-1m",
-  "x-ai/grok-4": "grok-4",
-  "z-ai/glm-4.5": "glm-4.5",
-  "zai-org/GLM-4.5-Air-FP8": "glm-4.5-air",
-  "z-ai/glm-4.5-air:free": "glm-4.5-air",
-  "z-ai/glm-4.5v": "glm-4.5v",
-  "z-ai/glm-4-32b": "glm-4-32b",
-  "zai-org/GLM-4.1V-9B-Thinking": "glm-4.1v-9b-thinking",
-  "thudm/glm-4.1v-9b-thinking": "glm-4.1v-9b-thinking",
-  "agentica-org/DeepCoder-14B-Preview": "deepcoder-14b",
-  "agentica-org/deepcoder-14b-preview:free": "deepcoder-14b",
-  "ArliAI/QwQ-32B-ArliAI-RpR-v4": "qwq-32b-arliai-rpr",
-  "arliai/qwq-32b-arliai-rpr-v1:free": "qwq-32b-arliai-rpr",
-  "cognitivecomputations/dolphin-mistral-24b-venice-edition:free": "dolphin-mistral-24b-venice-edition",
-  "cognitivecomputations/dolphin3.0-mistral-24b:free": "dolphin3.0-mistral-24b",
-  "cognitivecomputations/dolphin3.0-r1-mistral-24b:free": "dolphin3.0-r1-mistral-24b",
-  "deepseek/deepseek-chat-v3-0324:free": "deepseek-chat-v3-0324",
-  "unsloth/DeepSeek-R1-0528-Qwen3-8B": "deepseek-r1-0528-qwen-3-8b",
-  "deepseek/deepseek-r1-0528-qwen3-8b:free": "deepseek-r1-0528-qwen-3-8b",
-  "featherless/qwerky-72b:free": "qwerky-72b",
-  "google/gemini-2.0-flash-exp:free": "gemini-2.0-flash-exp",
-  "hf:google/gemma-2-9b-it": "gemma-2-9b-it",
-  "google/gemma-2-9b-it:free": "gemma-2-9b-it",
-  "google/gemma-3-12b-it:free": "gemma-3-12b-it",
-  "google/gemma-3-27b-it:free": "gemma-3-27b-it",
-  "google/gemma-3-4b-it:free": "gemma-3-4b-it",
-  "google/gemma-3n-e2b-it:free": "gemma-3n-e2b-it",
-  "google/gemma-3n-e4b-it:free": "gemma-3n-e4b-it",
-  "hf:meta-llama/Llama-3.2-11B-Vision-Instruct": "llama-3.2-11b-vision",
-  "meta/llama-3.2-11b-vision-instruct": "llama-3.2-11b-vision",
-  "meta-llama/llama-3.2-11b-vision-instruct:free": "llama-3.2-11b-vision",
-  "microsoft/mai-ds-r1:free": "mai-ds-r1",
-  "mistralai/devstral-small-2505:free": "devstral-small-2505",
-  "Mistral-Small-24B-Instruct-2501": "mistral-small-24b-2501",
-  "mistralai/mistral-small-24b-instruct-2501:free": "mistral-small-24b-2501",
-  "mistralai/mistral-small-3.2-24b-instruct:free": "mistral-small-3.2-24b",
-  "moonshotai/Kimi-Dev-72B": "kimi-dev-72b",
-  "moonshotai/kimi-dev-72b:free": "kimi-dev-72b",
-  "moonshotai/kimi-vl-a3b-thinking:free": "kimi-vl-a3b-thinking",
-  "NousResearch/DeepHermes-3-Llama-3-8B-Preview": "deephermes-3-llama-3-8b",
-  "nousresearch/deephermes-3-llama-3-8b-preview:free": "deephermes-3-llama-3-8b",
-  "nvidia/Llama-3_1-Nemotron-Ultra-253B-v1": "llama-3.1-nemotron-ultra-253b",
-  "nvidia/llama-3.1-nemotron-ultra-253b-v1:free": "llama-3.1-nemotron-ultra-253b",
-  "openai/gpt-oss-20b:free": "gpt-oss-20b",
-  "qwen3-8b": "qwen-3-8b",
-  "qwen/qwen3-8b:free": "qwen-3-8b",
-  "qwen3-coder": "qwen-3-coder",
-  "qwen/qwen3-coder:free": "qwen-3-coder",
-  "rekaai/reka-flash-3:free": "reka-flash-3",
-  "sarvamai/sarvam-m:free": "sarvam-m",
-  "shisa-ai/shisa-v2-llama3.3-70b:free": "shisa-v2-llama-3.3-70b",
-  "tencent/hunyuan-a13b-instruct:free": "hunyuan-a13b",
-  "tngtech/deepseek-r1t-chimera:free": "deepseek-r1t-chimera",
-  "tngtech/deepseek-r1t2-chimera:free": "deepseek-r1t2-chimera",
-  "NousResearch/Hermes-3-Llama-3.1-405B": "hermes-3-llama-3.1-405b",
-  "nousresearch/hermes-3-llama-3.1-405b": "hermes-3-llama-3.1-405b",
-  "hf:nvidia/Llama-3.1-Nemotron-70B-Instruct-HF": "llama-3.1-nemotron-70b",
-  "nvidia/llama-3.1-nemotron-70b-instruct": "llama-3.1-nemotron-70b",
-  "meta-llama/llama-4-maverick-17b-128e-instruct": "llama-4-maverick-17b-128e",
-  "meta-llama/Llama-4-Maverick-17B-128E-Instruct": "llama-4-maverick-17b-128e",
-  "meta/llama-4-maverick-17b-128e-instruct": "llama-4-maverick-17b-128e",
-  "qwen/qwen3-235b-a22b-thinking-2507": "qwen-3-235b-a22b-thinking-2507",
-  "qwen/qwen3-235b-a22b-2507": "qwen-3-235b-a22b-2507",
-  "meta-llama/llama-guard-4-12b": "llama-guard-4-12b",
-  "meta/llama-guard-4-12b": "llama-guard-4-12b",
-  "DeepSeek-V3": "deepseek",
-  "hf:deepseek-ai/DeepSeek-V3": "deepseek",
-  "deepseek/deepseek-chat": "deepseek-chat",
-  "Meta-Llama-3.3-70B-Instruct-Turbo": "llama-3.3-70b-turbo",
-  "mistralai/mistral-7b-instruct-v0.2": "mistral-7b-v0.2",
-  "cohere/command-r-plus-08-2024": "command-r-plus24",
-  "microsoft/phi-3.5-mini-instruct": "phi-3.5-mini",
-  "Qwen/Qwen-Image:replicate": "qwen-image",
-  "black-forest-labs/FLUX.1-Krea-dev:replicate": "flux-krea-dev",
-  "stabilityai/stable-diffusion-xl-base-1.0:hf-inference": "stable-diffusion-xl-base-1.0",
-  "llama3": "llama-3",
-  "Wan-AI/Wan2.2-T2V-A14B:replicate": "wan2.2-t2v-a14b",
-  "Wan-AI/Wan2.2-TI2V-5B:replicate": "wan2.2-ti2v-5b",
-  "tencent/HunyuanVideo:fal-ai": "hunyuanvideo",
-  "genmo/mochi-1-preview:fal-ai": "mochi-1",
-  "Wan-AI/Wan2.1-T2V-14B:replicate": "wan2.1-t2v-14b",
-  "Wan-AI/Wan2.2-T2V-A14B-Diffusers:fal-ai": "wan2.2-t2v-a14b-diffusers",
-  "zai-org/CogVideoX-5b:fal-ai": "cogvideox-5b",
-  "Lightricks/LTX-Video-0.9.7-dev:fal-ai": "ltx-video-0.9.7-dev",
-  "claude-opus-4-latest": "claude-opus-4",
-  "anthropic/claude-opus-4": "claude-opus-4",
-  "openai/chatgpt-4o-latest": "chatgpt-4o",
-  "mistralai/mistral-small-3.1-24b-instruct-2503": "mistral-small-3.1-24b-2503",
-  "x-ai/grok-3-mini-beta": "grok-3-mini-beta",
-  "mistralai/magistral-medium-2506:thinking": "magistral-medium-2506",
-  "claude-sonnet-4-latest": "claude-sonnet-4",
-  "anthropic/claude-sonnet-4": "claude-sonnet-4",
-  "claude-3-7-sonnet-latest": "claude-3-7-sonnet",
-  "minimax/minimax-m1": "minimax-m1",
-  "openai/gpt-5-mini": "gpt-5-mini",
-  "openai/gpt-5-nano": "gpt-5-nano",
-  "openai/o1-pro": "o1-pro",
-  "anthropic/claude-3-haiku": "claude-3-haiku",
-  "mistralai/mistral-large": "mistral-large",
-  "mistralai/ministral-3b": "ministral-3b",
-  "mistralai/ministral-8b": "ministral-8b",
-  "mistralai/mistral-tiny": "mistral-tiny",
-  "mistralai/mistral-small": "mistral-small",
-  "mistralai/pixtral-large-2411": "pixtral-large-2411",
-  "mistralai/codestral-2508": "codestral-2508",
-  "mistralai/devstral-small": "devstral-small",
-  "mistralai/pixtral-12b": "pixtral-12b",
-  "mistralai/mistral-saba": "mistral-saba",
-  "x-ai/grok-vision-beta": "grok-vision-beta",
-  "x-ai/grok-3-mini": "grok-3-mini",
-  "mistralai/mixtral-8x22b-instruct": "mixtral-8x22b",
-  "openai/gpt-3.5-turbo-instruct": "gpt-3.5-turbo",
-  "openai/gpt-4-turbo-preview": "gpt-4-turbo",
-  "openai/gpt-4o-search-preview": "gpt-4o-search",
-  "openai/gpt-4o-mini-search-preview": "gpt-4o-mini-search",
-  "anthropic/claude-3.7-sonnet:thinking": "claude-3.7-sonnet",
-  "anthropic/claude-3.5-haiku-20241022": "claude-3.5-haiku",
-  "anthropic/claude-3.5-sonnet-20240620": "claude-3.5-sonnet",
-  "anthropic/claude-3-opus": "claude-3-opus",
-  "cohere/command": "command",
-  "qwen/qwen-vl-plus": "qwen-vl-plus",
-  "qwen/qwen-vl-max": "qwen-vl-max",
-  "Qwen/Qwen2.5-VL-7B-Instruct": "qwen-2.5-vl-7b",
-  "qwen/qwen-2.5-vl-7b-instruct": "qwen-2.5-vl-7b",
-  "Qwen/Qwen2.5-Coder-7B": "qwen-2.5-coder-7b",
-  "qwen/qwen2.5-coder-7b-instruct": "qwen-2.5-coder-7b",
-  "deepseek/deepseek-prover-v2": "deepseek-prover",
-  "deepseek-ai/DeepSeek-R1-Distill-Llama-8B": "deepseek-r1-distill-llama-8b",
-  "deepseek-ai/deepseek-r1-distill-llama-8b": "deepseek-r1-distill-llama-8b",
-  "deepseek/deepseek-r1-distill-llama-8b": "deepseek-r1-distill-llama-8b",
-  "inflection/inflection-3-productivity": "inflection-3-productivity",
-  "inflection/inflection-3-pi": "inflection-3-pi",
-  "x-ai/grok-3-beta": "grok-3-beta",
-  "perplexity/sonar-deep-research": "sonar-deep-research",
-  "liquid/lfm-7b": "lfm-7b",
-  "liquid/lfm-3b": "lfm-3b",
-  "deepseek-ai/deepseek-coder-6.7b-instruct": "deepseek-coder-6.7b",
-  "google/gemma-7b": "gemma-7b",
-  "llama2-13b": "llama-2-13b",
-  "meta-llama/Llama-Guard-3-8B": "llama-guard-3-8b",
-  "meta-llama/llama-guard-3-8b": "llama-guard-3-8b",
-  "mistralai/mistral-7b-instruct-v0.1": "mistral-7b-v0.1",
-  "HuggingFaceH4/zephyr-7b-beta": "zephyr-7b-beta",
-  "CohereLabs/c4ai-command-r-08-2024": "command-r24",
-  "cohere/command-r-08-2024": "command-r24",
-  "CohereLabs/c4ai-command-r7b-12-2024": "command-r7b24",
-  "cohere/command-r7b-12-2024": "command-r7b24",
-  "CohereLabs/c4ai-command-r7b-arabic-02-2025": "command-r7b-arabic25",
-  "openai/gpt-oss-120b:free": "gpt-oss-120b",
-  "meta-llama/Meta-Llama-3-8B": "llama-3-8b",
-  "RedHatAI/Meta-Llama-3-8B-Instruct-FP8": "llama-3-8b",
-  "meta-llama/Llama-3.1-8B": "llama-3.1-8b",
-  "meta-llama/Llama-3.2-1B-Instruct": "llama-3.2-1b",
-  "meta-llama/llama-4-scout:free": "llama-4-scout",
-  "meta-llama/llama-4-maverick:free": "llama-4-maverick",
-  "alpindale/WizardLM-2-8x22B": "wizardlm-2-8x22b",
-  "CohereLabs/c4ai-command-r-v01": "command-r",
-  "Qwen/Qwen2.5-7B-Instruct": "qwen-2.5-7b",
-  "Gensyn/Qwen2.5-7B-Instruct": "qwen-2.5-7b",
-  "grok-latest": "grok",
-  "black-forest-labs/FLUX.1-kontext-pro": "flux-kontext-pro",
-  "qwen/qwen3-coder-30b-a3b-instruct": "qwen-3-coder-30b-a3b",
-  "qwen-max-2025-08-15": "qwen-max",
-  "deepseek/deepseek-chat-v3.1": "deepseek-chat-v3.1",
-  "deepseek/deepseek-chat-v3.1:free": "deepseek-chat-v3.1",
-  "google/gemini-2.5-flash-image-preview": "gemini-2.5-flash-image",
-  "google/gemini-2.5-flash-image-preview:free": "gemini-2.5-flash-image",
-  "meta-llama/llama-3.3-8b-instruct": "llama-3.3-8b",
-  "meta-llama/llama-3.3-8b-instruct:free": "llama-3.3-8b",
-  "hermes-3-llama-3.1-405b-fp8": "hermes-3-llama-3.1-405b",
-  "deepseek-ai/DeepSeek-V3.1": "deepseek-v3.1",
-  "deepseek-ai/deepseek-v3.1": "deepseek-v3.1",
-  "qwen/qwen3-coder-480b-a35b-instruct": "qwen-3-coder-480b-a35b",
-  "unsloth/Mistral-Small-3.2-24B-Instruct-2506": "mistral-small-3.2-24b-2506",
-  "NousResearch/Hermes-4-70B": "hermes-4-70b",
-  "nousresearch/hermes-4-70b": "hermes-4-70b",
-  "CohereLabs/command-a-translate-08-2025": "command-a-translate25",
-  "NousResearch/Hermes-4-405B": "hermes-4-405b",
-  "nousresearch/hermes-4-405b": "hermes-4-405b",
-  "Qwen/Qwen3-30B-A3B-Instruct-2507": "qwen-3-30b-a3b-2507",
-  "qwen/qwen3-30b-a3b-instruct-2507": "qwen-3-30b-a3b-2507",
-  "bytedance-research/USO": "uso",
-  "blurgy/CoMPaSS-FLUX.1": "compass-flux.1",
-  "blurgy/CoMPaSS-FLUX.1:replicate": "compass-flux.1",
-  "Raelina/Raena-Qwen-Image": "raena-qwen-image",
-  "Raelina/Raena-Qwen-Image:fal-ai": "raena-qwen-image",
-  "kudzueye/boreal-qwen-image": "boreal-qwen-image",
-  "kudzueye/boreal-qwen-image:fal-ai": "boreal-qwen-image",
-  "ostris/qwen_image_edit_inpainting": "qwen-.image.edit.inpainting",
-  "lodestones/Chroma1-Base": "chroma1-base",
-  "speach1sdef178/PJ0_QwenImage_Realistic_FP8_HF_Stage_2": "pj0.qwen-image.realistic.fp8.hf.stage.2",
-  "Lightricks/LTX-Video-0.9.5:fal-ai": "ltx-video-0.9.5",
-  "claude-opus-4-20250522": "claude-opus-4",
-  "claude-3-5-haiku-latest": "claude-3-5-haiku",
-  "claude-opus-4-1-latest": "claude-opus-4-1",
-  "nightride-on-v2": "nightride-on",
-  "mai-1-preview": "mai-1",
-  "claude-3-5-sonnet-latest": "claude-3-5-sonnet",
-  "claude-3-opus-latest": "claude-3-opus",
-  "Qwen/Qwen2.5-Coder-7B-Instruct": "qwen-2.5-coder-7b",
-  "": "default",
-  "openai/gpt-5": "gpt-5",
-  "ChatGLM": "chatglm",
-  "openai/gpt-4o:extended<>OPR": "gpt-4o",
-  "o3-mini-2025-01-31": "o3-mini",
-  "gpt-4.5-preview": "gpt-4.5",
-  "openai/gpt-oss-120b:exacto": "gpt-oss-120b",
-  "openai/gpt-oss-120b:exacto<>OPR": "gpt-oss-120b",
-  "NousResearch/Meta-Llama-3.1-70B-Instruct": "llama-3.1-70b",
-  "Meta-Llama-3.3-70B-Instruct": "llama-3.3-70b",
-  "DeepSeek-R1-Distill-Llama-70B": "deepseek-r1-distill-llama-70b",
-  "kimi-k2:1t": "kimi-k2",
-  "replicate/stability-ai/stable-diffusion-3.5-large": "sd-3.5-large",
-  "replicate/black-forest-labs/flux-dev": "flux-dev",
-  "replicate/black-forest-labs/flux-schnell": "flux-schnell",
-  "replicate/black-forest-labs/flux-dev-lora": "flux-dev-lora",
-  "gpt5": "gpt-5",
-  "gpt5_thinking": "gpt-5-thinking",
-  "Study": "study",
-  "chickytutor": "PollinationsAI:chickytutor",
-  "gemini-search": "gemini-3-flash-search",
-  "gpt-5-mini-2025-08-07": "gpt-5-mini",
-  "gpt-5-nano-2025-08-07": "gpt-5-nano",
-  "replicate/black-forest-labs/flux-kontext-pro": "flux-kontext-pro",
-  "qwen3-max-preview": "qwen-3-max",
-  "qwen3-max-2025-10-20": "qwen-3-max",
-  "qwen/qwen3-max": "qwen-3-max",
-  "qwen3-max": "qwen-3-max",
-  "qwen/qwen-plus-2025-07-28:thinking": "qwen-plus",
-  "qwen/qwen3-coder-plus": "qwen-3-coder-plus",
-  "GLM-4.6": "glm-4.6",
-  "zai-org/GLM-4.6": "glm-4.6",
-  "zai-org/GLM-4.6-FP8": "glm-4.6",
-  "z-ai/glm-4.6:exacto": "glm-4.6",
-  "z-ai/glm-4.6:exacto<>OPR": "glm-4.6",
-  "zai-org/GLM-4.5V-FP8": "glm-4.5v",
-  "0808-360B-DR": "0808-360b-dr",
-  "alibaba/tongyi-deepresearch-30b-a3b:free": "tongyi-deepresearch-30b-a3b",
-  "cognitivecomputations/dolphin-mistral-24b-venice-edition:free<>OPR": "dolphin-mistral-24b-venice-edition",
-  "unsloth/gemma-3-12b-it": "gemma-3-12b-it",
-  "kwaipilot/kat-coder-pro:free": "kat-coder-pro",
-  "kwaipilot/kat-coder-pro:free<>OPR": "kat-coder-pro",
-  "meituan/longcat-flash-chat:free": "longcat-flash-chat",
-  "nousresearch/hermes-3-llama-3.1-405b:free": "hermes-3-llama-3.1-405b",
-  "nvidia/nemotron-nano-12b-v2-vl:free": "nemotron-nano-12b-v2-vl",
-  "nvidia/nemotron-nano-12b-v2-vl": "nemotron-nano-12b-v2-vl",
-  "nvidia/nemotron-nano-9b-v2:free": "nemotron-nano-9b",
-  "qwen3-coder:480b": "qwen-3-coder",
-  "qwen/qwen3-coder:exacto<>OPR": "qwen-3-coder",
-  "tngtech/deepseek-r1t2-chimera:free<>OPR": "deepseek-r1t2-chimera",
-  "MiniMaxAI/MiniMax-M2": "minimax-m2",
-  "minimaxai/minimax-m2": "minimax-m2",
-  "minimax/minimax-m2": "minimax-m2",
-  "moonshotai/Kimi-K2-Thinking": "kimi-k2-thinking",
-  "moonshotai/kimi-k2-thinking": "kimi-k2-thinking",
-  "deepseek-ai/DeepSeek-OCR": "deepseek-ocr",
-  "allenai/olmOCR-2-7B-1025": "olmocr-2-7b-1025",
-  "PaddlePaddle/PaddleOCR-VL-0.9B": "paddleocr-vl-0.9b",
-  "deepseek-ai/DeepSeek-V3.2-Exp": "deepseek-v3.2-exp",
-  "deepseek/deepseek-v3.2-exp": "deepseek-v3.2-exp",
-  "deepseek-ai/DeepSeek-V3.1-Terminus": "deepseek-v3.1-terminus",
-  "deepseek-ai/deepseek-v3.1-terminus": "deepseek-v3.1-terminus",
-  "deepseek/deepseek-v3.1-terminus:exacto": "deepseek-v3.1-terminus",
-  "deepseek/deepseek-v3.1-terminus:exacto<>OPR": "deepseek-v3.1-terminus",
-  "Qwen/Qwen3-Next-80B-A3B-Instruct": "qwen-3-next-80b-a3b",
-  "qwen3-next-80b-a3b-instruct": "qwen-3-next-80b-a3b",
-  "qwen/qwen3-next-80b-a3b-instruct": "qwen-3-next-80b-a3b",
-  "moonshotai/Kimi-K2-Instruct-0905": "moonshotai/Kimi-K2-Instruct",
-  "moonshotai/kimi-k2-instruct-0905": "kimi-k2-0905",
-  "moonshotai/kimi-k2-0905:exacto": "kimi-k2-0905",
-  "moonshotai/kimi-k2-0905:exacto<>OPR": "kimi-k2-0905",
-  "deepseek-v3.1:671b": "deepseek-v3.1",
-  "moonshotai/kimi-k2-Instruct": "moonshotai/Kimi-K2-Instruct",
-  "unsloth/Qwen3-8B": "qwen-3-8b",
-  "swiss-ai/Apertus-8B-Instruct-2509": "apertus-8b-2509",
-  "Meta-Llama-3.2-1B-Instruct": "llama-3.2-1b",
-  "Phr00t/Qwen-Image-Edit-Rapid-AIO": "qwen-image-edit-rapid-aio",
-  "eigen-ai-labs/eigen-banana-qwen-image-edit": "eigen-banana-qwen-image-edit",
-  "briaai/FIBO": "fibo",
-  "briaai/FIBO:replicate": "fibo",
-  "Phil2Sat/Qwen-Image-Edit-Rapid-AIO-GGUF": "qwen-image-edit-rapid-aio-gguf",
-  "lightx2v/Qwen-Image-Lightning:fal-ai": "qwen-image-lightning",
-  "Photoroom/prx-1024-t2i-beta": "prx-1024-t2i-beta",
-  "fal-ai/qwen-image": "qwen-image",
-  "meituan-longcat/LongCat-Video:fal-ai": "longcat-video",
-  "Wan-AI/Wan2.2-TI2V-5B:wavespeed": "wan2.2-ti2v-5b",
-  "Wan-AI/Wan2.1-T2V-14B:wavespeed": "wan2.1-t2v-14b",
-  "akhaliq/veo3.1-fast:replicate": "veo3.1-fast",
-  "akhaliq/sora-2:fal-ai": "sora-2",
-  "Wan-AI/Wan2.1-T2V-1.3B:wavespeed": "wan2.1-t2v-1.3b",
-  "claude-sonnet-4-5-20250929": "claude-sonnet-4-5",
-  "qwen3-vl-235b-a22b-instruct": "qwen-3-vl-235b-a22b",
-  "Qwen/Qwen3-VL-235B-A22B-Instruct": "qwen-3-vl-235b-a22b",
-  "qwen/qwen3-vl-235b-a22b-instruct": "qwen-3-vl-235b-a22b",
-  "gemini-2.5-flash-preview-09-2025": "gemini-2.5-flash-preview25",
-  "google/gemini-2.5-flash-preview-09-2025": "gemini-2.5-flash-preview25",
-  "claude-haiku-4-5-20251001": "claude-haiku-4-5",
-  "qwen3-vl-235b-a22b-thinking": "qwen-3-vl-235b-a22b-thinking",
-  "Qwen/Qwen3-VL-235B-A22B-Thinking": "qwen-3-vl-235b-a22b-thinking",
-  "qwen/qwen3-vl-235b-a22b-thinking": "qwen-3-vl-235b-a22b-thinking",
-  "gemini-2.5-flash-lite-preview-09-2025-no-thinking": "gemini-2.5-flash-lite-preview25-no-thinking",
-  "qwen3-next-80b-a3b-thinking": "qwen-3-next-80b-a3b-thinking",
-  "Qwen/Qwen3-Next-80B-A3B-Thinking": "qwen-3-next-80b-a3b-thinking",
-  "qwen/qwen3-next-80b-a3b-thinking": "qwen-3-next-80b-a3b-thinking",
-  "amazon-nova-experimental-chat-10-09": "amazon-nova-experimental-chat",
-  "CohereLabs/c4ai-command-a-03-2025": "command-a25",
-  "mistralai/magistral-medium-2506:thinking<>OPR": "magistral-medium-2506",
-  "qwen3-vl-8b-thinking": "qwen-3-vl-8b-thinking",
-  "qwen/qwen3-vl-8b-thinking": "qwen-3-vl-8b-thinking",
-  "qwen3-vl-8b-instruct": "qwen-3-vl-8b",
-  "Qwen/Qwen3-VL-8B-Instruct": "qwen-3-vl-8b",
-  "qwen/qwen3-vl-8b-instruct": "qwen-3-vl-8b",
-  "MiMo-7B": "mimo-7b",
-  "qwen3-max-thinking": "qwen-3-max-thinking",
-  "qwen3-omni-flash": "qwen-3-omni-flash",
-  "MiMo-VL-7B-RL-2508": "mimo-vl-7b-rl-2508",
-  "inception/mercury": "mercury",
-  "openai/gpt-5.1": "gpt-5.1",
-  "inclusionai/ring-1t": "ring-1t",
-  "willow-chat-alpha-2025-11-07": "willow-chat-alpha",
-  "imagen-4.0-ultra-generate-001": "imagen-4.0-ultra-generate",
-  "imagen-4.0-generate-001": "imagen-4.0-generate",
-  "wan2.5-preview": "wan2.5",
-  "bytedance/seedream-3": "seedream-3",
-  "replicate/ideogram-ai/ideogram-v3-quality": "ideogram-v3-quality",
-  "imagen-4.0-fast-generate-001": "imagen-4.0-fast-generate",
-  "replicate/luma/photon": "photon",
-  "replicate/recraft-ai/recraft-v3": "recraft",
-  "reve-v1": "reve",
-  "o1-pro-2025-03-19": "o1-pro",
-  "anthropic/claude-haiku-4.5": "claude-haiku-4-5",
-  "anthropic/claude-sonnet-4.5": "claude-sonnet-4-5",
-  "ministral-3b-latest": "ministral-3b",
-  "ministral-8b-latest": "ministral-8b",
-  "mistral-tiny-latest": "mistral-tiny",
-  "pixtral-large-latest": "pixtral-large",
-  "codestral-latest": "codestral",
-  "pixtral-12b-latest": "pixtral-12b",
-  "mistral-small-latest": "mistral-small",
-  "open-mixtral-8x22b": "mixtral-8x22b",
-  "anthropic/claude-3.7-sonnet:thinking<>OPR": "claude-3.7-sonnet",
-  "qwen2.5-vl-7b-instruct": "qwen-2.5-vl-7b",
-  "unsloth/Qwen2.5-Coder-7B-Instruct": "qwen-2.5-coder-7b",
-  "qwen2.5-vl-3b-instruct": "qwen-2.5-vl-3b",
-  "openrouter:openai/gpt-4": "gpt-4",
-  "openrouter:openai/gpt-4o:extended": "gpt-4o",
-  "openrouter:openai/gpt-4o-mini-2024-07-18": "gpt-4o-mini",
-  "openrouter:openai/o1": "o1",
-  "openrouter:openai/o3-mini": "o3-mini",
-  "openrouter:openai/o4-mini": "o4-mini",
-  "openrouter:openai/gpt-4.1": "gpt-4.1",
-  "openrouter:openai/gpt-4.1-mini": "gpt-4.1-mini",
-  "openrouter:openai/gpt-4.1-nano": "gpt-4.1-nano",
-  "openrouter:openai/gpt-oss-120b:free": "gpt-oss-120b",
-  "GPT OSS 120B": "gpt-oss-120b",
-  "NousResearch/Meta-Llama-3.1-8B-Instruct": "llama-3.1-8b",
-  "Meta-Llama-3.1-8B-Instruct": "llama-3.1-8b",
-  "openrouter:mistralai/mistral-7b-instruct:free": "mistral-7b",
-  "openrouter:mistralai/mixtral-8x7b-instruct": "mixtral-8x7b",
-  "openrouter:mistralai/mistral-nemo": "mistral-nemo",
-  "openrouter:mistralai/mistral-small-3.1-24b-instruct:free": "mistral-small-3.1-24b",
-  "Qwen3 235B": "qwen-3-235b",
-  "openrouter:deepseek/deepseek-r1-0528:free": "deepseek-r1-0528",
-  "openrouter:x-ai/grok-3": "grok-3",
-  "openrouter:moonshotai/kimi-k2:free": "kimi-k2",
-  "perplexity-fast": "sonar",
-  "perplexity-reasoning": "sonar-reasoning",
   "gpt-5-2": "gpt-5.2",
-  "openrouter:openai/gpt-5.2": "gpt-5.2",
+  "openai:openai/gpt-5.2": "gpt-5.2",
   "openai/gpt-5.2": "gpt-5.2",
   "gpt-5-2-instant": "gpt-5.2-instant",
   "gpt-5-2-thinking": "gpt-5.2-thinking",
   "gpt-5-1": "gpt-5.1",
-  "openrouter:openai/gpt-5.1": "gpt-5.1",
+  "azure:openai/gpt-5.1": "gpt-5.1",
+  "openai/gpt-5.1": "gpt-5.1",
   "gpt-5-1-instant": "gpt-5.1-instant",
   "gpt-5-1-thinking": "gpt-5.1-thinking",
-  "openrouter:openai/gpt-5": "gpt-5",
-  "openrouter:openai/gpt-5-nano": "gpt-5-nano",
-  "openrouter:qwen/qwen3-coder:free": "qwen-3-coder",
+  "GPT-5": "gpt-5",
+  "gpt-5-free": "gpt-5",
+  "openai:openai/gpt-5": "gpt-5",
+  "openai/gpt-5": "gpt-5",
+  "openai:openai/gpt-5.4": "gpt-5.4",
+  "openai/gpt-5.4": "gpt-5.4",
+  "azure:openai/gpt-5.4-mini": "gpt-5.4-mini",
+  "openai/gpt-5.4-mini": "gpt-5.4-mini",
+  "qwen-coder:14b": "qwen-coder",
+  "mistral:7b-instruct-v0.3-q4_0": "mistral",
   "openrouter:google/gemini-3-flash-preview": "gemini-3-flash",
   "gemini-3-flash-preview": "gemini-3-flash",
+  "gemini-3-flash-preview:cloud": "gemini-3-flash",
   "google/gemini-3-flash-preview": "gemini-3-flash",
-  "gemini-fast": "gemini-2.5-flash-lite",
-  "openrouter:google/gemini-2.5-flash-lite": "gemini-2.5-flash-lite",
-  "google/gemini-2.5-flash-lite": "gemini-2.5-flash-lite",
-  "claude-haiku-4.5": "claude-haiku-4-5",
-  "openrouter:anthropic/claude-haiku-4.5": "claude-haiku-4-5",
-  "claude-sonnet-4.5": "claude-sonnet-4-5",
-  "openrouter:anthropic/claude-sonnet-4.5": "claude-sonnet-4-5",
-  "claude-large": "claude-opus-4.5",
-  "openrouter:anthropic/claude-opus-4.5": "claude-opus-4.5",
-  "anthropic/claude-opus-4.5": "claude-opus-4.5",
-  "gemini-large": "gemini-3-pro",
-  "openrouter:google/gemini-3-pro-preview": "gemini-3-pro",
-  "google/gemini-3-pro-preview": "gemini-3-pro",
-  "zai-org/GLM-4.7": "glm-4.7",
-  "openrouter:z-ai/glm-4.7": "glm-4.7",
-  "zai-org/GLM-4.7-FP8": "glm-4.7",
-  "z-ai/glm-4.7": "glm-4.7",
-  "MiniMax-M3": "minimax-m3",
-  "minimax/minimax-m3": "minimax-m3",
+  "hf:deepseek-ai/DeepSeek-V3": "deepseek",
+  "deepseek-ai/DeepSeek-V3": "deepseek",
+  "deepseek-v2:16b-lite-chat-q8_0": "deepseek",
+  "gemma:2b-instruct": "gemma",
+  "grok-latest": "grok",
+  "x-ai:x-ai/grok-4-20-reasoning": "grok-4-20-reasoning",
+  "anthropic/claude-opus-4.6": "claude-opus-4.6",
+  "anthropic/claude-opus-4.7": "claude-opus-4.7",
+  "openrouter:~moonshotai/kimi-latest": "kimi",
+  "~moonshotai/kimi-latest": "kimi",
+  "minimax:minimax/minimax-m2.7": "minimax-m2.7",
+  "MiniMaxAI/MiniMax-M2.7": "minimax-m2.7",
   "MiniMax-M2.7": "minimax-m2.7",
+  "minimax-m2.7:cloud": "minimax-m2.7",
   "minimax/minimax-m2.7": "minimax-m2.7",
-  "MiniMax-M2.7-highspeed": "minimax-m2.7-highspeed",
-  "minimax/minimax-m2.7-highspeed": "minimax-m2.7-highspeed",
-  "MiniMaxAI/MiniMax-M2.1": "minimax-m2.1",
-  "minimax-m2.1-preview": "minimax-m2.1",
-  "openrouter:minimax/minimax-m2.1": "minimax-m2.1",
-  "minimaxai/minimax-m2.1": "minimax-m2.1",
-  "minimax/minimax-m2.1": "minimax-m2.1",
-  "fal-ai/z-image/turbo": "turbo",
-  "gptimage-large": "gpt-image-1.5",
-  "zimage": "z-image",
-  "openrouter:x-ai/grok-4": "grok-4",
-  "openrouter:openai/gpt-5-chat": "gpt-5-chat",
+  "openrouter:minimax/minimax-01": "minimax-01",
+  "mistralai/mistral-large": "mistral-large",
+  "stepfun-ai/Step-3.5-Flash": "step-3.5-flash",
+  "openrouter:stepfun/step-3.5-flash": "step-3.5-flash",
+  "step-3.5-flash:free": "step-3.5-flash",
+  "stepfun/step-3.5-flash": "step-3.5-flash",
+  "x-ai:x-ai/grok-4": "grok-4",
+  "openrouter:x-ai/grok-3-mini-beta": "grok-3-mini",
+  "qwen3.7-plus": "qwen-3.7-plus",
+  "togetherai:qwen/qwen3.7-plus": "qwen-3.7-plus",
+  "qwen/qwen3.7-plus": "qwen-3.7-plus",
+  "qwen3.7-max": "qwen-3.7-max",
+  "togetherai:qwen/qwen3.7-max": "qwen-3.7-max",
+  "qwen/qwen3.7-max": "qwen-3.7-max",
+  "qwen3.6-plus-preview": "qwen-3.6-plus",
+  "qwen3.6-plus": "qwen-3.6-plus",
+  "alibaba:qwen/qwen3.6-plus": "qwen-3.6-plus",
+  "qwen/qwen3.6-plus": "qwen-3.6-plus",
+  "qwen3.6-max-preview": "qwen-3.6-max",
+  "alibaba:qwen/qwen3.6-max-preview": "qwen-3.6-max",
+  "qwen/qwen3.6-max-preview": "qwen-3.6-max",
+  "qwen3.6-27b": "qwen-3.6-27b",
+  "alibaba:qwen/qwen3.6-27b": "qwen-3.6-27b",
+  "Qwen/Qwen3.6-27B": "qwen-3.6-27b",
+  "qwen/qwen3.6-27b": "qwen-3.6-27b",
+  "qwen-latest-series-invite-beta-v16": "qwen-series-invite-beta",
+  "qwen3.5-plus": "qwen-3.5-plus",
+  "openrouter:qwen/qwen3.5-plus-20260420": "qwen-3.5-plus",
+  "qwen/qwen3.5-plus-02-15": "qwen-3.5-plus",
+  "qwen3.5-omni-plus": "qwen-3.5-omni-plus",
+  "qwen3.6-35b-a3b": "qwen-3.6-35b-a3b",
+  "Qwen/Qwen3.6-35B-A3B": "qwen-3.6-35b-a3b",
+  "alibaba:qwen/qwen3.6-35b-a3b": "qwen-3.6-35b-a3b",
+  "qwen/qwen3.6-35b-a3b": "qwen-3.6-35b-a3b",
+  "qwen3.5-flash": "qwen-3.5-flash",
+  "openrouter:qwen/qwen3.5-flash-02-23": "qwen-3.5-flash",
+  "qwen/qwen3.5-flash-02-23": "qwen-3.5-flash",
+  "qwen3.5-max-2026-03-08": "qwen-3.5-max",
+  "qwen3.5-397b-a17b": "qwen-3.5-397b-a17b",
+  "Qwen/Qwen3.5-397B-A17B": "qwen-3.5-397b-a17b",
+  "alibaba:qwen/qwen3.5-397b-a17b": "qwen-3.5-397b-a17b",
+  "qwen/qwen3.5-397b-a17b": "qwen-3.5-397b-a17b",
+  "qwen3.5-122b-a10b": "qwen-3.5-122b-a10b",
+  "alibaba:qwen/qwen3.5-122b-a10b": "qwen-3.5-122b-a10b",
+  "Qwen/Qwen3.5-122B-A10B": "qwen-3.5-122b-a10b",
+  "qwen/qwen3.5-122b-a10b": "qwen-3.5-122b-a10b",
+  "qwen3.5-omni-flash": "qwen-3.5-omni-flash",
+  "qwen3.5-27b": "qwen-3.5-27b",
+  "alibaba:qwen/qwen3.5-27b": "qwen-3.5-27b",
+  "Qwen/Qwen3.5-27B": "qwen-3.5-27b",
+  "qwen/qwen3.5-27b": "qwen-3.5-27b",
+  "qwen3.5-35b-a3b": "qwen-3.5-35b-a3b",
+  "alibaba:qwen/qwen3.5-35b-a3b": "qwen-3.5-35b-a3b",
+  "Qwen/Qwen3.5-35B-A3B": "qwen-3.5-35b-a3b",
+  "qwen/qwen3.5-35b-a3b": "qwen-3.5-35b-a3b",
+  "qwen3-max-2026-01-23": "qwen-3-max",
+  "Qwen/Qwen3-Max": "qwen-3-max",
   "qwen3-max-2025-09-26": "qwen-3-max",
-  "openrouter:qwen/qwen3-max": "qwen-3-max",
-  "qwen/qwen-plus-2025-07-28:thinking<>OPR": "qwen-plus",
-  "openrouter:qwen/qwen3-235b-a22b": "qwen-3-235b-a22b",
-  "openrouter:qwen/qwen3-coder-plus": "qwen-3-coder-plus",
-  "openrouter:qwen/qwen3-30b-a3b": "qwen-3-30b-a3b",
-  "openrouter:qwen/qwen3-coder-30b-a3b-instruct": "qwen-3-coder-30b-a3b",
-  "arcee-ai/trinity-mini:free": "trinity-mini",
-  "openrouter:arcee-ai/trinity-mini:free": "trinity-mini",
-  "openrouter:cognitivecomputations/dolphin-mistral-24b-venice-edition:free": "dolphin-mistral-24b-venice-edition",
-  "openrouter:google/gemini-2.0-flash-exp:free": "gemini-2.0-flash-exp",
-  "openrouter:google/gemma-3-12b-it:free": "gemma-3-12b-it",
-  "openrouter:google/gemma-3-27b-it:free": "gemma-3-27b-it",
-  "openrouter:google/gemma-3-4b-it:free": "gemma-3-4b-it",
-  "openrouter:google/gemma-3n-e2b-it:free": "gemma-3n-e2b-it",
-  "openrouter:google/gemma-3n-e4b-it:free": "gemma-3n-e4b-it",
-  "openrouter:kwaipilot/kat-coder-pro:free": "kat-coder-pro",
-  "mistralai/devstral-2512:free": "devstral-2512",
-  "openrouter:mistralai/devstral-2512:free": "devstral-2512",
-  "openrouter:nousresearch/hermes-3-llama-3.1-405b:free": "hermes-3-llama-3.1-405b",
-  "nvidia/nemotron-3-nano-30b-a3b:free": "nemotron-3-nano-30b-a3b",
-  "nvidia/Nemotron-3-Nano-30B-A3B": "nemotron-3-nano-30b-a3b",
-  "openrouter:nvidia/nemotron-3-nano-30b-a3b:free": "nemotron-3-nano-30b-a3b",
-  "nvidia/nemotron-3-nano-30b-a3b": "nemotron-3-nano-30b-a3b",
-  "nvidia/nemotron-3-nano-30b-a3b:free<>no-think<>OPR": "nemotron-3-nano-30b-a3b",
-  "openrouter:nvidia/nemotron-nano-12b-v2-vl:free": "nemotron-nano-12b-v2-vl",
-  "openrouter:nvidia/nemotron-nano-9b-v2:free": "nemotron-nano-9b",
-  "openrouter:openai/gpt-oss-20b:free": "gpt-oss-20b",
-  "qwen/qwen-2.5-vl-7b-instruct:free": "qwen-2.5-vl-7b",
-  "openrouter:tngtech/deepseek-r1t-chimera:free": "deepseek-r1t-chimera",
-  "openrouter:tngtech/deepseek-r1t2-chimera:free": "deepseek-r1t2-chimera",
-  "tngtech/tng-r1t-chimera:free": "tng-r1t-chimera",
-  "openrouter:tngtech/tng-r1t-chimera:free": "tng-r1t-chimera",
-  "xiaomi/mimo-v2-flash:free": "mimo-v2-flash",
-  "XiaomiMiMo/MiMo-V2-Flash": "mimo-v2-flash",
-  "openrouter:xiaomi/mimo-v2-flash:free": "mimo-v2-flash",
-  "xiaomi/mimo-v2-flash:free<>OPR": "mimo-v2-flash",
-  "openrouter:z-ai/glm-4.5-air:free": "glm-4.5-air",
+  "alibaba:qwen/qwen3-max": "qwen-3-max",
+  "qwen3-max": "qwen-3-max",
+  "qwen/qwen3-max": "qwen-3-max",
+  "qwen-plus-2025-07-28": "qwen-plus",
+  "openrouter:qwen/qwen-plus": "qwen-plus",
+  "qwen/qwen-plus": "qwen-plus",
+  "qwen3-coder-plus": "qwen-3-coder-plus",
+  "alibaba:qwen/qwen3-coder-plus": "qwen-3-coder-plus",
+  "qwen/qwen3-coder-plus": "qwen-3-coder-plus",
+  "qwen3-vl-plus": "qwen-3-vl-plus",
+  "alibaba:qwen/qwen3-vl-plus": "qwen-3-vl-plus",
+  "qwen3-omni-flash-2025-12-01": "qwen-3-omni-flash",
+  "qwen3-omni-flash": "qwen-3-omni-flash",
+  "alibaba:qwen/qwen3-omni-flash": "qwen-3-omni-flash",
+  "gpt-4o-mini-image-free": "gpt-4o-mini-image",
+  "grok-4.1-fast-free": "grok-4.1-fast",
+  "openrouter-free": "openrouter",
+  "zai-org/GLM-5.2": "glm-5.2",
+  "zai-org/GLM-5.2-FP8": "glm-5.2",
+  "z-ai:z-ai/glm-5.2": "glm-5.2",
+  "glm-5.2:cloud": "glm-5.2",
+  "z-ai/glm-5.2": "glm-5.2",
+  "moonshotai/Kimi-K2.7-Code": "kimi-k2.7-code",
+  "togetherai:moonshotai/kimi-k2.7-code": "kimi-k2.7-code",
+  "kimi-k2.7-code:cloud": "kimi-k2.7-code",
+  "moonshotai/kimi-k2.7-code": "kimi-k2.7-code",
+  "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B": "nvidia-nemotron-3-ultra-550b-a55b",
+  "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16": "nvidia-nemotron-3-ultra-550b-a55b",
+  "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning": "nemotron-3-nano-omni-30b-a3b-reasoning",
+  "openrouter:nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free": "nemotron-3-nano-omni-30b-a3b-reasoning",
+  "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free": "nemotron-3-nano-omni-30b-a3b-reasoning",
+  "deepseek-ai/DeepSeek-V4-Flash": "deepseek-v4-flash",
+  "deepseek:deepseek/deepseek-v4-flash": "deepseek-v4-flash",
+  "deepseek-v4-flash:cloud": "deepseek-v4-flash",
+  "deepseek/deepseek-v4-flash": "deepseek-v4-flash",
+  "deepseek-ai/DeepSeek-V4-Pro": "deepseek-v4-pro",
+  "deepseek:deepseek/deepseek-v4-pro": "deepseek-v4-pro",
+  "deepseek-v4-pro:cloud": "deepseek-v4-pro",
+  "deepseek/deepseek-v4-pro": "deepseek-v4-pro",
+  "moonshotai/Kimi-K2.6": "kimi-k2.6",
+  "moonshotai:moonshotai/kimi-k2.6": "kimi-k2.6",
+  "kimi-k2.6:cloud": "kimi-k2.6",
+  "moonshotai/kimi-k2.6": "kimi-k2.6",
+  "XiaomiMiMo/MiMo-V2.5": "mimo-v2.5",
+  "openrouter:xiaomi/mimo-v2.5": "mimo-v2.5",
+  "xiaomi/mimo-v2.5": "mimo-v2.5",
+  "XiaomiMiMo/MiMo-V2.5-Pro": "mimo-v2.5-pro",
+  "openrouter:xiaomi/mimo-v2.5-pro": "mimo-v2.5-pro",
+  "xiaomi/mimo-v2.5-pro": "mimo-v2.5-pro",
+  "zai-org/GLM-5.1": "glm-5.1",
+  "z-ai:z-ai/glm-5.1": "glm-5.1",
+  "zai-org/GLM-5.1-FP8": "glm-5.1",
+  "glm-5.1:cloud": "glm-5.1",
+  "z-ai/glm-5.1": "glm-5.1",
+  "google/gemma-4-26B-A4B-it": "gemma-4-26b-a4b-it",
+  "openrouter:google/gemma-4-26b-a4b-it:free": "gemma-4-26b-a4b-it",
+  "google/gemma-4-26b-a4b-it": "gemma-4-26b-a4b-it",
+  "google/gemma-4-31B-it": "gemma-4-31b-it",
+  "togetherai:google/gemma-4-31b-it": "gemma-4-31b-it",
+  "google/gemma-4-31b-it": "gemma-4-31b-it",
+  "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B": "nvidia-nemotron-3-super-120b-a12b",
+  "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16": "nvidia-nemotron-3-super-120b-a12b",
+  "zai-org/GLM-5": "glm-5",
+  "z-ai:z-ai/glm-5": "glm-5",
+  "glm-5:cloud": "glm-5",
+  "z-ai/glm-5": "glm-5",
+  "MiniMaxAI/MiniMax-M2.5": "minimax-m2.5",
+  "minimax:minimax/minimax-m2.5": "minimax-m2.5",
+  "minimax-m2.5:cloud": "minimax-m2.5",
+  "minimax/minimax-m2.5": "minimax-m2.5",
+  "Qwen/Qwen3-Max-Thinking": "qwen-3-max-thinking",
+  "qwen3-max-thinking": "qwen-3-max-thinking",
+  "openrouter:qwen/qwen3-max-thinking": "qwen-3-max-thinking",
+  "qwen/qwen3-max-thinking": "qwen-3-max-thinking",
+  "moonshotai/Kimi-K2.5": "kimi-k2.5",
+  "moonshotai:moonshotai/kimi-k2.5": "kimi-k2.5",
+  "kimi-k2.5:cloud": "kimi-k2.5",
+  "moonshotai/kimi-k2.5": "kimi-k2.5",
+  "zai-org/GLM-4.7-Flash": "glm-4.7-flash",
+  "z-ai:z-ai/glm-4.7-flash": "glm-4.7-flash",
+  "glm-4.7-flash:latest": "glm-4.7-flash",
+  "z-ai/glm-4.7-flash": "glm-4.7-flash",
   "deepseek-ai/DeepSeek-V3.2": "deepseek-v3.2",
   "openrouter:deepseek/deepseek-v3.2": "deepseek-v3.2",
-  "deepseek-ai/deepseek-v3.2": "deepseek-v3.2",
-  "deepseek-v3.2:free": "deepseek-v3.2",
+  "deepseek-v3.2:cloud": "deepseek-v3.2",
   "deepseek/deepseek-v3.2": "deepseek-v3.2",
-  "minimax-m2-preview": "minimax-m2",
-  "openrouter:minimax/minimax-m2": "minimax-m2",
-  "openrouter:moonshotai/kimi-k2-thinking": "kimi-k2-thinking",
-  "openrouter:deepseek/deepseek-v3.2-exp": "deepseek-v3.2-exp",
-  "openrouter:deepseek/deepseek-v3.1-terminus:exacto": "deepseek-v3.1-terminus",
-  "openrouter:qwen/qwen3-next-80b-a3b-instruct": "qwen-3-next-80b-a3b",
-  "kimi-k2-0905-preview": "kimi-k2-0905",
-  "openrouter:moonshotai/kimi-k2-0905:exacto": "kimi-k2-0905",
-  "openrouter:z-ai/glm-4.5": "glm-4.5",
-  "openrouter:qwen/qwen3-235b-a22b-thinking-2507": "qwen-3-235b-a22b-thinking-2507",
-  "openrouter:qwen/qwen3-235b-a22b-2507": "qwen-3-235b-a22b-2507",
-  "openrouter:meta-llama/llama-guard-4-12b": "llama-guard-4-12b",
-  "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8": "nvidia-nemotron-3-nano-30b-a3b",
-  "nvidia-nemotron-3-nano-30b-a3b-bf16": "nvidia-nemotron-3-nano-30b-a3b",
-  "google/gemma-2-2b-it": "gemma-2-2b-it",
+  "black-forest-labs/FLUX-2-klein-4b": "flux-2-klein-4b",
+  "black-forest-labs/FLUX-2-klein-9b": "flux-2-klein-9b",
+  "empero-ai/Qwythos-9B-Claude-Mythos-5-1M": "qwythos-9b-claude-mythos-5-1m",
+  "WeiboAI/VibeThinker-3B": "vibethinker-3b",
+  "deepreinforce-ai/Ornith-1.0-9B": "ornith-1.0-9b",
+  "microsoft/FastContext-1.0-4B-SFT": "fastcontext-1.0-4b-sft",
+  "empero-ai/Qwable-9B-Claude-Fable-5": "qwable-9b-claude-fable-5",
+  "DJLougen/Qwable-5-27B-Coder": "qwable-5-27b-coder",
+  "Gryphe/Gemma-4-26B-A4B-StyleTune-V2": "gemma-4-26b-a4b-styletune",
+  "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4": "nvidia-nemotron-3-ultra-550b-a55b-nvfp4",
+  "microsoft/FastContext-1.0-4B-RL": "fastcontext-1.0-4b-rl",
+  "Qwen/Qwen3-8B": "qwen-3-8b",
+  "qwen3-8b": "qwen-3-8b",
+  "qwen/qwen3-8b": "qwen-3-8b",
+  "AEON-7/Qwen3.6-27B-AEON-Ultimate-Uncensored-BF16": "qwen-3.6-27b-aeon-ultimate-uncensored",
+  "Qwen/Qwen3-Coder-30B-A3B-Instruct": "qwen-3-coder-30b-a3b",
+  "alibaba:qwen/qwen3-coder-30b-a3b-instruct": "qwen-3-coder-30b-a3b",
+  "qwen3-coder-30b-a3b": "qwen-3-coder-30b-a3b",
+  "qwen/qwen3-coder-30b-a3b-instruct": "qwen-3-coder-30b-a3b",
+  "Qwen/Qwen3-Coder-Next": "qwen-3-coder-next",
+  "openrouter:qwen/qwen3-coder-next": "qwen-3-coder-next",
+  "qwen3-coder-next": "qwen-3-coder-next",
+  "qwen3-coder-next:q8_0": "qwen-3-coder-next",
+  "qwen/qwen3-coder-next": "qwen-3-coder-next",
+  "meta-llama/Llama-3.2-1B-Instruct": "llama-3.2-1b",
+  "meta-llama/llama-3.2-1b-instruct": "llama-3.2-1b",
+  "BennyDaBall/Z-Image-Engineer-V6": "z-image-engineer",
   "openrouter:meta-llama/llama-3.2-11b-vision-instruct": "llama-3.2-11b-vision",
+  "hf:meta-llama/Llama-3.2-11B-Vision-Instruct": "llama-3.2-11b-vision",
+  "meta-llama/llama-3.2-11b-vision-instruct": "llama-3.2-11b-vision",
   "openrouter:cohere/command-r-plus-08-2024": "command-r-plus24",
-  "Qwen/Qwen-Image-2512": "qwen-image-2512",
-  "Qwen/Qwen-Image-2512:replicate": "qwen-image-2512",
-  "fal-ai/qwen-image-2512": "qwen-image-2512",
-  "unsloth/Qwen-Image-2512-GGUF": "qwen-image-2512-gguf",
-  "Wuli-art/Qwen-Image-2512-Turbo-LoRA": "qwen-image-2512-turbo-lora",
+  "command-r-plus-08-2024": "command-r-plus24",
+  "cohere/command-r-plus-08-2024": "command-r-plus24",
+  "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B": "deepseek-r1-distill-qwen-32b",
+  "hf:nvidia/Llama-3.1-Nemotron-70B-Instruct-HF": "llama-3.1-nemotron-70b",
+  "krea/Krea-2-Turbo": "krea-2-turbo",
+  "krea/Krea-2-Turbo:fal-ai": "krea-2-turbo",
+  "krea/Krea-2-Raw": "krea-2-raw",
+  "AlperKTS/Krea2_FP8": "krea2.fp8",
+  "ideogram-ai/ideogram-4-fp8": "ideogram-4",
+  "ideogram-ai/ideogram-4-fp8:fal-ai": "ideogram-4",
   "Tongyi-MAI/Z-Image-Turbo": "z-image-turbo",
   "Tongyi-MAI/Z-Image-Turbo:wavespeed": "z-image-turbo",
-  "lightx2v/Qwen-Image-2512-Lightning": "qwen-image-2512-lightning",
-  "fal/FLUX.2-dev-Turbo": "flux.2-dev-turbo",
-  "fal/FLUX.2-dev-Turbo:fal-ai": "flux.2-dev-turbo",
-  "inclusionAI/TwinFlow-Z-Image-Turbo": "twinflow-z-image-turbo",
-  "lodestones/Zeta-Chroma": "zeta-chroma",
+  "vantagewithai/Krea-2-Turbo-GGUF": "krea-2-turbo-gguf",
+  "ostris/ideogram_4_turbotime_lora": "ideogram.4.turbotime.lora",
+  "ostris/ideogram_4_turbotime_lora:fal-ai": "ideogram.4.turbotime.lora",
+  "krea/Krea-2-LoRA-retroanime": "krea-2-lora-retroanime",
+  "krea/Krea-2-LoRA-retroanime:fal-ai": "krea-2-lora-retroanime",
+  "ideogram-ai/ideogram-4-nf4": "ideogram-4-nf4",
+  "Phr00t/Qwen-Image-Edit-Rapid-AIO": "qwen-image-edit-rapid-aio",
+  "gokaygokay/Krea-2-Realism-LoRA": "krea-2-realism-lora",
+  "ponpoke/flux2-klein-9b-uncensored-text-encoder": "flux2-klein-9b-uncensored-text-encoder",
+  "llama3:8b-instruct-q4_K_M": "llama-3",
+  "moonshotai/Kimi-K2-Instruct-0905": "kimi-k2-0905",
+  "Qwen/QVQ-72B-Preview": "qvq-72b",
+  "stabilityai/stable-diffusion-xl-base-1.0": "sdxl-1.0",
+  "Wan-AI/Wan2.2-TI2V-5B:wavespeed": "wan2.2-ti2v-5b",
+  "meituan-longcat/LongCat-Video:fal-ai": "longcat-video",
+  "Wan-AI/Wan2.1-T2V-1.3B:wavespeed": "wan2.1-t2v-1.3b",
+  "Wan-AI/Wan2.1-T2V-14B:wavespeed": "wan2.1-t2v-14b",
   "tencent/HunyuanVideo-1.5:wavespeed": "hunyuanvideo-1.5",
+  "Wan-AI/Wan2.2-T2V-A14B:replicate": "wan2.2-t2v-a14b",
   "Wan-AI/Wan2.2-T2V-A14B-Diffusers:replicate": "wan2.2-t2v-a14b-diffusers",
-  "htdong/Wan-Alpha:fal-ai": "wan-alpha",
+  "zai-org/CogVideoX-5b:fal-ai": "cogvideox-5b",
+  "genmo/mochi-1-preview:fal-ai": "mochi-1",
+  "Max": "max",
+  "anthropic:anthropic/claude-opus-4-6": "claude-opus-4-6",
+  "anthropic:anthropic/claude-opus-4-7": "claude-opus-4-7",
+  "gpt-5.2-chat-latest": "gpt-5.2-chat",
+  "openai:openai/gpt-5.2-chat": "gpt-5.2-chat",
+  "openai/gpt-5.2-chat": "gpt-5.2-chat",
+  "anthropic:anthropic/claude-sonnet-4-6": "claude-sonnet-4-6",
   "claude-opus-4-5-20251101": "claude-opus-4-5",
-  "openrouter:qwen/qwen3-vl-8b-thinking": "qwen-3-vl-8b-thinking",
-  "openrouter:qwen/qwen3-vl-8b-instruct": "qwen-3-vl-8b",
+  "anthropic:anthropic/claude-opus-4-5": "claude-opus-4-5",
+  "ernie-5.1-preview": "ernie-5.1",
+  "claude-sonnet-4-5-20250929": "claude-sonnet-4-5",
+  "anthropic:anthropic/claude-sonnet-4-5": "claude-sonnet-4-5",
+  "claude-sonnet-4.5": "claude-sonnet-4-5",
+  "anthropic/claude-sonnet-4.5": "claude-sonnet-4-5",
+  "gpt-5.3-chat-latest": "gpt-5.3-chat",
+  "openrouter:openai/gpt-5.3-chat": "gpt-5.3-chat",
+  "openai/gpt-5.3-chat": "gpt-5.3-chat",
+  "minimax:minimax/minimax-m3": "minimax-m3",
+  "MiniMaxAI/MiniMax-M3": "minimax-m3",
+  "MiniMax-M3": "minimax-m3",
+  "minimax-m3:cloud": "minimax-m3",
+  "minimax/minimax-m3": "minimax-m3",
+  "claude-opus-4-1-20250805": "claude-opus-4-1",
+  "anthropic:anthropic/claude-opus-4-1": "claude-opus-4-1",
+  "claude-opus-4-1-latest": "claude-opus-4-1",
+  "z-ai:z-ai/glm-4.7": "glm-4.7",
+  "zai-org/GLM-4.7": "glm-4.7",
+  "glm-4.7:cloud": "glm-4.7",
+  "z-ai/glm-4.7": "glm-4.7",
+  "o3-2025-04-16": "o3",
+  "openai:openai/o3": "o3",
+  "openai/o3": "o3",
+  "openai:openai/gpt-5-chat": "gpt-5-chat",
+  "openai/gpt-5-chat": "gpt-5-chat",
+  "qwen3-235b-a22b-instruct-2507": "qwen-3-235b-a22b-2507",
+  "togetherai:qwen/qwen3-235b-a22b-instruct-2507-tput": "qwen-3-235b-a22b-2507",
+  "Qwen/Qwen3-235B-A22B-Instruct-2507": "qwen-3-235b-a22b-2507",
+  "qwen/qwen3-235b-a22b-2507": "qwen-3-235b-a22b-2507",
+  "kimi-k2-0905-preview": "kimi-k2-0905",
+  "openrouter:moonshotai/kimi-k2-0905": "kimi-k2-0905",
+  "moonshotai/kimi-k2-0905": "kimi-k2-0905",
+  "kimi-k2-0711-preview": "kimi-k2-0711",
+  "mistral-large-3:675b": "mistral-large-3",
+  "mistral-large-3:675b-cloud": "mistral-large-3",
+  "qwen3-vl-235b-a22b-instruct": "qwen-3-vl-235b-a22b",
+  "openrouter:qwen/qwen3-vl-235b-a22b-instruct": "qwen-3-vl-235b-a22b",
+  "qwen3-vl-235b-a22b": "qwen-3-vl-235b-a22b",
+  "Qwen/Qwen3-VL-235B-A22B-Instruct": "qwen-3-vl-235b-a22b",
+  "qwen/qwen3-vl-235b-a22b-instruct": "qwen-3-vl-235b-a22b",
+  "claude-opus-4-20250514": "claude-opus-4",
+  "anthropic:anthropic/claude-opus-4": "claude-opus-4",
+  "claude-opus-4-20250522": "claude-opus-4",
+  "anthropic/claude-opus-4": "claude-opus-4",
+  "claude-haiku-4-5-20251001": "claude-haiku-4-5",
+  "anthropic:anthropic/claude-haiku-4-5": "claude-haiku-4-5",
+  "claude-haiku-4.5": "claude-haiku-4-5",
+  "anthropic/claude-haiku-4.5": "claude-haiku-4-5",
+  "mistralai:mistralai/mistral-medium-2508": "mistral-medium-2508",
+  "qwen3-235b-a22b-no-thinking": "qwen-3-235b-a22b-no-thinking",
+  "qwen3-next-80b-a3b-instruct": "qwen-3-next-80b-a3b",
+  "openrouter:qwen/qwen3-next-80b-a3b-instruct:free": "qwen-3-next-80b-a3b",
+  "qwen3-next-80b-a3b": "qwen-3-next-80b-a3b",
+  "Qwen/Qwen3-Next-80B-A3B-Instruct": "qwen-3-next-80b-a3b",
+  "qwen/qwen3-next-80b-a3b-instruct": "qwen-3-next-80b-a3b",
+  "qwen3-235b-a22b-thinking-2507": "qwen-3-235b-a22b-thinking-2507",
+  "openrouter:qwen/qwen3-235b-a22b-thinking-2507": "qwen-3-235b-a22b-thinking-2507",
+  "Qwen/Qwen3-235B-A22B-Thinking-2507": "qwen-3-235b-a22b-thinking-2507",
+  "qwen/qwen3-235b-a22b-thinking-2507": "qwen-3-235b-a22b-thinking-2507",
+  "qwen3-vl-235b-a22b-thinking": "qwen-3-vl-235b-a22b-thinking",
+  "openrouter:qwen/qwen3-vl-235b-a22b-thinking": "qwen-3-vl-235b-a22b-thinking",
+  "Qwen/Qwen3-VL-235B-A22B-Thinking": "qwen-3-vl-235b-a22b-thinking",
+  "qwen/qwen3-vl-235b-a22b-thinking": "qwen-3-vl-235b-a22b-thinking",
+  "claude-sonnet-4-20250514": "claude-sonnet-4",
+  "anthropic:anthropic/claude-sonnet-4": "claude-sonnet-4",
+  "claude-sonnet-4-latest": "claude-sonnet-4",
+  "anthropic/claude-sonnet-4": "claude-sonnet-4",
+  "qwen3-coder-480b-a35b-instruct": "qwen-3-coder-480b-a35b",
+  "alibaba:qwen/qwen3-coder-480b-a35b-instruct": "qwen-3-coder-480b-a35b",
+  "qwen3-coder-480b-a35b": "qwen-3-coder-480b-a35b",
+  "Qwen/Qwen3-Coder-480B-A35B-Instruct": "qwen-3-coder-480b-a35b",
+  "minimax-m2.1-preview": "minimax-m2.1",
+  "minimax:minimax/minimax-m2.1": "minimax-m2.1",
+  "MiniMaxAI/MiniMax-M2.1": "minimax-m2.1",
+  "minimax-m2.1:cloud": "minimax-m2.1",
+  "minimax/minimax-m2.1": "minimax-m2.1",
+  "qwen3-30b-a3b-instruct-2507": "qwen-3-30b-a3b-2507",
+  "openrouter:qwen/qwen3-30b-a3b-instruct-2507": "qwen-3-30b-a3b-2507",
+  "Qwen/Qwen3-30B-A3B-Instruct-2507": "qwen-3-30b-a3b-2507",
+  "qwen/qwen3-30b-a3b-instruct-2507": "qwen-3-30b-a3b-2507",
+  "qwen3-235b-a22b": "qwen-3-235b-a22b",
+  "alibaba:qwen/qwen3-235b-a22b": "qwen-3-235b-a22b",
+  "Qwen/Qwen3-235B-A22B": "qwen-3-235b-a22b",
+  "qwen/qwen3-235b-a22b": "qwen-3-235b-a22b",
+  "qwen3-next-80b-a3b-thinking": "qwen-3-next-80b-a3b-thinking",
+  "alibaba:qwen/qwen3-next-80b-a3b-thinking": "qwen-3-next-80b-a3b-thinking",
+  "Qwen/Qwen3-Next-80B-A3B-Thinking": "qwen-3-next-80b-a3b-thinking",
+  "qwen/qwen3-next-80b-a3b-thinking": "qwen-3-next-80b-a3b-thinking",
+  "openrouter:arcee-ai/trinity-large-thinking": "trinity-large-thinking",
+  "arcee-ai/Trinity-Large-Thinking": "trinity-large-thinking",
+  "arcee-ai/trinity-large-thinking": "trinity-large-thinking",
+  "openrouter:google/gemma-3-27b-it": "gemma-3-27b-it",
+  "google/gemma-3-27b-it": "gemma-3-27b-it",
+  "openrouter:minimax/minimax-m1": "minimax-m1",
+  "minimax/minimax-m1": "minimax-m1",
+  "openrouter:inception/mercury-2": "mercury-2",
+  "inception/mercury-2": "mercury-2",
+  "minimax-m2-preview": "minimax-m2",
+  "minimax:minimax/minimax-m2": "minimax-m2",
+  "MiniMaxAI/MiniMax-M2": "minimax-m2",
+  "minimax-m2:cloud": "minimax-m2",
+  "minimax/minimax-m2": "minimax-m2",
   "openrouter:amazon/nova-2-lite-v1": "nova-2-lite",
   "amazon/nova-2-lite-v1": "nova-2-lite",
-  "EB45-turbo-vl-0906": "eb45-turbo-vl-0906",
-  "openrouter:anthropic/claude-sonnet-4": "claude-sonnet-4",
-  "openrouter:minimax/minimax-m1": "minimax-m1",
-  "openrouter:allenai/olmo-3-32b-think": "olmo-3-32b-think",
-  "allenai/olmo-3-32b-think": "olmo-3-32b-think",
-  "amazon-nova-experimental-chat-11-10": "amazon-nova-experimental-chat",
-  "mistral-large-3:675b": "mistral-large-3",
-  "arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-pro-v1:0<>BED": "amazon.nova-pro",
-  "openrouter:prime-intellect/intellect-3": "intellect-3",
-  "PrimeIntellect/INTELLECT-3-FP8": "intellect-3",
-  "prime-intellect/intellect-3": "intellect-3",
   "olmo-3.1-32b-instruct": "olmo-3.1-32b",
-  "openrouter:allenai/olmo-3.1-32b-instruct": "olmo-3.1-32b",
-  "allenai/Olmo-3.1-32B-Instruct": "olmo-3.1-32b",
-  "allenai/olmo-3.1-32b-instruct": "olmo-3.1-32b",
-  "openrouter:allenai/olmo-3.1-32b-think": "olmo-3.1-32b-think",
-  "allenai/Olmo-3.1-32B-Think": "olmo-3.1-32b-think",
-  "allenai/olmo-3.1-32b-think": "olmo-3.1-32b-think",
-  "allenai/olmo-3.1-32b-think:free<>OPR": "olmo-3.1-32b-think",
-  "openrouter:z-ai/glm-4.5v": "glm-4.5v",
-  "openrouter:z-ai/glm-4.6v": "glm-4.6v",
-  "zai-org/GLM-4.6V": "glm-4.6v",
-  "zai-org/GLM-4.6V-FP8": "glm-4.6v",
-  "z-ai/glm-4.6v": "glm-4.6v",
-  "openrouter:anthropic/claude-opus-4": "claude-opus-4",
-  "zai-org/GLM-4.6V-Flash": "glm-4.6v-flash",
-  "openrouter:google/gemini-2.5-flash-preview-09-2025": "gemini-2.5-flash-preview25",
-  "openrouter:meituan/longcat-flash-chat": "longcat-flash-chat",
-  "meituan/longcat-flash-chat": "longcat-flash-chat",
-  "openrouter:qwen/qwen3-vl-235b-a22b-instruct": "qwen-3-vl-235b-a22b",
-  "openrouter:qwen/qwen3-vl-235b-a22b-thinking": "qwen-3-vl-235b-a22b-thinking",
-  "qwen3-omni-flash-2025-12-01": "qwen-3-omni-flash",
-  "openrouter:openai/chatgpt-4o-latest": "chatgpt-4o",
-  "openrouter:qwen/qwen3-30b-a3b-instruct-2507": "qwen-3-30b-a3b-2507",
-  "inclusionAI/Ling-1T": "ling-1t",
-  "openrouter:z-ai/glm-4.6:exacto": "glm-4.6",
-  "openrouter:inception/mercury": "mercury",
-  "openrouter:openai/o3": "o3",
-  "openrouter:qwen/qwen3-next-80b-a3b-thinking": "qwen-3-next-80b-a3b-thinking",
-  "flux-2-pro-20251231": "flux-2-pro",
-  "fal-ai/flux-2-pro": "flux-2-pro",
-  "flux-2-flex-20251231": "flux-2-flex",
-  "fal-ai/flux-2-flex": "flux-2-flex",
-  "flux-2-dev-20251222": "flux-2-dev",
-  "flux-2-max-20251222": "flux-2-max",
+  "qwen3-30b-a3b": "qwen-3-30b-a3b",
+  "openrouter:qwen/qwen3-30b-a3b": "qwen-3-30b-a3b",
+  "qwen/qwen3-30b-a3b": "qwen-3-30b-a3b",
+  "togetherai:google/gemma-3n-e4b-it": "gemma-3n-e4b-it",
+  "google/gemma-3n-E4B-it": "gemma-3n-e4b-it",
+  "google/gemma-3n-e4b-it": "gemma-3n-e4b-it",
+  "togetherai:openai/gpt-oss-20b": "gpt-oss-20b",
+  "openai/gpt-oss-20b": "gpt-oss-20b",
+  "gpt-oss:20b": "gpt-oss-20b",
+  "nvidia-nemotron-3-nano-30b-a3b-bf16": "nvidia-nemotron-3-nano-30b-a3b",
+  "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16": "nvidia-nemotron-3-nano-30b-a3b",
+  "openrouter:ibm-granite/granite-4.1-8b": "granite-4.1-8b",
+  "ibm-granite/granite-4.1-8b": "granite-4.1-8b",
+  "mistral-small-3.1-24b-instruct-2503": "mistral-small-3.1-24b-2503",
+  "mistralai/Mistral-Small-3.1-24B-Instruct-2503": "mistral-small-3.1-24b-2503",
+  "jebel_1": "jebel.1",
+  "jebel_2": "jebel.2",
+  "artemis_1": "artemis.1",
+  "artemis_2": "artemis.2",
+  "openrouter:stepfun/step-3.7-flash": "step-3.7-flash",
+  "stepfun-ai/Step-3.7-Flash": "step-3.7-flash",
+  "stepfun/step-3.7-flash": "step-3.7-flash",
+  "globe_2": "globe.2",
+  "hofburg_2": "hofburg.2",
+  "hofburg_3": "hofburg.3",
+  "nightride-on-v2": "nightride-on",
+  "inclusionAI/Ring-1T": "ring-1t",
+  "u2-preview": "u2",
+  "stephen-v2": "stephen",
+  "EB45-vision": "eb45-vision",
+  "EB45-turbo": "eb45-turbo",
+  "mistral-medium-3.5:latest": "mistral-medium-3.5",
+  "hofburg_4": "hofburg.4",
+  "hofburg_5": "hofburg.5",
+  "mistralai:mistralai/mistral-small-2603": "mistral-small-2603",
+  "mistralai/mistral-small-2603": "mistral-small-2603",
+  "qwen3-vl-8b-thinking": "qwen-3-vl-8b-thinking",
+  "openrouter:qwen/qwen3-vl-8b-thinking": "qwen-3-vl-8b-thinking",
+  "Qwen/Qwen3-VL-8B-Thinking": "qwen-3-vl-8b-thinking",
+  "qwen/qwen3-vl-8b-thinking": "qwen-3-vl-8b-thinking",
+  "openrouter:openrouter/fusion": "fusion",
+  "openrouter/fusion": "fusion",
+  "anthropic:anthropic/claude-fable-5": "claude-fable-5",
+  "anthropic/claude-fable-5": "claude-fable-5",
+  "artemis_3": "artemis.3",
+  "artemis_4": "artemis.4",
+  "qwen-vl-max-2025-08-13": "qwen-vl-max",
+  "openrouter:qwen/qwen-vl-max": "qwen-vl-max",
+  "qwen3-vl-8b-instruct": "qwen-3-vl-8b",
+  "openrouter:qwen/qwen3-vl-8b-instruct": "qwen-3-vl-8b",
+  "qwen3-vl-8b": "qwen-3-vl-8b",
+  "Qwen/Qwen3-VL-8B-Instruct": "qwen-3-vl-8b",
+  "qwen/qwen3-vl-8b-instruct": "qwen-3-vl-8b",
+  "azure:x-ai/grok-4.3": "grok-4.3",
+  "x-ai/grok-4.3": "grok-4.3",
+  "glassy_lagoon": "glassy.lagoon",
+  "emerald_lagoon": "emerald.lagoon",
+  "openai:openai/gpt-5.5": "gpt-5.5",
+  "openai/gpt-5.5": "gpt-5.5",
+  "anthropic:anthropic/claude-opus-4-8": "claude-opus-4-8",
+  "amazon.nova-pro-v1:0": "amazon.nova-pro",
+  "z-ai:z-ai/glm-5v-turbo": "glm-5v-turbo",
+  "z-ai/glm-5v-turbo": "glm-5v-turbo",
+  "imagen-4.0-generate-001": "imagen-4.0-generate",
+  "Qwen/Qwen-Image-2512:fal-ai": "qwen-image-2512",
+  "wan2.5-preview": "wan2.5",
   "wan2.5-t2i-preview": "wan2.5-t2i",
-  "chatgpt-image-latest (20251216)": "chatgpt-image (20251216)",
+  "recraft-v3": "recraft",
+  "Tongyi-MAI/Z-Image:fal-ai": "z-image",
+  "imagen-3.0-generate-002": "imagen-3.0-generate",
+  "phantom_brush": "phantom.brush",
+  "zen-bear-v4": "zen-bear",
+  "auto-bear-v2": "auto-bear",
+  "spectral_ink": "spectral.ink",
+  "phantom_quill": "phantom.quill",
   "wan2.5-i2i-preview": "wan2.5-i2i",
-  "openrouter:mistralai/codestral-2508": "codestral-2508",
-  "openrouter:google/gemini-2.0-flash-lite-001": "gemini-2.0-flash-lite",
-  "google/gemini-2.0-flash-lite-001": "gemini-2.0-flash-lite",
-  "gemini-2.0-flash-lite-001": "gemini-2.0-flash-lite",
-  "openrouter:openai/gpt-5-mini": "gpt-5-mini",
-  "openrouter:openai/gpt-5.1-chat": "gpt-5.1-chat",
-  "openai/gpt-5.1-chat": "gpt-5.1-chat",
-  "gpt-5.1-chat-latest": "gpt-5.1-chat",
-  "openrouter:openai/gpt-5.1-codex": "gpt-5.1-codex",
+  "imagen-4.0-ultra-generate-001": "imagen-4.0-ultra-generate",
+  "imagen-4.0-fast-generate-001": "imagen-4.0-fast-generate",
+  "chatgpt-image-latest-high-fidelity (20251216)": "chatgpt-image-high-fidelity (20251216)",
+  "alibaba:qwen/qvq-max": "qvq-max",
+  "alibaba:qwen/qwen-flash": "qwen-flash",
+  "openrouter:qwen/qwen-max": "qwen-max",
+  "alibaba:qwen/qwen-mt-plus": "qwen-mt-plus",
+  "alibaba:qwen/qwen-mt-turbo": "qwen-mt-turbo",
+  "alibaba:qwen/qwen-omni-turbo": "qwen-omni-turbo",
+  "openrouter:qwen/qwen-turbo": "qwen-turbo",
+  "alibaba:qwen/qwen-vl-ocr": "qwen-vl-ocr",
+  "openrouter:qwen/qwen-vl-plus": "qwen-vl-plus",
+  "alibaba:qwen/qwen2-5-14b-instruct": "qwen-2-5-14b",
+  "alibaba:qwen/qwen2-5-32b-instruct": "qwen-2-5-32b",
+  "alibaba:qwen/qwen2-5-72b-instruct": "qwen-2-5-72b",
+  "alibaba:qwen/qwen2-5-7b-instruct": "qwen-2-5-7b",
+  "alibaba:qwen/qwen2-5-omni-7b": "qwen-2-5-omni-7b",
+  "alibaba:qwen/qwen2-5-vl-72b-instruct": "qwen-2-5-vl-72b",
+  "alibaba:qwen/qwen2-5-vl-7b-instruct": "qwen-2-5-vl-7b",
+  "qwen3-14b": "qwen-3-14b",
+  "Qwen/Qwen3-14B": "qwen-3-14b",
+  "qwen/qwen3-14b": "qwen-3-14b",
+  "alibaba:qwen/qwen3-coder-flash": "qwen-3-coder-flash",
+  "qwen/qwen3-coder-flash": "qwen-3-coder-flash",
+  "openrouter:qwen/qwen3-vl-30b-a3b-instruct": "qwen-3-vl-30b-a3b",
+  "qwen3-vl-30b-a3b": "qwen-3-vl-30b-a3b",
+  "Qwen/Qwen3-VL-30B-A3B-Instruct": "qwen-3-vl-30b-a3b",
+  "qwen/qwen3-vl-30b-a3b-instruct": "qwen-3-vl-30b-a3b",
+  "alibaba:qwen/qwq-plus": "qwq-plus",
+  "anthropic:anthropic/claude-3-5-sonnet-20240620": "claude-3-5-sonnet",
+  "claude-3-5-sonnet-latest": "claude-3-5-sonnet",
+  "anthropic:anthropic/claude-3-7-sonnet": "claude-3-7-sonnet",
+  "claude-3-7-sonnet-20250219": "claude-3-7-sonnet",
+  "claude-3-haiku-20240307": "claude-3-haiku",
+  "anthropic/claude-3-haiku": "claude-3-haiku",
+  "azure:openai/gpt-5-codex": "gpt-5-codex",
+  "openai/gpt-5-codex": "gpt-5-codex",
+  "openai:openai/gpt-5-mini": "gpt-5-mini",
+  "openai/gpt-5-mini": "gpt-5-mini",
+  "openai:openai/gpt-5-nano": "gpt-5-nano",
+  "openai/gpt-5-nano": "gpt-5-nano",
+  "azure:openai/gpt-5.1-codex": "gpt-5.1-codex",
   "openai/gpt-5.1-codex": "gpt-5.1-codex",
-  "openrouter:openai/gpt-5.1-codex-max": "gpt-5.1-codex-max",
-  "openai/gpt-5.1-codex-max": "gpt-5.1-codex-max",
-  "openrouter:openai/gpt-5.1-codex-mini": "gpt-5.1-codex-mini",
+  "azure:openai/gpt-5.1-codex-mini": "gpt-5.1-codex-mini",
   "openai/gpt-5.1-codex-mini": "gpt-5.1-codex-mini",
-  "openrouter:openai/gpt-5.2-chat": "gpt-5.2-chat",
-  "openai/gpt-5.2-chat": "gpt-5.2-chat",
-  "gpt-5.2-chat-latest": "gpt-5.2-chat",
-  "openrouter:openai/gpt-5.2-pro": "gpt-5.2-pro",
-  "openai/gpt-5.2-pro": "gpt-5.2-pro",
-  "openrouter:mistralai/ministral-14b-2512": "ministral-14b-2512",
-  "mistralai/ministral-14b-instruct-2512": "ministral-14b-2512",
+  "azure:openai/gpt-5.2-codex": "gpt-5.2-codex",
+  "openai/gpt-5.2-codex": "gpt-5.2-codex",
+  "azure:openai/gpt-5.3-codex": "gpt-5.3-codex",
+  "openai/gpt-5.3-codex": "gpt-5.3-codex",
+  "azure:openai/gpt-5.4-nano": "gpt-5.4-nano",
+  "openai/gpt-5.4-nano": "gpt-5.4-nano",
+  "azure:x-ai/grok-4-1-fast-non-reasoning": "grok-4-1-fast-non-reasoning",
+  "azure:x-ai/grok-4-1-fast-reasoning": "grok-4-1-fast-reasoning",
+  "x-ai:x-ai/grok-4-20-non-reasoning": "grok-4-20-non-reasoning",
+  "google:google/gemini-2.0-flash-lite": "gemini-2.0-flash-lite",
+  "openrouter:google/gemini-2.5-flash-lite": "gemini-2.5-flash-lite",
+  "google/gemini-2.5-flash-lite": "gemini-2.5-flash-lite",
+  "minimax:minimax/minimax-m2.1-highspeed": "minimax-m2.1-highspeed",
+  "minimax:minimax/minimax-m2.5-highspeed": "minimax-m2.5-highspeed",
+  "minimax:minimax/minimax-m2.7-highspeed": "minimax-m2.7-highspeed",
+  "MiniMax-M2.7-highspeed": "minimax-m2.7-highspeed",
+  "mistralai:mistralai/codestral-2508": "codestral-2508",
+  "mistralai/codestral-2508": "codestral-2508",
+  "mistralai:mistralai/devstral-2512": "devstral-2512",
+  "mistralai/devstral-2512": "devstral-2512",
+  "mistralai:mistralai/magistral-medium-2509": "magistral-medium-2509",
+  "mistralai:mistralai/magistral-small-2509": "magistral-small-2509",
+  "mistralai:mistralai/ministral-14b-2512": "ministral-14b-2512",
   "mistralai/ministral-14b-2512": "ministral-14b-2512",
-  "openrouter:mistralai/ministral-3b-2512": "ministral-3b-2512",
+  "mistralai:mistralai/ministral-3b-2512": "ministral-3b-2512",
   "mistralai/ministral-3b-2512": "ministral-3b-2512",
-  "openrouter:mistralai/ministral-8b-2512": "ministral-8b-2512",
+  "mistralai:mistralai/ministral-8b-2512": "ministral-8b-2512",
   "mistralai/ministral-8b-2512": "ministral-8b-2512",
-  "openrouter:mistralai/mistral-large": "mistral-large",
-  "openrouter:openai/o1-pro": "o1-pro",
-  "openrouter:openai/o3-pro": "o3-pro",
+  "mistralai:mistralai/mistral-large-2512": "mistral-large-2512",
+  "mistralai/mistral-large-2512": "mistral-large-2512",
+  "mistralai:mistralai/mistral-medium-3-5": "mistral-medium-3-5",
+  "mistralai/mistral-medium-3-5": "mistral-medium-3-5",
+  "mistralai:mistralai/open-mistral-nemo-2407": "open-mistral-nemo-2407",
+  "mistralai:mistralai/voxtral-small-2507": "voxtral-small-2507",
+  "moonshotai:moonshotai/moonshot-v1-128k": "moonshot-v1-128k",
+  "moonshotai:moonshotai/moonshot-v1-128k-vision-preview": "moonshot-v1-128k-vision",
+  "moonshotai:moonshotai/moonshot-v1-32k": "moonshot-v1-32k",
+  "moonshotai:moonshotai/moonshot-v1-32k-vision-preview": "moonshot-v1-32k-vision",
+  "moonshotai:moonshotai/moonshot-v1-8k": "moonshot-v1-8k",
+  "moonshotai:moonshotai/moonshot-v1-8k-vision-preview": "moonshot-v1-8k-vision",
+  "moonshotai:moonshotai/moonshot-v1-auto": "moonshot-v1-auto",
+  "openai:openai/gpt-5.1-chat": "gpt-5.1-chat",
+  "openai/gpt-5.1-chat": "gpt-5.1-chat",
+  "openai:openai/gpt-5.2-pro": "gpt-5.2-pro",
+  "openai/gpt-5.2-pro": "gpt-5.2-pro",
+  "openai:openai/gpt-5.4-pro": "gpt-5.4-pro",
+  "openai/gpt-5.4-pro": "gpt-5.4-pro",
+  "openai:openai/gpt-5.5-pro": "gpt-5.5-pro",
+  "openai/gpt-5.5-pro": "gpt-5.5-pro",
+  "openai:openai/o1-pro": "o1-pro",
+  "openai/o1-pro": "o1-pro",
+  "openai:openai/o3-pro": "o3-pro",
   "openai/o3-pro": "o3-pro",
-  "o3-pro-2025-06-10": "o3-pro",
-  "openrouter:mistralai/pixtral-large-2411": "pixtral-large-2411",
-  "anthropic/claude-3.5-sonnet": "claude-3.5-sonnet",
-  "openrouter:deepseek/deepseek-prover-v2": "deepseek-prover",
   "openrouter:ai21/jamba-large-1.7": "jamba-large-1.7",
   "ai21/jamba-large-1.7": "jamba-large-1.7",
-  "openrouter:ai21/jamba-mini-1.7": "jamba-mini-1.7",
-  "ai21/jamba-mini-1.7": "jamba-mini-1.7",
   "openrouter:aion-labs/aion-1.0": "aion-1.0",
   "aion-labs/aion-1.0": "aion-1.0",
   "openrouter:aion-labs/aion-1.0-mini": "aion-1.0-mini",
   "aion-labs/aion-1.0-mini": "aion-1.0-mini",
+  "openrouter:aion-labs/aion-2.0": "aion-2.0",
+  "aion-labs/aion-2.0": "aion-2.0",
   "openrouter:aion-labs/aion-rp-llama-3.1-8b": "aion-rp-llama-3.1-8b",
   "aion-labs/aion-rp-llama-3.1-8b": "aion-rp-llama-3.1-8b",
-  "openrouter:alfredpros/codellama-7b-instruct-solidity": "codellama-7b-solidity",
-  "alfredpros/codellama-7b-instruct-solidity": "codellama-7b-solidity",
-  "openrouter:alibaba/tongyi-deepresearch-30b-a3b": "tongyi-deepresearch-30b-a3b",
-  "alibaba/tongyi-deepresearch-30b-a3b": "tongyi-deepresearch-30b-a3b",
-  "openrouter:allenai/olmo-2-0325-32b-instruct": "olmo-2-0325-32b",
-  "allenai/olmo-2-0325-32b-instruct": "olmo-2-0325-32b",
-  "openrouter:allenai/olmo-3-7b-instruct": "olmo-3-7b",
-  "allenai/Olmo-3-7B-Instruct": "olmo-3-7b",
-  "allenai/olmo-3-7b-instruct": "olmo-3-7b",
-  "openrouter:allenai/olmo-3-7b-think": "olmo-3-7b-think",
-  "allenai/Olmo-3-7B-Think": "olmo-3-7b-think",
-  "allenai/olmo-3-7b-think": "olmo-3-7b-think",
-  "openrouter:alpindale/goliath-120b": "goliath-120b",
-  "alpindale/goliath-120b": "goliath-120b",
+  "openrouter:allenai/olmo-3-32b-think": "olmo-3-32b-think",
+  "allenai/olmo-3-32b-think": "olmo-3-32b-think",
   "openrouter:amazon/nova-lite-v1": "nova-lite",
   "amazon/nova-lite-v1": "nova-lite",
   "openrouter:amazon/nova-micro-v1": "nova-micro",
@@ -5626,194 +5460,237 @@ model_aliases = {
   "anthracite-org/magnum-v4-72b": "magnum-v4-72b",
   "openrouter:anthropic/claude-opus-4.1": "claude-opus-4.1",
   "anthropic/claude-opus-4.1": "claude-opus-4.1",
+  "openrouter:anthropic/claude-opus-4.6-fast": "claude-opus-4.6-fast",
+  "anthropic/claude-opus-4.6-fast": "claude-opus-4.6-fast",
+  "openrouter:anthropic/claude-opus-4.7-fast": "claude-opus-4.7-fast",
+  "anthropic/claude-opus-4.7-fast": "claude-opus-4.7-fast",
+  "openrouter:anthropic/claude-opus-4.8-fast": "claude-opus-4.8-fast",
+  "anthropic/claude-opus-4.8-fast": "claude-opus-4.8-fast",
   "openrouter:arcee-ai/coder-large": "coder-large",
   "arcee-ai/coder-large": "coder-large",
-  "openrouter:arcee-ai/maestro-reasoning": "maestro-reasoning",
-  "arcee-ai/maestro-reasoning": "maestro-reasoning",
-  "openrouter:arcee-ai/spotlight": "spotlight",
-  "arcee-ai/spotlight": "spotlight",
+  "openrouter:arcee-ai/trinity-mini": "trinity-mini",
+  "arcee-ai/trinity-mini": "trinity-mini",
   "openrouter:arcee-ai/virtuoso-large": "virtuoso-large",
   "arcee-ai/virtuoso-large": "virtuoso-large",
-  "openrouter:baidu/ernie-4.5-21b-a3b": "ernie-4.5-21b-a3b",
-  "baidu/ernie-4.5-21b-a3b": "ernie-4.5-21b-a3b",
-  "openrouter:baidu/ernie-4.5-21b-a3b-thinking": "ernie-4.5-21b-a3b-thinking",
-  "baidu/ernie-4.5-21b-a3b-thinking": "ernie-4.5-21b-a3b-thinking",
-  "openrouter:baidu/ernie-4.5-300b-a47b": "ernie-4.5-300b-a47b",
-  "baidu/ernie-4.5-300b-a47b": "ernie-4.5-300b-a47b",
-  "openrouter:baidu/ernie-4.5-vl-28b-a3b": "ernie-4.5-vl-28b-a3b",
-  "baidu/ernie-4.5-vl-28b-a3b": "ernie-4.5-vl-28b-a3b",
   "openrouter:baidu/ernie-4.5-vl-424b-a47b": "ernie-4.5-vl-424b-a47b",
   "baidu/ernie-4.5-vl-424b-a47b": "ernie-4.5-vl-424b-a47b",
   "openrouter:bytedance-seed/seed-1.6": "seed-1.6",
   "bytedance-seed/seed-1.6": "seed-1.6",
   "openrouter:bytedance-seed/seed-1.6-flash": "seed-1.6-flash",
   "bytedance-seed/seed-1.6-flash": "seed-1.6-flash",
+  "openrouter:bytedance-seed/seed-2.0-lite": "seed-2.0-lite",
+  "bytedance-seed/seed-2.0-lite": "seed-2.0-lite",
+  "openrouter:bytedance-seed/seed-2.0-mini": "seed-2.0-mini",
+  "bytedance-seed/seed-2.0-mini": "seed-2.0-mini",
   "openrouter:bytedance/ui-tars-1.5-7b": "ui-tars-1.5-7b",
+  "ByteDance-Seed/UI-TARS-1.5-7B": "ui-tars-1.5-7b",
   "bytedance/ui-tars-1.5-7b": "ui-tars-1.5-7b",
+  "openrouter:cognitivecomputations/dolphin-mistral-24b-venice-edition:free": "dolphin-mistral-24b-venice-edition",
+  "dphn/Dolphin-Mistral-24B-Venice-Edition": "dolphin-mistral-24b-venice-edition",
+  "cognitivecomputations/dolphin-mistral-24b-venice-edition:free": "dolphin-mistral-24b-venice-edition",
   "openrouter:cohere/command-r-08-2024": "command-r24",
-  "openrouter:deepcogito/cogito-v2-preview-llama-109b-moe": "cogito-v2-preview-llama-109b-moe",
-  "deepcogito/cogito-v2-preview-llama-109b-moe": "cogito-v2-preview-llama-109b-moe",
-  "openrouter:deepcogito/cogito-v2-preview-llama-405b": "cogito-v2-preview-llama-405b",
-  "deepcogito/cogito-v2-preview-llama-405B": "cogito-v2-preview-llama-405b",
-  "deepcogito/cogito-v2-preview-llama-405b": "cogito-v2-preview-llama-405b",
-  "openrouter:deepcogito/cogito-v2-preview-llama-70b": "cogito-v2-preview-llama-70b",
-  "deepcogito/cogito-v2-preview-llama-70B": "cogito-v2-preview-llama-70b",
-  "deepcogito/cogito-v2-preview-llama-70b": "cogito-v2-preview-llama-70b",
+  "CohereLabs/c4ai-command-r-08-2024": "command-r24",
+  "cohere/command-r-08-2024": "command-r24",
+  "command-r7b-12-2024": "command-r7b24",
+  "CohereLabs/c4ai-command-r7b-12-2024": "command-r7b24",
+  "cohere/command-r7b-12-2024": "command-r7b24",
+  "openrouter:cohere/north-mini-code:free": "north-mini-code",
+  "cohere/north-mini-code:free": "north-mini-code",
   "openrouter:deepcogito/cogito-v2.1-671b": "cogito-v2.1-671b",
   "deepcogito/cogito-v2.1-671b": "cogito-v2.1-671b",
   "openrouter:deepseek/deepseek-chat-v3-0324": "deepseek-chat-v3-0324",
+  "deepseek/deepseek-chat-v3-0324": "deepseek-chat-v3-0324",
   "openrouter:deepseek/deepseek-chat-v3.1": "deepseek-chat-v3.1",
-  "openrouter:deepseek/deepseek-r1-0528-qwen3-8b": "deepseek-r1-0528-qwen-3-8b",
-  "openrouter:deepseek/deepseek-v3.2-speciale": "deepseek-v3.2-speciale",
-  "deepseek/deepseek-v3.2-speciale": "deepseek-v3.2-speciale",
-  "openrouter:eleutherai/llemma_7b": "llemma.7b",
-  "eleutherai/llemma_7b": "llemma.7b",
-  "openrouter:essentialai/rnj-1-instruct": "rnj-1",
-  "EssentialAI/rnj-1-instruct": "rnj-1",
-  "rnj-1:8b": "rnj-1",
-  "essentialai/rnj-1-instruct": "rnj-1",
-  "openrouter:google/gemini-2.5-flash-image-preview": "gemini-2.5-flash-image",
+  "deepseek/deepseek-chat-v3.1": "deepseek-chat-v3.1",
+  "openrouter:deepseek/deepseek-r1-0528": "deepseek-r1-0528",
+  "deepseek-ai/DeepSeek-R1-0528": "deepseek-r1-0528",
+  "deepseek/deepseek-r1-0528": "deepseek-r1-0528",
+  "openrouter:deepseek/deepseek-v3.1-terminus": "deepseek-v3.1-terminus",
+  "deepseek-ai/DeepSeek-V3.1-Terminus": "deepseek-v3.1-terminus",
+  "deepseek/deepseek-v3.1-terminus": "deepseek-v3.1-terminus",
+  "openrouter:deepseek/deepseek-v3.2-exp": "deepseek-v3.2-exp",
+  "deepseek-ai/DeepSeek-V3.2-Exp": "deepseek-v3.2-exp",
+  "deepseek/deepseek-v3.2-exp": "deepseek-v3.2-exp",
+  "openrouter:google/gemini-2.5-flash-image": "gemini-2.5-flash-image",
+  "google/gemini-2.5-flash-image": "gemini-2.5-flash-image",
   "openrouter:google/gemini-2.5-flash-lite-preview-09-2025": "gemini-2.5-flash-lite-preview25",
   "google/gemini-2.5-flash-lite-preview-09-2025": "gemini-2.5-flash-lite-preview25",
   "openrouter:google/gemini-3-pro-image-preview": "gemini-3-pro-image",
   "google/gemini-3-pro-image-preview": "gemini-3-pro-image",
+  "openrouter:google/gemini-3.1-flash-image-preview": "gemini-3.1-flash-image",
+  "google/gemini-3.1-flash-image-preview": "gemini-3.1-flash-image",
+  "openrouter:google/gemini-3.1-pro-preview-customtools": "gemini-3.1-pro-preview-customtools",
+  "google/gemini-3.1-pro-preview-customtools": "gemini-3.1-pro-preview-customtools",
   "hf:google/gemma-2-27b-it": "gemma-2-27b-it",
-  "openrouter:google/gemma-2-9b-it": "gemma-2-9b-it",
+  "openrouter:google/gemma-3-12b-it": "gemma-3-12b-it",
+  "google/gemma-3-12b-it": "gemma-3-12b-it",
+  "openrouter:google/gemma-3-4b-it": "gemma-3-4b-it",
+  "google/gemma-3-4b-it": "gemma-3-4b-it",
+  "openrouter:google/lyria-3-clip-preview": "lyria-3-clip",
+  "google/lyria-3-clip-preview": "lyria-3-clip",
+  "openrouter:google/lyria-3-pro-preview": "lyria-3-pro",
+  "google/lyria-3-pro-preview": "lyria-3-pro",
   "openrouter:gryphe/mythomax-l2-13b": "mythomax-l2-13b",
   "gryphe/mythomax-l2-13b": "mythomax-l2-13b",
   "openrouter:ibm-granite/granite-4.0-h-micro": "granite-4.0-h-micro",
   "ibm-granite/granite-4.0-h-micro": "granite-4.0-h-micro",
-  "openrouter:inception/mercury-coder": "mercury-coder",
-  "inception/mercury-coder": "mercury-coder",
-  "openrouter:liquid/lfm-2.2-6b": "lfm-2.2-6b",
-  "liquid/lfm-2.2-6b": "lfm-2.2-6b",
-  "openrouter:liquid/lfm2-8b-a1b": "lfm2-8b-a1b",
-  "liquid/lfm2-8b-a1b": "lfm2-8b-a1b",
+  "openrouter:inclusionai/ling-2.6-1t": "ling-2.6-1t",
+  "inclusionAI/Ling-2.6-1T": "ling-2.6-1t",
+  "inclusionai/ling-2.6-1t": "ling-2.6-1t",
+  "openrouter:inclusionai/ling-2.6-flash": "ling-2.6-flash",
+  "inclusionai/ling-2.6-flash": "ling-2.6-flash",
+  "openrouter:inclusionai/ring-2.6-1t": "ring-2.6-1t",
+  "inclusionai/ring-2.6-1t": "ring-2.6-1t",
+  "openrouter:inflection/inflection-3-pi": "inflection-3-pi",
+  "inflection/inflection-3-pi": "inflection-3-pi",
+  "openrouter:inflection/inflection-3-productivity": "inflection-3-productivity",
+  "inflection/inflection-3-productivity": "inflection-3-productivity",
+  "openrouter:kwaipilot/kat-coder-pro-v2": "kat-coder-pro",
+  "kwaipilot/kat-coder-pro-v2": "kat-coder-pro",
+  "openrouter:liquid/lfm-2-24b-a2b": "lfm-2-24b-a2b",
+  "liquid/lfm-2-24b-a2b": "lfm-2-24b-a2b",
+  "openrouter:liquid/lfm-2.5-1.2b-instruct:free": "lfm-2.5-1.2b",
+  "liquid/lfm-2.5-1.2b-instruct:free": "lfm-2.5-1.2b",
+  "openrouter:liquid/lfm-2.5-1.2b-thinking:free": "lfm-2.5-1.2b-thinking",
+  "liquid/lfm-2.5-1.2b-thinking:free": "lfm-2.5-1.2b-thinking",
   "openrouter:mancer/weaver": "weaver",
   "mancer/weaver": "weaver",
-  "meta/llama-3.2-90b-vision-instruct": "llama-3.2-90b-vision",
-  "hf:meta-llama/Llama-3.2-90B-Vision-Instruct": "llama-3.2-90b-vision",
-  "meta-llama/llama-3.2-90b-vision-instruct": "llama-3.2-90b-vision",
-  "openrouter:meta-llama/llama-guard-2-8b": "llama-guard-2-8b",
-  "meta-llama/llama-guard-2-8b": "llama-guard-2-8b",
-  "openrouter:meta-llama/llama-guard-3-8b": "llama-guard-3-8b",
+  "openrouter:microsoft/phi-4": "phi-4",
+  "microsoft/phi-4": "phi-4",
+  "phi-4:14b": "phi-4",
+  "openrouter:microsoft/phi-4-mini-instruct": "phi-4-mini",
+  "microsoft/Phi-4-mini-instruct": "phi-4-mini",
+  "microsoft/phi-4-mini-instruct": "phi-4-mini",
+  "openrouter:microsoft/wizardlm-2-8x22b": "wizardlm-2-8x22b",
+  "alpindale/WizardLM-2-8x22B": "wizardlm-2-8x22b",
+  "microsoft/wizardlm-2-8x22b": "wizardlm-2-8x22b",
   "minimax/minimax-01": "minimax-01",
-  "openrouter:mistralai/devstral-medium": "devstral-medium",
-  "mistralai/devstral-medium": "devstral-medium",
-  "devstral-medium-latest": "devstral-medium",
-  "openrouter:mistralai/devstral-small": "devstral-small",
-  "openrouter:mistralai/devstral-small-2505": "devstral-small-2505",
-  "openrouter:mistralai/ministral-3b": "ministral-3b",
-  "openrouter:mistralai/ministral-8b": "ministral-8b",
-  "openrouter:mistralai/mistral-7b-instruct-v0.1": "mistral-7b-v0.1",
-  "openrouter:mistralai/mistral-7b-instruct-v0.2": "mistral-7b-v0.2",
-  "openrouter:mistralai/mistral-7b-instruct-v0.3": "mistral-7b-v0.3",
-  "mistralai/Mistral-7B-Instruct-v0.3": "mistral-7b-v0.3",
-  "mistralai/mistral-7b-instruct-v0.3": "mistral-7b-v0.3",
-  "hf:mistralai/Mistral-7B-Instruct-v0.3": "mistral-7b-v0.3",
+  "openrouter:minimax/minimax-m2-her": "minimax-m2-her",
+  "minimax/minimax-m2-her": "minimax-m2-her",
   "openrouter:mistralai/mistral-large-2407": "mistral-large-2407",
   "mistralai/mistral-large-2407": "mistral-large-2407",
-  "openrouter:mistralai/mistral-large-2411": "mistral-large-2411",
-  "mistralai/mistral-large-2411": "mistral-large-2411",
-  "openrouter:mistralai/mistral-large-2512": "mistral-large-2512",
-  "mistralai/mistral-large-2512": "mistral-large-2512",
-  "openrouter:mistralai/mistral-medium-3": "mistral-medium-3",
-  "mistralai/mistral-medium-3-instruct": "mistral-medium-3",
-  "mistralai/mistral-medium-3": "mistral-medium-3",
   "openrouter:mistralai/mistral-medium-3.1": "mistral-medium-3.1",
   "mistralai/mistral-medium-3.1": "mistral-medium-3.1",
-  "mistral-saba-latest": "mistral-saba",
+  "openrouter:mistralai/mistral-saba": "mistral-saba",
+  "mistralai/mistral-saba": "mistral-saba",
   "openrouter:mistralai/mistral-small-24b-instruct-2501": "mistral-small-24b-2501",
+  "mistralai/mistral-small-24b-instruct-2501": "mistral-small-24b-2501",
   "openrouter:mistralai/mistral-small-3.2-24b-instruct": "mistral-small-3.2-24b",
-  "openrouter:mistralai/mistral-small-creative": "mistral-small-creative",
-  "mistralai/mistral-small-creative": "mistral-small-creative",
-  "openrouter:mistralai/mistral-tiny": "mistral-tiny",
-  "openrouter:mistralai/pixtral-12b": "pixtral-12b",
+  "mistralai/mistral-small-3.2-24b-instruct": "mistral-small-3.2-24b",
+  "open-mixtral-8x22b": "mixtral-8x22b",
+  "mistralai/mixtral-8x22b-instruct": "mixtral-8x22b",
   "openrouter:mistralai/voxtral-small-24b-2507": "voxtral-small-24b-2507",
   "mistralai/voxtral-small-24b-2507": "voxtral-small-24b-2507",
-  "openrouter:moonshotai/kimi-dev-72b": "kimi-dev-72b",
+  "openrouter:moonshotai/kimi-k2-thinking": "kimi-k2-thinking",
+  "moonshotai/Kimi-K2-Thinking": "kimi-k2-thinking",
+  "kimi-k2-thinking:cloud": "kimi-k2-thinking",
+  "moonshotai/kimi-k2-thinking": "kimi-k2-thinking",
   "openrouter:morph/morph-v3-fast": "morph-v3-fast",
   "morph/morph-v3-fast": "morph-v3-fast",
   "openrouter:morph/morph-v3-large": "morph-v3-large",
   "morph/morph-v3-large": "morph-v3-large",
-  "openrouter:neversleep/llama-3.1-lumimaid-8b": "llama-3.1-lumimaid-8b",
-  "neversleep/llama-3.1-lumimaid-8b": "llama-3.1-lumimaid-8b",
-  "openrouter:neversleep/noromaid-20b": "noromaid-20b",
-  "neversleep/noromaid-20b": "noromaid-20b",
-  "openrouter:nex-agi/deepseek-v3.1-nex-n1": "deepseek-v3.1-nex-n1",
-  "nex-agi/deepseek-v3.1-nex-n1": "deepseek-v3.1-nex-n1",
-  "openrouter:nousresearch/deephermes-3-mistral-24b-preview": "deephermes-3-mistral-24b",
-  "nousresearch/deephermes-3-mistral-24b-preview": "deephermes-3-mistral-24b",
-  "NousResearch/Hermes-2-Pro-Llama-3-8B": "hermes-2-pro-llama-3-8b",
-  "nousresearch/hermes-2-pro-llama-3-8b": "hermes-2-pro-llama-3-8b",
+  "openrouter:nex-agi/nex-n2-pro": "nex-n2-pro",
+  "nex-agi/nex-n2-pro": "nex-n2-pro",
+  "openrouter:nousresearch/hermes-3-llama-3.1-405b:free": "hermes-3-llama-3.1-405b",
+  "nousresearch/hermes-3-llama-3.1-405b": "hermes-3-llama-3.1-405b",
+  "openrouter:nousresearch/hermes-3-llama-3.1-70b": "hermes-3-70b",
   "nousresearch/hermes-3-llama-3.1-70b": "hermes-3-llama-3.1-70b",
   "openrouter:nousresearch/hermes-4-405b": "hermes-4-405b",
+  "nousresearch/hermes-4-405b": "hermes-4-405b",
   "openrouter:nousresearch/hermes-4-70b": "hermes-4-70b",
-  "openrouter:nvidia/llama-3.1-nemotron-ultra-253b-v1": "llama-3.1-nemotron-ultra-253b",
+  "NousResearch/Hermes-4-70B": "hermes-4-70b",
+  "nousresearch/hermes-4-70b": "hermes-4-70b",
   "openrouter:nvidia/llama-3.3-nemotron-super-49b-v1.5": "llama-3.3-nemotron-super-49b-v1.5",
   "nvidia/llama-3.3-nemotron-super-49b-v1.5": "llama-3.3-nemotron-super-49b-v1.5",
-  "openrouter:openai/codex-mini": "codex-mini",
-  "openai/codex-mini": "codex-mini",
-  "codex-mini-latest": "codex-mini",
+  "openrouter:nvidia/nemotron-3-nano-30b-a3b:free": "nemotron-3-nano-30b-a3b",
+  "nvidia/nemotron-3-nano-30b-a3b": "nemotron-3-nano-30b-a3b",
+  "openrouter:nvidia/nemotron-3-super-120b-a12b:free": "nemotron-3-super-120b-a12b",
+  "nvidia/nemotron-3-super-120b-a12b": "nemotron-3-super-120b-a12b",
+  "togetherai:nvidia/nemotron-3-ultra-550b-a55b": "nemotron-3-ultra-550b-a55b",
+  "nvidia/nemotron-3-ultra-550b-a55b": "nemotron-3-ultra-550b-a55b",
+  "openrouter:nvidia/nemotron-3.5-content-safety:free": "nemotron-3.5-content-safety",
+  "nvidia/nemotron-3.5-content-safety:free": "nemotron-3.5-content-safety",
+  "openrouter:nvidia/nemotron-nano-12b-v2-vl:free": "nemotron-nano-12b-v2-vl",
+  "nvidia/nemotron-nano-12b-v2-vl:free": "nemotron-nano-12b-v2-vl",
+  "openrouter:nvidia/nemotron-nano-9b-v2:free": "nemotron-nano-9b",
+  "nvidia/nemotron-nano-9b-v2:free": "nemotron-nano-9b",
   "openrouter:openai/gpt-3.5-turbo-instruct": "gpt-3.5-turbo",
+  "openai/gpt-3.5-turbo": "gpt-3.5-turbo",
   "openrouter:openai/gpt-3.5-turbo-0613": "gpt-3.5-turbo-0613",
   "openai/gpt-3.5-turbo-0613": "gpt-3.5-turbo-0613",
   "openrouter:openai/gpt-3.5-turbo-16k": "gpt-3.5-turbo-16k",
   "openai/gpt-3.5-turbo-16k": "gpt-3.5-turbo-16k",
-  "openrouter:openai/gpt-4-0314": "gpt-4-0314",
-  "openai/gpt-4-0314": "gpt-4-0314",
-  "openrouter:openai/gpt-4-1106-preview": "gpt-4-1106",
-  "openai/gpt-4-1106-preview": "gpt-4-1106",
   "openrouter:openai/gpt-4-turbo-preview": "gpt-4-turbo",
-  "openrouter:openai/gpt-4o-audio-preview": "gpt-4o-audio",
-  "openai/gpt-4o-audio-preview": "gpt-4o-audio",
-  "gpt-4o-mini-search-preview-2025-03-11": "gpt-4o-mini-search",
-  "gpt-4o-search-preview-2025-03-11": "gpt-4o-search",
-  "openrouter:openai/gpt-5-codex": "gpt-5-codex",
-  "openai/gpt-5-codex": "gpt-5-codex",
+  "openai/gpt-4-turbo-preview": "gpt-4-turbo",
+  "openrouter:openai/gpt-4o-mini-search-preview": "gpt-4o-mini-search",
+  "openai/gpt-4o-mini-search-preview": "gpt-4o-mini-search",
+  "openrouter:openai/gpt-4o-search-preview": "gpt-4o-search",
+  "openai/gpt-4o-search-preview": "gpt-4o-search",
   "openrouter:openai/gpt-5-image": "gpt-5-image",
   "openai/gpt-5-image": "gpt-5-image",
   "openrouter:openai/gpt-5-image-mini": "gpt-5-image-mini",
   "openai/gpt-5-image-mini": "gpt-5-image-mini",
   "openrouter:openai/gpt-5-pro": "gpt-5-pro",
   "openai/gpt-5-pro": "gpt-5-pro",
+  "openrouter:openai/gpt-5.1-codex-max": "gpt-5.1-codex-max",
+  "openai/gpt-5.1-codex-max": "gpt-5.1-codex-max",
+  "openrouter:openai/gpt-5.4-image-2": "gpt-5.4-image-2",
+  "openai/gpt-5.4-image-2": "gpt-5.4-image-2",
+  "openrouter:openai/gpt-audio": "gpt-audio",
+  "openai/gpt-audio": "gpt-audio",
+  "openrouter:openai/gpt-audio-mini": "gpt-audio-mini",
+  "openai/gpt-audio-mini": "gpt-audio-mini",
+  "openrouter:openai/gpt-chat-latest": "gpt-chat",
+  "openai/gpt-chat-latest": "gpt-chat",
   "openrouter:openai/gpt-oss-safeguard-20b": "gpt-oss-safeguard-20b",
   "openai/gpt-oss-safeguard-20b": "gpt-oss-safeguard-20b",
   "openrouter:openai/o3-deep-research": "o3-deep-research",
   "openai/o3-deep-research": "o3-deep-research",
   "openrouter:openai/o4-mini-deep-research": "o4-mini-deep-research",
   "openai/o4-mini-deep-research": "o4-mini-deep-research",
-  "openrouter:opengvlab/internvl3-78b": "internvl3-78b",
-  "opengvlab/internvl3-78b": "internvl3-78b",
   "openrouter:openrouter/bodybuilder": "bodybuilder",
   "openrouter/bodybuilder": "bodybuilder",
+  "openrouter:openrouter/free": "free",
+  "openrouter/free": "free",
+  "openrouter:openrouter/owl-alpha": "owl-alpha",
+  "openrouter/owl-alpha": "owl-alpha",
+  "openrouter:openrouter/pareto-code": "pareto-code",
+  "openrouter/pareto-code": "pareto-code",
+  "openrouter:perceptron/perceptron-mk1": "perceptron-mk1",
+  "perceptron/perceptron-mk1": "perceptron-mk1",
+  "openrouter:perplexity/sonar-deep-research": "sonar-deep-research",
+  "perplexity/sonar-deep-research": "sonar-deep-research",
   "openrouter:perplexity/sonar-pro-search": "sonar-pro-search",
   "perplexity/sonar-pro-search": "sonar-pro-search",
+  "openrouter:poolside/laguna-m.1:free": "laguna-m.1",
+  "poolside/laguna-m.1": "laguna-m.1",
+  "openrouter:poolside/laguna-xs.2:free": "laguna-xs.2",
+  "poolside/laguna-xs.2": "laguna-xs.2",
   "openrouter:qwen/qwen3-30b-a3b-thinking-2507": "qwen-3-30b-a3b-thinking-2507",
-  "Qwen/Qwen3-30B-A3B-Thinking-2507": "qwen-3-30b-a3b-thinking-2507",
   "qwen/qwen3-30b-a3b-thinking-2507": "qwen-3-30b-a3b-thinking-2507",
-  "qwen3-30b-a3b-thinking-2507": "qwen-3-30b-a3b-thinking-2507",
-  "openrouter:qwen/qwen3-coder-flash": "qwen-3-coder-flash",
-  "qwen/qwen3-coder-flash": "qwen-3-coder-flash",
-  "openrouter:qwen/qwen3-vl-30b-a3b-instruct": "qwen-3-vl-30b-a3b",
-  "Qwen/Qwen3-VL-30B-A3B-Instruct": "qwen-3-vl-30b-a3b",
-  "qwen/qwen3-vl-30b-a3b-instruct": "qwen-3-vl-30b-a3b",
-  "qwen3-vl-30b-a3b-instruct": "qwen-3-vl-30b-a3b",
+  "openrouter:qwen/qwen3-coder:free": "qwen-3-coder",
+  "qwen3-coder": "qwen-3-coder",
+  "qwen3-coder:480b": "qwen-3-coder",
+  "qwen3-coder:30b": "qwen-3-coder",
+  "qwen/qwen3-coder": "qwen-3-coder",
   "openrouter:qwen/qwen3-vl-30b-a3b-thinking": "qwen-3-vl-30b-a3b-thinking",
   "Qwen/Qwen3-VL-30B-A3B-Thinking": "qwen-3-vl-30b-a3b-thinking",
   "qwen/qwen3-vl-30b-a3b-thinking": "qwen-3-vl-30b-a3b-thinking",
-  "qwen3-vl-30b-a3b-thinking": "qwen-3-vl-30b-a3b-thinking",
   "openrouter:qwen/qwen3-vl-32b-instruct": "qwen-3-vl-32b",
-  "Qwen/Qwen3-VL-32B-Instruct": "qwen-3-vl-32b",
+  "qwen3-vl-32b": "qwen-3-vl-32b",
   "qwen/qwen3-vl-32b-instruct": "qwen-3-vl-32b",
-  "openrouter:raifle/sorcererlm-8x22b": "sorcererlm-8x22b",
-  "raifle/sorcererlm-8x22b": "sorcererlm-8x22b",
+  "openrouter:qwen/qwen3.6-flash": "qwen-3.6-flash",
+  "qwen/qwen3.6-flash": "qwen-3.6-flash",
+  "openrouter:rekaai/reka-edge": "reka-edge",
+  "rekaai/reka-edge": "reka-edge",
+  "openrouter:rekaai/reka-flash-3": "reka-flash-3",
+  "rekaai/reka-flash-3": "reka-flash-3",
   "openrouter:relace/relace-apply-3": "relace-apply-3",
   "relace/relace-apply-3": "relace-apply-3",
   "openrouter:relace/relace-search": "relace-search",
   "relace/relace-search": "relace-search",
-  "openrouter:sao10k/l3-euryale-70b": "l3-euryale-70b",
-  "sao10k/l3-euryale-70b": "l3-euryale-70b",
+  "openrouter:sakana/fugu-ultra": "fugu-ultra",
+  "sakana/fugu-ultra": "fugu-ultra",
   "openrouter:sao10k/l3-lunaris-8b": "l3-lunaris-8b",
   "sao10k/l3-lunaris-8b": "l3-lunaris-8b",
   "openrouter:sao10k/l3.1-70b-hanami-x1": "l3.1-70b-hanami-x1",
@@ -5822,11 +5699,12 @@ model_aliases = {
   "sao10k/l3.1-euryale-70b": "l3.1-euryale-70b",
   "openrouter:sao10k/l3.3-euryale-70b": "l3.3-euryale-70b",
   "sao10k/l3.3-euryale-70b": "l3.3-euryale-70b",
-  "openrouter:stepfun-ai/step3": "step3",
-  "stepfun-ai/step3": "step3",
   "openrouter:switchpoint/router": "router",
   "switchpoint/router": "router",
   "openrouter:tencent/hunyuan-a13b-instruct": "hunyuan-a13b",
+  "tencent/hunyuan-a13b-instruct": "hunyuan-a13b",
+  "openrouter:tencent/hy3-preview": "hy3",
+  "tencent/hy3-preview": "hy3",
   "openrouter:thedrummer/cydonia-24b-v4.1": "cydonia-24b-v4.1",
   "thedrummer/cydonia-24b-v4.1": "cydonia-24b-v4.1",
   "openrouter:thedrummer/rocinante-12b": "rocinante-12b",
@@ -5835,13 +5713,134 @@ model_aliases = {
   "thedrummer/skyfall-36b-v2": "skyfall-36b",
   "openrouter:thedrummer/unslopnemo-12b": "unslopnemo-12b",
   "thedrummer/unslopnemo-12b": "unslopnemo-12b",
-  "openrouter:thudm/glm-4.1v-9b-thinking": "glm-4.1v-9b-thinking",
   "openrouter:undi95/remm-slerp-l2-13b": "remm-slerp-l2-13b",
   "undi95/remm-slerp-l2-13b": "remm-slerp-l2-13b",
-  "openrouter:x-ai/grok-4-fast": "grok-4-fast",
-  "x-ai/grok-4-fast": "grok-4-fast",
-  "openrouter:x-ai/grok-4.1-fast": "grok-4.1-fast",
-  "x-ai/grok-4.1-fast": "grok-4.1-fast",
-  "openrouter:x-ai/grok-code-fast-1": "grok-code-fast-1",
-  "x-ai/grok-code-fast-1": "grok-code-fast-1"
+  "openrouter:upstage/solar-pro-3": "solar-pro-3",
+  "upstage/solar-pro-3": "solar-pro-3",
+  "openrouter:writer/palmyra-x5": "palmyra-x5",
+  "writer/palmyra-x5": "palmyra-x5",
+  "openrouter:x-ai/grok-4.20": "grok-4.20",
+  "x-ai/grok-4.20": "grok-4.20",
+  "openrouter:x-ai/grok-4.20-multi-agent": "grok-4.20-multi-agent",
+  "x-ai/grok-4.20-multi-agent": "grok-4.20-multi-agent",
+  "openrouter:x-ai/grok-build-0.1": "grok-build-0.1",
+  "x-ai/grok-build-0.1": "grok-build-0.1",
+  "openrouter:~google/gemini-flash-latest": "gemini-flash",
+  "~google/gemini-flash-latest": "gemini-flash",
+  "openrouter:~google/gemini-pro-latest": "gemini-pro",
+  "~google/gemini-pro-latest": "gemini-pro",
+  "openrouter:~openai/gpt-latest": "gpt",
+  "~openai/gpt-latest": "gpt",
+  "openrouter:~openai/gpt-mini-latest": "gpt-mini",
+  "~openai/gpt-mini-latest": "gpt-mini",
+  "togetherai:arize-ai/qwen-2-1.5b-instruct": "qwen-2-1.5b",
+  "togetherai:deepcogito/cogito-v2-1-671b": "cogito-v2-1-671b",
+  "togetherai:liquidai/lfm2-24b-a2b": "lfm2-24b-a2b",
+  "togetherai:meta-llama/llama-3.3-70b-instruct-turbo": "llama-3.3-70b-turbo",
+  "togetherai:meta-llama/llama-guard-4-12b": "llama-guard-4-12b",
+  "meta-llama/Llama-Guard-4-12B": "llama-guard-4-12b",
+  "meta-llama/llama-guard-4-12b": "llama-guard-4-12b",
+  "togetherai:meta-llama/meta-llama-3-8b-instruct-lite": "llama-3-8b-lite",
+  "togetherai:qwen/qwen2.5-7b-instruct-turbo": "qwen-2.5-7b-turbo",
+  "togetherai:qwen/qwen3.5-9b": "qwen-3.5-9b",
+  "Qwen/Qwen3.5-9B": "qwen-3.5-9b",
+  "qwen/qwen3.5-9b": "qwen-3.5-9b",
+  "x-ai:x-ai/grok-2-vision": "grok-2-vision",
+  "x-ai:x-ai/grok-2-vision-1212": "grok-2-vision-1212",
+  "x-ai:x-ai/grok-3-fast": "grok-3-fast",
+  "x-ai:x-ai/grok-3-mini-fast": "grok-3-mini-fast",
+  "x-ai:x-ai/grok-4-0709": "grok-4-0709",
+  "x-ai:x-ai/grok-4-1-fast": "grok-4-1-fast",
+  "x-ai:x-ai/grok-4-fast": "grok-4-fast",
+  "x-ai:x-ai/grok-4-fast-non-reasoning": "grok-4-fast-non-reasoning",
+  "x-ai:x-ai/grok-code-fast-1": "grok-code-fast-1",
+  "x-ai:x-ai/grok-vision-beta": "grok-vision-beta",
+  "z-ai:z-ai/autoglm-phone-multilingual": "autoglm-phone-multilingual",
+  "z-ai:z-ai/glm-4-32b-0414-128k": "glm-4-32b-0414-128k",
+  "z-ai:z-ai/glm-4.5": "glm-4.5",
+  "zai-org/GLM-4.5": "glm-4.5",
+  "z-ai/glm-4.5": "glm-4.5",
+  "z-ai:z-ai/glm-4.5-air": "glm-4.5-air",
+  "zai-org/GLM-4.5-Air": "glm-4.5-air",
+  "z-ai/glm-4.5-air": "glm-4.5-air",
+  "z-ai:z-ai/glm-4.5-airx": "glm-4.5-airx",
+  "z-ai:z-ai/glm-4.5-flash": "glm-4.5-flash",
+  "z-ai:z-ai/glm-4.5-x": "glm-4.5-x",
+  "z-ai:z-ai/glm-4.5v": "glm-4.5v",
+  "zai-org/GLM-4.5V-FP8": "glm-4.5v",
+  "zai-org/GLM-4.5V": "glm-4.5v",
+  "z-ai/glm-4.5v": "glm-4.5v",
+  "z-ai:z-ai/glm-4.6": "glm-4.6",
+  "zai-org/GLM-4.6": "glm-4.6",
+  "glm-4.6:cloud": "glm-4.6",
+  "z-ai/glm-4.6": "glm-4.6",
+  "z-ai:z-ai/glm-4.6v": "glm-4.6v",
+  "zai-org/GLM-4.6V-FP8": "glm-4.6v",
+  "z-ai/glm-4.6v": "glm-4.6v",
+  "z-ai:z-ai/glm-4.6v-flash": "glm-4.6v-flash",
+  "zai-org/GLM-4.6V-Flash": "glm-4.6v-flash",
+  "z-ai:z-ai/glm-4.6v-flashx": "glm-4.6v-flashx",
+  "z-ai:z-ai/glm-4.7-flashx": "glm-4.7-flashx",
+  "z-ai:z-ai/glm-5-turbo": "glm-5-turbo",
+  "z-ai/glm-5-turbo": "glm-5-turbo",
+  "pixtral-large-latest": "pixtral-large",
+  "openrouter:meta-llama/llama-3.3-8b-instruct:free": "llama-3.3-8b",
+  "openrouter:google/gemini-flash-1.5-8b": "gemini-1.5-8b-flash",
+  "openrouter:google/gemini-pro-1.5": "gemini-1.5-pro",
+  "openrouter:google/gemini-2.5-flash-preview:thinking": "gemini-2.5-flash-thinking",
+  "openrouter:google/gemma-3-1b-it:free": "gemma-3-1b",
+  "openrouter:nousresearch/hermes-2-pro-llama-3-8b": "hermes-2-pro",
+  "openrouter:nousresearch/hermes-3-llama-3.1-405b": "hermes-3-405b",
+  "openrouter:nousresearch/deephermes-3-llama-3-8b-preview:free": "deephermes-3-8b",
+  "openrouter:nousresearch/deephermes-3-mistral-24b-preview:free": "deephermes-3-24b",
+  "openrouter:microsoft/phi-3-mini-128k-instruct": "phi-3-mini",
+  "openrouter:microsoft/phi-3-medium-128k-instruct": "phi-3-medium",
+  "openrouter:microsoft/phi-4-multimodal-instruct": "phi-4-multimodal",
+  "openrouter:microsoft/phi-4-reasoning:free": "phi-4-reasoning",
+  "openrouter:microsoft/mai-ds-r1:free": "mai-ds-r1",
+  "openrouter:anthropic/claude-3.7-sonnet:thinking": "claude-3.7-sonnet-thinking",
+  "claude-3-opus-latest": "claude-3-opus",
+  "claude-3-sonnet-20240229": "claude-3-sonnet",
+  "openrouter:rekaai/reka-flash-3:free": "reka-flash",
+  "openrouter:cohere/command": "command",
+  "openrouter:qwen/qwen3-0.6b-04-28:free": "qwen-3-0.6b",
+  "qwen3-0.6b": "qwen-3-0.6b",
+  "Qwen/Qwen3-0.6B": "qwen-3-0.6b",
+  "openrouter:qwen/qwen3-1.7b:free": "qwen-3-1.7b",
+  "qwen3-1.7b": "qwen-3-1.7b",
+  "Qwen/Qwen3-1.7B": "qwen-3-1.7b",
+  "openrouter:qwen/qwen3-4b:free": "qwen-3-4b",
+  "qwen3-4b": "qwen-3-4b",
+  "Qwen/Qwen3-4B": "qwen-3-4b",
+  "openrouter:qwen/qwen2.5-coder-7b-instruct": "qwen-2.5-coder-7b",
+  "Qwen/Qwen2.5-Coder-7B-Instruct": "qwen-2.5-coder-7b",
+  "Qwen/Qwen2.5-Coder-7B": "qwen-2.5-coder-7b",
+  "openrouter:qwen/qwen2.5-vl-3b-instruct:free": "qwen-2.5-vl-3b",
+  "deepseek-ai/DeepSeek-V3-0324": "deepseek-v3-0324",
+  "lordoliver/DeepSeek-V3-0324:671b-q4_k_m": "deepseek-v3-0324",
+  "openrouter:deepseek/deepseek-r1-zero:free": "deepseek-r1-zero",
+  "openrouter:deepseek/deepseek-r1-distill-llama-8b": "deepseek-r1-distill-llama-8b",
+  "deepseek-ai/DeepSeek-R1-Distill-Llama-8B": "deepseek-r1-distill-llama-8b",
+  "deepseek/deepseek-chat": "deepseek-chat",
+  "deepseek-coder:6.7b": "deepseek-coder",
+  "openrouter:x-ai/grok-3-beta": "grok-3-beta",
+  "openrouter:perplexity/llama-3.1-sonar-small-128k-online": "llama-3.1-sonar-small-online",
+  "openrouter:perplexity/llama-3.1-sonar-large-128k-online": "llama-3.1-sonar-large-online",
+  "openrouter:nvidia/llama-3.1-nemotron-ultra-253b-v1:free": "nemotron-253b",
+  "openrouter:thudm/glm-4-9b:free": "glm-4-9b",
+  "openrouter:thudm/glm-z1-9b:free": "glm-z1-9b",
+  "openrouter:thudm/glm-z1-rumination-32b": "glm-z1-rumination-32b",
+  "openrouter:cognitivecomputations/dolphin3.0-r1-mistral-24b:free": "dolphin-3.0-r1-24b",
+  "openrouter:cognitivecomputations/dolphin3.0-mistral-24b:free": "dolphin-3.0-24b",
+  "openrouter:cognitivecomputations/dolphin-mixtral-8x22b": "dolphin-8x22b",
+  "openrouter:agentica-org/deepcoder-14b-preview:free": "deepcoder-14b",
+  "openrouter:moonshotai/kimi-vl-a3b-thinking:free": "kimi-vl-thinking",
+  "openrouter:moonshotai/moonlight-16b-a3b-instruct:free": "moonlight-16b",
+  "openrouter:featherless/qwerky-72b:free": "qwerky-72b",
+  "openrouter:liquid/lfm-7b": "lfm-7b",
+  "openrouter:liquid/lfm-3b": "lfm-3b",
+  "openrouter:liquid/lfm-40b": "lfm-40b",
+  "CohereLabs/c4ai-command-a-03-2025": "command-a25",
+  "command-r7b-arabic-02-2025": "command-r7b-arabic25",
+  "CohereLabs/c4ai-command-r7b-arabic-02-2025": "command-r7b-arabic25"
 }

--- a/g4f/providers/any_provider.py
+++ b/g4f/providers/any_provider.py
@@ -210,7 +210,7 @@ class AnyModelProviderMixin(ProviderModelMixin):
             if not provider.working:
                 continue
             try:
-                if provider in [Copilot, CopilotAccount, Perplexity]:
+                if provider in [Copilot, CopilotAccount, CopilotApp, Perplexity]:
                     for model in provider.model_aliases.keys():
                         if model not in cls.model_map:
                             cls.model_map[model] = {}

--- a/g4f/providers/any_provider.py
+++ b/g4f/providers/any_provider.py
@@ -174,6 +174,15 @@ class AnyModelProviderMixin(ProviderModelMixin):
         cls.vision_models = []
         cls.video_models = []
 
+        from ..Provider import __getattr__
+        def resolve_provider(p):
+            if isinstance(p, str):
+                try:
+                    return __getattr__(p)
+                except AttributeError:
+                    return None
+            return p
+
         # Get models from the models registry
         cls.model_map = {
             "default": {
@@ -184,9 +193,9 @@ class AnyModelProviderMixin(ProviderModelMixin):
         cls.model_map.update(
             {
                 name: {
-                    provider.__name__: model.get_long_name()
-                    for provider in providers
-                    if provider.working
+                    p.__name__: model.get_long_name()
+                    for p in (resolve_provider(provider) for provider in providers)
+                    if p and getattr(p, "working", False)
                 }
                 for name, (model, providers) in models.__models__.items()
             }

--- a/g4f/providers/any_provider.py
+++ b/g4f/providers/any_provider.py
@@ -178,7 +178,7 @@ class AnyModelProviderMixin(ProviderModelMixin):
         cls.model_map = {
             "default": {
                 provider.__name__: ""
-                for provider in models.default.best_provider.providers
+                for provider in models.default.best_provider.get_providers()
             },
         }
         cls.model_map.update(
@@ -465,9 +465,9 @@ class AnyProvider(AsyncGeneratorProvider, AnyModelProviderMixin):
             elif has_audio:
                 providers = [PollinationsAI, MarkItDown]
             elif has_image:
-                providers = models.default_vision.best_provider.providers
+                providers = models.default_vision.best_provider.get_providers()
             else:
-                providers = models.default.best_provider.providers
+                providers = models.default.best_provider.get_providers()
         elif model in RouterConfig.routes:
             async for chunk in ConfigModelProvider(RouterConfig.routes.get(model)).create_async_generator(
                 model, messages, stream=stream, media=media, api_key=api_key, **kwargs

--- a/g4f/providers/any_provider.py
+++ b/g4f/providers/any_provider.py
@@ -18,9 +18,9 @@ from ..Provider import (
     Cloudflare,
     Gemini,
     Grok,
-    Perplexity,
     PollinationsAI,
     PuterJS,
+    CopilotApp,
 )
 from ..Provider import (
     DeepInfra,
@@ -62,6 +62,7 @@ PROVIDERS_LIST_2 = [
     OpenaiChat,
     Copilot,
     CopilotAccount,
+    CopilotApp,
     PollinationsAI,
     Perplexity,
     Gemini,
@@ -501,10 +502,13 @@ class AnyProvider(AsyncGeneratorProvider, AnyModelProviderMixin):
                     model = cls.model_aliases[model]
             if model in cls.model_map:
                 for provider, alias in cls.model_map[model].items():
-                    provider = Provider.__map__[provider]
-                    if model not in provider.model_aliases:
-                        provider.model_aliases[model] = alias
-                    providers.append(provider)
+                    try:
+                        provider_cls = Provider.__map__[provider]
+                        if model not in provider_cls.model_aliases:
+                            provider_cls.model_aliases[model] = alias
+                        providers.append(provider_cls)
+                    except KeyError:
+                        pass
         if not providers:
             for provider in PROVIDERS_LIST_2 + PROVIDERS_LIST_3:
                 try:

--- a/g4f/providers/retry_provider.py
+++ b/g4f/providers/retry_provider.py
@@ -238,7 +238,10 @@ class RetryProvider(IterListProvider):
         started = False
 
         if self.single_provider_retry:
-            provider = self.providers[0]
+            providers = self.get_providers()
+            if not providers:
+                raise RetryNoProviderError("No providers available")
+            provider = providers[0]
             self.last_provider = provider
             for attempt in range(self.max_retries):
                 try:

--- a/g4f/version.py
+++ b/g4f/version.py
@@ -31,9 +31,7 @@ def get_pypi_version(package_name: str) -> str:
         response.raise_for_status()
         return response.json()["info"]["version"]
     except Exception as e:
-        if isinstance(e, ImportError) or e.__class__.__name__ == "RequestException":
-            raise VersionNotFoundError(f"Failed to get PyPI version for '{package_name}'") from e
-        raise e
+        raise VersionNotFoundError(f"Failed to get PyPI version for '{package_name}'") from e
 
 
 @lru_cache(maxsize=1)
@@ -56,9 +54,7 @@ def get_github_version(repo: str) -> str:
             raise VersionNotFoundError(f"No tag_name found in latest GitHub release for '{repo}'")
         return data["tag_name"]
     except Exception as e:
-        if isinstance(e, ImportError) or e.__class__.__name__ == "RequestException":
-            raise VersionNotFoundError(f"Failed to get GitHub release version for '{repo}'") from e
-        raise e
+        raise VersionNotFoundError(f"Failed to get GitHub release version for '{repo}'") from e
 
 
 def get_git_version() -> str | None:
@@ -115,13 +111,14 @@ class VersionUtils:
         If not installed via PyPI, falls back to GitHub releases.
         """
         try:
-            from importlib.metadata import version as get_package_version, PackageNotFoundError
-            get_package_version(PACKAGE_NAME)
-        except ImportError:
-            return get_github_version(GITHUB_REPOSITORY)
-        except PackageNotFoundError:
-            return get_github_version(GITHUB_REPOSITORY)
-        return get_pypi_version(PACKAGE_NAME)
+            try:
+                from importlib.metadata import version as get_package_version, PackageNotFoundError
+                get_package_version(PACKAGE_NAME)
+            except (ImportError, PackageNotFoundError):
+                return get_github_version(GITHUB_REPOSITORY)
+            return get_pypi_version(PACKAGE_NAME)
+        except Exception:
+            return self.current_version
 
     @cached_property
     def latest_version_cached(self) -> str:


### PR DESCRIPTION
### 🐛 What's the issue?
This PR addresses five significant bugs related to recent lazy-loading optimizations, network stability, and a major startup performance regression:

1. **Import Bypass Issue:** When a user does `from g4f.Provider import PollinationsAI`, Python's built-in import machinery finds the `PollinationsAI.py` file and automatically registers it as a submodule. This happens *before* `__getattr__` is called, causing it to return a module object instead of the provider class, which breaks backward compatibility. 
2. **Issue #3469 (`AttributeError: 'str' object has no attribute 'working'`):** Since `IterListProvider` was optimized to store strings instead of eager classes, calling `.providers` directly in `g4f/providers/any_provider.py` returned a list of strings instead of class objects. This caused a crash when it tried to check `if provider.working`.
3. **Hidden String Provider Bugs (`g4f/providers/retry_provider.py`):** The same string-provider issue lurked in `RetryProvider`, which accessed `self.providers[0]` directly without resolving strings, causing an application crash when used with single provider retry.
4. **Lazy-Loading Performance Regression:** The `__models__` registry eagerly resolved all string providers on import time to populate the `__models__` mapping. Because of this eager resolution, `import g4f` caused every single provider module in the entire repository to be loaded, skyrocketing import time from ~0.1s to 6-8 seconds. 
5. **Offline GUI Crash (`g4f.cli gui`):** If a user launches the GUI without internet access (or with DNS/proxy issues), the version check to `api.github.com` raises a network connection error. Because `g4f/version.py` only caught exactly `"RequestException"`, the unhandled network error caused the main route to return a 500 Internal Server Error, making the GUI completely unusable offline.

### 🛠️ How does this PR fix it?
1. **Module Interception (`g4f/Provider/__init__.py`):** Wrapped the `g4f.Provider` module in a custom `types.ModuleType`. By overriding `__getattribute__` on the module class itself, we intercept *all* attribute accesses before the default import machinery kicks in. This guarantees that the **class** is always returned and correctly enforces our lazy loader.
2. **String Resolution (`g4f/providers/any_provider.py` & `g4f/providers/retry_provider.py`):** Changed direct access of `.providers` to use dynamic runtime resolution (like `resolve_provider` or `.get_providers()`). This automatically resolves string names into actual provider classes ONLY on demand, preventing crashes during provider iteration.
3. **Lazy-Loading Restored (`g4f/models.py`):** Reverted the registry building in `_get_best_providers` so that it safely stores strings in `__models__` instead of classes. This guarantees that provider modules are never loaded on startup, preserving the original fast import time.
4. **Graceful Network Error Handling (`g4f/version.py`):** Updated the exception catching in `get_pypi_version` and `get_github_version` to properly catch all network errors. Added a top-level try-except in `latest_version` so that if all checks fail, it gracefully falls back to the current version without crashing the application.

### ✅ Testing
- Verified that `from g4f.Provider import PollinationsAI` correctly resolves to `<class 'abc.ABCMeta'>` (the class object) and not a module.
- Tested `AnyProvider` execution and verified that `models.default.best_provider.get_providers()` successfully resolves all strings, fixing the #3469 crash.
- Simulated offline mode (`Errno -3 Temporary failure in name resolution`) and verified that the GUI loads perfectly with a 200 OK instead of a 500 crash.
- Verified that `import g4f` is lightning fast because lazy-loading strings inside `__models__` is preserved.
- All 177 unittests pass successfully.

Closes #3469
