### PR TITLE
Fix upload  multi images in Qwen.py

### DIFF
--- a/g4f/Provider/Qwen.py
+++ b/g4f/Provider/Qwen.py
@@ -227,11 +227,11 @@ class Qwen(AsyncGeneratorProvider, ProviderModelMixin):
 
             # Put File into Url
             str_date = datetime.datetime.now(datetime.timezone.utc).strftime('%Y%m%dT%H%M%SZ')
-            headers = get_oss_headers('PUT', str_date, data, file_type)
+            headers_put = get_oss_headers('PUT', str_date, data, file_type)
             async with session.put(
                     file_url.split("?")[0],
                     data=data_bytes,
-                    headers=headers
+                    headers=headers_put
             ) as response:
                 await raise_for_status(response)
 


### PR DESCRIPTION
Rename the local `headers` variable to `headers_put` and use it in the session.put call to avoid shadowing an outer variable and improve clarity.