### PR TITLE
fix: bypass Turnstile Captcha for DeepInfra and fix Debian package nest-asyncio2 dependency

### DIFF
--- a/g4f/Provider/DeepInfra.py
+++ b/g4f/Provider/DeepInfra.py
@@ -1,9 +1,74 @@
 from __future__ import annotations
 
+import time
 import requests
 
 from ..typing import Messages, AsyncResult
 from .template import OpenaiTemplate
+
+def get_turnstile_token() -> str:
+    """
+    Opens the DeepInfra page using DrissionPage to obtain a Turnstile token.
+    Raises MissingRequirementsError if DrissionPage is not installed.
+    """
+    try:
+        from DrissionPage import ChromiumPage, ChromiumOptions
+    except ImportError:
+        from ..errors import MissingRequirementsError
+        raise MissingRequirementsError('Install "DrissionPage" package to use DeepInfra without an API key | pip install DrissionPage')
+
+    co = ChromiumOptions()
+    # Hide the window off-screen
+    co.set_argument('--window-position=-2000,-2000')
+    co.set_argument('--window-size=800,600')
+    co.set_argument('--log-level=3')
+    
+    page = ChromiumPage(co)
+    
+    try:
+        # Generate a token on any model's page; it is valid for the entire domain
+        page.get('https://deepinfra.com/zai-org/GLM-5.2')
+        
+        # Inject JS to block the original request
+        js_block_fetch = """
+        const origFetch = window.fetch;
+        window.fetch = async function(...args) {
+            let url = args[0];
+            if (typeof url === 'string' && url.includes('/chat/completions')) {
+                return new Response('{}', {status: 200});
+            }
+            return origFetch.apply(this, args);
+        };
+        """
+        page.run_js(js_block_fetch)
+        
+        # Initiate Turnstile
+        textarea = page.ele('tag:textarea', timeout=15)
+        if not textarea:
+            return ""
+            
+        textarea.input('Test')
+        textarea.input('\n')
+        
+        # Wait for the challenge to be solved
+        token_input = page.ele('@name=cf-turnstile-response', timeout=20)
+        
+        if not token_input:
+            return ""
+            
+        token = ""
+        for _ in range(40):
+            token = token_input.attr('value')
+            if token:
+                break
+            time.sleep(0.5)
+            
+        return token
+    finally:
+        try:
+            page.quit()
+        except:
+            pass
 
 class DeepInfra(OpenaiTemplate):
     url = "https://deepinfra.com"
@@ -36,4 +101,10 @@ class DeepInfra(OpenaiTemplate):
             headers["X-Deepinfra-Source"] = "model-embed"
             headers["Origin"] = "https://deepinfra.com"
             headers["Referer"] = "https://deepinfra.com/"
+            
+            # Generate a Turnstile token for each request (required without an API key)
+            token = get_turnstile_token()
+            if token:
+                headers["X-DeepInfra-Turnstile"] = token
+                
         return headers

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -41,7 +41,7 @@ cat > debian/${PACKAGE_NAME}/DEBIAN/postinst << 'EOF'
 set -e
 
 # Install Python dependencies
-pip3 install --break-system-packages aiohttp requests brotli pycryptodome nest_asyncio
+pip3 install --break-system-packages aiohttp requests brotli pycryptodome nest-asyncio2
 
 # Make g4f command available
 if [ ! -L /usr/local/bin/g4f ]; then


### PR DESCRIPTION
This PR addresses two separate issues currently affecting the project:

**1. DeepInfra Captcha Issue (#3453):**
The `DeepInfra` provider recently added a Cloudflare Turnstile captcha to their anonymous endpoint, causing a `Missing captcha token` error. To fix this, a `get_turnstile_token()` method has been added using `DrissionPage` to headlessly solve the challenge and extract the valid token. `MissingRequirementsError` is used for a lazy import, so `DrissionPage` is **not** forced onto all users as a base dependency.

**2. Debian Build Script Dependency (#3473):**
In `scripts/build-deb.sh`, the postinst script was mistakenly installing `nest_asyncio` instead of the required `nest-asyncio2`, which breaks async execution paths for users installing via `.deb`. This PR updates the script to install the correct `nest-asyncio2` dependency to match `requirements-min.txt` and `setup.py`.

## Changes Made
- `g4f/Provider/DeepInfra.py`: Implemented Turnstile token retrieval via DrissionPage.
- `scripts/build-deb.sh`: Changed `nest_asyncio` to `nest-asyncio2` (line 44).

## Related Issues
Fixes #3453 
Fixes #3473 

## Testing
- DeepInfra generates text successfully without captcha errors.
- Verified `scripts/build-deb.sh` dependency name against `requirements-min.txt`.
