### PR TITLE
fix(CI): add timeout to get_models() requests to prevent CI hang

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -24,6 +24,7 @@ jobs:
       run: pip install -r requirements-min.txt
     - name: Run tests
       run: python -m etc.unittest
+      timeout-minutes: 5
     - name: Set up Python 3.14
       uses: actions/setup-python@v6
       with:
@@ -34,6 +35,7 @@ jobs:
         pip install -r requirements.txt
     - name: Run tests
       run: python -m etc.unittest
+      timeout-minutes: 5
     - name: Save PR number
       env:
         PR_NUMBER: ${{ github.event.number }}

--- a/g4f/Provider/DeepInfra.py
+++ b/g4f/Provider/DeepInfra.py
@@ -162,7 +162,7 @@ class DeepInfra(OpenaiTemplate):
     def get_models(cls, **kwargs):
         if not cls.models:
             url = 'https://api.deepinfra.com/models/featured'
-            response = requests.get(url)
+            response = requests.get(url, timeout=kwargs.get("timeout", 15))
             models = response.json()
             
             cls.models = {model["model_name"]: {"id": model["model_name"], **model} for model in models if model.get("type") == "text-generation" or model.get("reported_type") == "text-to-image"}

--- a/g4f/Provider/glm/__init__.py
+++ b/g4f/Provider/glm/__init__.py
@@ -220,14 +220,15 @@ class GLM(AsyncGeneratorProvider, ProviderModelMixin, AuthFileMixin):
     @classmethod
     def get_models(cls, **kwargs) -> list:
         if not cls.models:
-            response = requests.get(f"{cls.url}/api/v1/auths/")
+            response = requests.get(f"{cls.url}/api/v1/auths/", timeout=kwargs.get("timeout", 15))
             auth_data = response.json()
             cls.api_key = auth_data.get("token")
             cls.auth_user_id = str(auth_data.get("id", ""))
             cls.auth_user_name = auth_data.get("name") or auth_data.get("nickname") or "User"
             response = requests.get(
                 f"{cls.url}/api/models",
-                headers={"Authorization": f"Bearer {cls.api_key}"}
+                headers={"Authorization": f"Bearer {cls.api_key}"},
+                timeout=kwargs.get("timeout", 15)
             )
             items = response.json().get("data", [])
             cls.model_aliases = {

--- a/g4f/Provider/local/Ollama.py
+++ b/g4f/Provider/local/Ollama.py
@@ -100,7 +100,7 @@ class Ollama(OpenaiTemplate):
             cls.models = []
             if not api_key or AppConfig.disable_custom_api_key:
                 api_key = AuthManager.load_api_key(cls)
-            models = requests.get("https://ollama.com/api/tags").json()["models"]
+            models = requests.get("https://ollama.com/api/tags", timeout=kwargs.get("timeout", 15)).json()["models"]
             if models:
                 cls.live += 1
             cls.models = [model["name"] for model in models]
@@ -111,7 +111,7 @@ class Ollama(OpenaiTemplate):
             else:
                 url = base_url.replace("/v1", "/api/tags")
             try:
-                models = requests.get(url).json()["models"]
+                models = requests.get(url, timeout=kwargs.get("timeout", 15)).json()["models"]
             except requests.exceptions.RequestException as e:
                 return cls.models
             if cls.live == 0 and models:

--- a/g4f/Provider/needs_auth/Puter.py
+++ b/g4f/Provider/needs_auth/Puter.py
@@ -209,7 +209,7 @@ class Puter(AsyncGeneratorProvider, ProviderModelMixin):
         if not cls.models:
             try:
                 url = cls.models_endpoint
-                cls.models = requests.get(url).json().get("models", [])
+                cls.models = requests.get(url, timeout=kwargs.get("timeout", 15)).json().get("models", [])
                 cls.models = [model for model in cls.models if model not in ["abuse", "costly", "fake", "model-fallback-test-1"]]
                 cls.live += 1
             except Exception as e:

--- a/g4f/Provider/needs_auth/hf/HuggingChat.py
+++ b/g4f/Provider/needs_auth/hf/HuggingChat.py
@@ -50,7 +50,7 @@ class HuggingChat(AsyncAuthedProvider, ProviderModelMixin):
     def get_models(cls, **kwargs) -> list[str]:
         if not cls.models:
             try:
-                models = requests.get(f"{cls.url}/api/v2/models").json().get("json")
+                models = requests.get(f"{cls.url}/api/v2/models", timeout=kwargs.get("timeout", 15)).json().get("json")
                 cls.text_models = [model["id"] for model in models] 
                 cls.models = cls.text_models + cls.image_models
                 cls.vision_models = [model["id"] for model in models if model["multimodal"]]

--- a/g4f/Provider/needs_auth/hf/HuggingFaceInference.py
+++ b/g4f/Provider/needs_auth/hf/HuggingFaceInference.py
@@ -34,7 +34,7 @@ class HuggingFaceInference(AsyncGeneratorProvider, ProviderModelMixin):
     model_data: dict[str, dict] = {}
 
     @classmethod
-    def get_models(cls) -> list[str]:
+    def get_models(cls, **kwargs) -> list[str]:
         if not cls.models:
             models = text_models.copy()
             url = "https://huggingface.co/api/models?inference=warm&pipeline_tag=text-generation"

--- a/g4f/Provider/needs_auth/hf/HuggingFaceInference.py
+++ b/g4f/Provider/needs_auth/hf/HuggingFaceInference.py
@@ -38,12 +38,12 @@ class HuggingFaceInference(AsyncGeneratorProvider, ProviderModelMixin):
         if not cls.models:
             models = text_models.copy()
             url = "https://huggingface.co/api/models?inference=warm&pipeline_tag=text-generation"
-            response = requests.get(url)
+            response = requests.get(url, timeout=kwargs.get("timeout", 15))
             if response.ok: 
                 extra_models = [model["id"] for model in response.json() if model.get("trendingScore", 0) >= 10]
                 models = extra_models + vision_models + [model for model in models if model not in extra_models]
             url = "https://huggingface.co/api/models?pipeline_tag=text-to-image"
-            response = requests.get(url)
+            response = requests.get(url, timeout=kwargs.get("timeout", 15))
             cls.image_models = image_models.copy()
             if response.ok:
                 extra_models = [model["id"] for model in response.json() if model.get("trendingScore", 0) >= 20] 

--- a/g4f/Provider/needs_auth/hf/HuggingFaceMedia.py
+++ b/g4f/Provider/needs_auth/hf/HuggingFaceMedia.py
@@ -32,7 +32,7 @@ class HuggingFaceMedia(AsyncGeneratorProvider, ProviderModelMixin):
     def get_models(cls, **kwargs) -> list[str]:
         if not cls.models:
             url = "https://huggingface.co/api/models?inference=warm&expand[]=inferenceProviderMapping"
-            response = requests.get(url)
+            response = requests.get(url, timeout=kwargs.get("timeout", 15))
             if response.ok:
                 models = response.json()
                 providers = {


### PR DESCRIPTION
## Problem

The `Unittest` CI workflow hangs indefinitely (2-6 hours) on `python -m etc.unittest` due to `requests.get()` calls without a `timeout` parameter in several provider `get_models()` methods.

The test passes `timeout=5` via `provider.get_models(timeout=5)`, but providers like `DeepInfra` and `glm` accept it as `**kwargs` and never use it — so the timeout is silently ignored.

When Cloudflare or other WAFs tarpit the connection (accept TCP but never respond), `requests.get()` waits indefinitely, blocking the entire test run.

## Changes

### Provider timeout fix (7 files)
Added `timeout=kwargs.get("timeout", 15)` to `requests.get()` calls in `get_models()`:
- `DeepInfra.py`
- `glm/__init__.py`
- `local/Ollama.py`
- `needs_auth/Puter.py`
- `needs_auth/hf/HuggingChat.py`
- `needs_auth/hf/HuggingFaceInference.py` (also added missing `**kwargs` to method signature to prevent `NameError`)
- `needs_auth/hf/HuggingFaceMedia.py`

### CI safety net
Added `timeout-minutes: 5` to both `Run tests` steps in `unittest.yml` to prevent future hangs regardless of cause.

## Testing

Ran `python -m etc.unittest` on fork CI — all 167 tests passed in 19 seconds (28 skipped).
