### PR TITLE
Gemini: cookie snapshot, XSRF retry, prompt

### DIFF
--- a/etc/unittest/test_gemini.py
+++ b/etc/unittest/test_gemini.py
@@ -14,13 +14,16 @@ from g4f.Provider.needs_auth.Gemini import (
     _build_model_headers,
     _extract_gemini_error_code,
     _extract_reasoning,
+    _has_authenticated_session,
     _is_xsrf_error,
     _iter_response_lines,
     _normalize_messages,
     _parse_account_models,
     _parse_google_frames,
+    _resolve_gemini_conversation,
     _resolve_gemini_prompt,
     _resolve_model,
+    Conversation,
 )
 from g4f.errors import MissingAuthError, ResponseError, ResponseStatusError
 from g4f.models import ModelRegistry
@@ -156,6 +159,67 @@ class GeminiHelpersTest(unittest.TestCase):
         )
         with self.assertRaises(TypeError):
             _normalize_messages({"role": "user"})
+
+    def test_anonymous_followup_uses_full_message_history(self):
+        messages = [
+            {"role": "user", "content": "first turn"},
+            {"role": "assistant", "content": "first answer"},
+            {"role": "user", "content": "second turn"},
+        ]
+        conversation = Conversation(
+            "conversation-id",
+            "response-id",
+            "choice-id",
+            "gemini-auto",
+        )
+
+        self.assertFalse(_has_authenticated_session({}))
+        resolved = _resolve_gemini_conversation(
+            conversation,
+            "gemini-auto",
+            {},
+        )
+        prompt = _resolve_gemini_prompt(messages, None, resolved)
+        request = Gemini.build_request(
+            prompt,
+            "en",
+            "gemini-auto",
+            4,
+            conversation=resolved,
+            request_uuid="test-request",
+        )
+
+        self.assertIsNone(resolved)
+        self.assertIn("first turn", prompt)
+        self.assertIn("first answer", prompt)
+        self.assertIn("second turn", prompt)
+        self.assertEqual(request[2][:3], ["", "", ""])
+
+    def test_authenticated_followup_keeps_conversation_handle(self):
+        conversation = Conversation(
+            "conversation-id",
+            "response-id",
+            "choice-id",
+            "gemini-3.5-flash",
+        )
+        cookies = {"__Secure-1PSID": "session"}
+
+        self.assertTrue(_has_authenticated_session(cookies))
+        self.assertIs(
+            _resolve_gemini_conversation(
+                conversation,
+                "gemini-3.5-flash",
+                cookies,
+            ),
+            conversation,
+        )
+        self.assertIsNone(
+            _resolve_gemini_conversation(
+                conversation,
+                "gemini-auto",
+                cookies,
+            )
+        )
 
     def test_xsrf_response_is_retryable(self):
         error = ResponseStatusError(

--- a/etc/unittest/test_gemini.py
+++ b/etc/unittest/test_gemini.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import unittest
+from unittest.mock import AsyncMock, patch
 
 from g4f.Provider.needs_auth.Gemini import (
     ACCOUNT_STATUS_AVAILABLE,
@@ -12,12 +13,15 @@ from g4f.Provider.needs_auth.Gemini import (
     _build_model_headers,
     _extract_gemini_error_code,
     _extract_reasoning,
+    _is_xsrf_error,
     _iter_response_lines,
+    _normalize_messages,
     _parse_account_models,
     _parse_google_frames,
+    _resolve_gemini_prompt,
     _resolve_model,
 )
-from g4f.errors import MissingAuthError, ResponseError
+from g4f.errors import MissingAuthError, ResponseError, ResponseStatusError
 from g4f.models import ModelRegistry
 
 
@@ -119,6 +123,15 @@ class GeminiHelpersTest(unittest.TestCase):
                 resolved, _ = _resolve_model(legacy_name)
                 self.assertEqual(resolved, current_name)
 
+    def test_unknown_model_lists_supported_models(self):
+        with self.assertRaises(ValueError) as context:
+            _resolve_model("gemini-3.6-flash")
+
+        message = str(context.exception)
+        self.assertIn("Unknown Gemini model: gemini-3.6-flash", message)
+        self.assertIn("Supported models:", message)
+        self.assertIn("gemini-3.5-flash", message)
+
     def test_public_model_registry_exposes_current_models(self):
         self.assertEqual(ModelRegistry.get("gemini").name, "gemini-3.5-flash")
         for model in (
@@ -129,6 +142,28 @@ class GeminiHelpersTest(unittest.TestCase):
         ):
             with self.subTest(model=model):
                 self.assertEqual(ModelRegistry.get(model).name, model)
+
+    def test_prompt_only_requests_accept_missing_messages(self):
+        messages = _normalize_messages(None)
+
+        self.assertEqual(messages, [])
+        self.assertEqual(
+            _resolve_gemini_prompt(messages, "prompt-only request", None),
+            "prompt-only request",
+        )
+        with self.assertRaises(TypeError):
+            _normalize_messages({"role": "user"})
+
+    def test_xsrf_response_is_retryable(self):
+        error = ResponseStatusError(
+            'Response 400: [["er",null,{"reason":"xsrf"}]]'
+        )
+
+        self.assertTrue(_is_xsrf_error(error, 400))
+        self.assertFalse(_is_xsrf_error(error, 401))
+        self.assertFalse(
+            _is_xsrf_error(ResponseStatusError("Response 400"), 400)
+        )
 
     def test_extract_reasoning_from_dedicated_field(self):
         candidate = [None] * 38
@@ -175,6 +210,198 @@ class GeminiHelpersTest(unittest.TestCase):
 
 
 class GeminiStreamTest(unittest.IsolatedAsyncioTestCase):
+    async def test_public_generator_retries_xsrf_with_prompt_only_request(self):
+        class FakeResponse:
+            def __init__(self, status, content=b"[]\n"):
+                self.status = status
+                self.headers = {}
+                self.released = False
+                self.content = self
+                self._content = content
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, _exc_type, _exc, _traceback):
+                return False
+
+            async def iter_any(self):
+                yield self._content
+
+            def release(self):
+                self.released = True
+
+        class FakeSession:
+            def __init__(self, responses):
+                self.responses = iter(responses)
+                self.calls = []
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, _exc_type, _exc, _traceback):
+                return False
+
+            async def post(self, _url, **kwargs):
+                self.calls.append(
+                    {
+                        "data": dict(kwargs["data"]),
+                        "params": dict(kwargs["params"]),
+                        "cookies": dict(kwargs["cookies"]),
+                        "cookies_object": kwargs["cookies"],
+                    }
+                )
+                return next(self.responses)
+
+        class ProbeGemini(Gemini):
+            auto_refresh = False
+            _cookies = None
+            _metadata_cookie_key = None
+            _metadata_auth_user = None
+            _metadata_fetched_at = 0
+            _account_status = None
+            _account_models = {}
+            _account_models_fetched_at = 0
+            _snlm0e = None
+            _sid = None
+
+        first_response = FakeResponse(400)
+        session = FakeSession([first_response, FakeResponse(200)])
+        source_cookies = {
+            "__Secure-1PSID": "session",
+            "__Secure-1PSIDTS": "old",
+        }
+        metadata_fetches = 0
+
+        async def fetch_metadata(_session, cookies, _auth_user=None):
+            nonlocal metadata_fetches
+            metadata_fetches += 1
+            self.assertIsNot(cookies, source_cookies)
+            ProbeGemini._snlm0e = f"token-{metadata_fetches}"
+            ProbeGemini._sid = f"sid-{metadata_fetches}"
+            ProbeGemini._bl = f"build-{metadata_fetches}"
+
+        async def check_status(response):
+            if response.status == 400:
+                raise ResponseStatusError(
+                    'Response 400: [["er",null,{"reason":"xsrf"}]]'
+                )
+
+        with patch(
+            "g4f.Provider.needs_auth.Gemini.ClientSession",
+            return_value=session,
+        ):
+            with patch.object(
+                ProbeGemini,
+                "fetch_snlm0e",
+                new_callable=AsyncMock,
+                side_effect=fetch_metadata,
+            ) as fetch:
+                with patch.object(
+                    ProbeGemini,
+                    "fetch_account_models",
+                    new_callable=AsyncMock,
+                ):
+                    with patch.object(
+                        ProbeGemini,
+                        "upload_images",
+                        new_callable=AsyncMock,
+                        return_value=[],
+                    ):
+                        with patch(
+                            "g4f.Provider.needs_auth.Gemini.raise_for_status",
+                            side_effect=check_status,
+                        ):
+                            generator = ProbeGemini.create_async_generator(
+                                model="gemini-3.5-flash",
+                                messages=None,
+                                prompt="prompt-only request",
+                                cookies=source_cookies,
+                                max_retries=1,
+                            )
+                            await generator.__anext__()
+                            await generator.aclose()
+
+        self.assertEqual(fetch.await_count, 2)
+        self.assertEqual(len(session.calls), 2)
+        self.assertTrue(first_response.released)
+        self.assertEqual(session.calls[0]["data"]["at"], "token-1")
+        self.assertEqual(session.calls[0]["params"]["bl"], "build-1")
+        self.assertEqual(session.calls[0]["params"]["f.sid"], "sid-1")
+        self.assertEqual(session.calls[1]["data"]["at"], "token-2")
+        self.assertEqual(session.calls[1]["params"]["bl"], "build-2")
+        self.assertEqual(session.calls[1]["params"]["f.sid"], "sid-2")
+        self.assertIs(
+            session.calls[0]["cookies_object"],
+            session.calls[1]["cookies_object"],
+        )
+        self.assertIsNot(session.calls[0]["cookies_object"], source_cookies)
+        self.assertEqual(source_cookies["__Secure-1PSIDTS"], "old")
+        request = json.loads(json.loads(session.calls[1]["data"]["f.req"])[1])
+        self.assertEqual(request[0][0], "prompt-only request")
+
+    async def test_auto_refresh_waits_before_rotating(self):
+        with patch(
+            "g4f.Provider.needs_auth.Gemini.asyncio.sleep",
+            new_callable=AsyncMock,
+            side_effect=asyncio.CancelledError(),
+        ) as sleep:
+            with patch(
+                "g4f.Provider.needs_auth.Gemini.rotate_1psidts",
+                new_callable=AsyncMock,
+            ) as rotate:
+                with self.assertRaises(asyncio.CancelledError):
+                    await Gemini.start_auto_refresh(
+                        cookies={"__Secure-1PSID": "session"}
+                    )
+
+        sleep.assert_awaited_once_with(Gemini.refresh_interval)
+        rotate.assert_not_awaited()
+
+    async def test_auto_refresh_ignores_missing_cookies(self):
+        with patch(
+            "g4f.Provider.needs_auth.Gemini.rotate_1psidts",
+            new_callable=AsyncMock,
+        ) as rotate:
+            await Gemini.start_auto_refresh(cookies=None)
+
+            rotate.assert_not_awaited()
+
+    async def test_auto_refresh_uses_cookie_snapshot(self):
+        source = {
+            "__Secure-1PSID": "session",
+            "__Secure-1PSIDTS": "old",
+        }
+        observed = {}
+
+        async def rotate(_url, cookies, _proxy):
+            observed["same_object"] = cookies is source
+            observed["sidts"] = cookies.get("__Secure-1PSIDTS")
+            raise asyncio.CancelledError()
+
+        previous_cookies = Gemini._cookies
+        Gemini._cookies = None
+        try:
+            with patch(
+                "g4f.Provider.needs_auth.Gemini.asyncio.sleep",
+                new_callable=AsyncMock,
+            ) as sleep:
+                with patch(
+                    "g4f.Provider.needs_auth.Gemini.rotate_1psidts",
+                    new_callable=AsyncMock,
+                    side_effect=rotate,
+                ) as rotate_mock:
+                    with self.assertRaises(asyncio.CancelledError):
+                        await Gemini.start_auto_refresh(cookies=source)
+
+            sleep.assert_awaited_once_with(Gemini.refresh_interval)
+            rotate_mock.assert_awaited_once()
+            self.assertFalse(observed["same_object"])
+            self.assertEqual(observed["sidts"], "old")
+            self.assertEqual(source["__Secure-1PSIDTS"], "old")
+        finally:
+            Gemini._cookies = previous_cookies
+
     async def test_stream_idle_timeout(self):
         class SlowContent:
             async def iter_any(self):

--- a/etc/unittest/test_gemini.py
+++ b/etc/unittest/test_gemini.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import importlib
 import json
 import unittest
 from unittest.mock import AsyncMock, patch
@@ -23,6 +24,8 @@ from g4f.Provider.needs_auth.Gemini import (
 )
 from g4f.errors import MissingAuthError, ResponseError, ResponseStatusError
 from g4f.models import ModelRegistry
+
+GEMINI_MODULE = importlib.import_module("g4f.Provider.needs_auth.Gemini")
 
 
 def build_account_response(status: int) -> tuple[str, dict[str, dict]]:
@@ -287,8 +290,9 @@ class GeminiStreamTest(unittest.IsolatedAsyncioTestCase):
                     'Response 400: [["er",null,{"reason":"xsrf"}]]'
                 )
 
-        with patch(
-            "g4f.Provider.needs_auth.Gemini.ClientSession",
+        with patch.object(
+            GEMINI_MODULE,
+            "ClientSession",
             return_value=session,
         ):
             with patch.object(
@@ -308,8 +312,9 @@ class GeminiStreamTest(unittest.IsolatedAsyncioTestCase):
                         new_callable=AsyncMock,
                         return_value=[],
                     ):
-                        with patch(
-                            "g4f.Provider.needs_auth.Gemini.raise_for_status",
+                        with patch.object(
+                            GEMINI_MODULE,
+                            "raise_for_status",
                             side_effect=check_status,
                         ):
                             generator = ProbeGemini.create_async_generator(
@@ -341,13 +346,15 @@ class GeminiStreamTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(request[0][0], "prompt-only request")
 
     async def test_auto_refresh_waits_before_rotating(self):
-        with patch(
-            "g4f.Provider.needs_auth.Gemini.asyncio.sleep",
+        with patch.object(
+            GEMINI_MODULE.asyncio,
+            "sleep",
             new_callable=AsyncMock,
             side_effect=asyncio.CancelledError(),
         ) as sleep:
-            with patch(
-                "g4f.Provider.needs_auth.Gemini.rotate_1psidts",
+            with patch.object(
+                GEMINI_MODULE,
+                "rotate_1psidts",
                 new_callable=AsyncMock,
             ) as rotate:
                 with self.assertRaises(asyncio.CancelledError):
@@ -359,8 +366,9 @@ class GeminiStreamTest(unittest.IsolatedAsyncioTestCase):
         rotate.assert_not_awaited()
 
     async def test_auto_refresh_ignores_missing_cookies(self):
-        with patch(
-            "g4f.Provider.needs_auth.Gemini.rotate_1psidts",
+        with patch.object(
+            GEMINI_MODULE,
+            "rotate_1psidts",
             new_callable=AsyncMock,
         ) as rotate:
             await Gemini.start_auto_refresh(cookies=None)
@@ -382,12 +390,14 @@ class GeminiStreamTest(unittest.IsolatedAsyncioTestCase):
         previous_cookies = Gemini._cookies
         Gemini._cookies = None
         try:
-            with patch(
-                "g4f.Provider.needs_auth.Gemini.asyncio.sleep",
+            with patch.object(
+                GEMINI_MODULE.asyncio,
+                "sleep",
                 new_callable=AsyncMock,
             ) as sleep:
-                with patch(
-                    "g4f.Provider.needs_auth.Gemini.rotate_1psidts",
+                with patch.object(
+                    GEMINI_MODULE,
+                    "rotate_1psidts",
                     new_callable=AsyncMock,
                     side_effect=rotate,
                 ) as rotate_mock:

--- a/g4f/Provider/needs_auth/Gemini.py
+++ b/g4f/Provider/needs_auth/Gemini.py
@@ -229,8 +229,37 @@ def _resolve_model(model: str, think_override: int = None) -> tuple[str, int]:
             raise ValueError("Thinking mode must be an integer between 0 and 4")
     model = MODEL_ALIASES.get(model, model)
     if model not in models:
-        raise ValueError(f"Unknown Gemini model: {model}")
+        raise ValueError(
+            f"Unknown Gemini model: {model}. "
+            f"Supported models: {', '.join(models)}"
+        )
     return model, models[model]["think"] if think_mode is None else think_mode
+
+
+def _normalize_messages(messages: Messages | None) -> Messages:
+    if messages is None:
+        return []
+    if not isinstance(messages, list):
+        raise TypeError("messages must be a list")
+    return messages
+
+
+def _resolve_gemini_prompt(
+    messages: Messages,
+    prompt: str | None,
+    conversation,
+) -> str:
+    if prompt is not None:
+        return prompt
+    if not messages:
+        return ""
+    if conversation is None:
+        return format_prompt(messages)
+    return get_last_user_message(messages)
+
+
+def _is_xsrf_error(error: Exception, status: int | None) -> bool:
+    return status == 400 and "xsrf" in str(error).lower()
 
 
 class Gemini(AsyncGeneratorProvider, ProviderModelMixin):
@@ -292,15 +321,30 @@ class Gemini(AsyncGeneratorProvider, ProviderModelMixin):
         return {"success": True, "message": "Login successful"}
 
     @classmethod
-    async def start_auto_refresh(cls, proxy: str = None) -> None:
+    async def start_auto_refresh(
+        cls,
+        proxy: str = None,
+        cookies: Cookies = None,
+    ) -> None:
         """
         Start the background task to automatically refresh cookies.
         """
+        refresh_cookies = dict(cookies or {})
+        secure_1psid = refresh_cookies.get(GOOGLE_SID_COOKIE)
+        if not secure_1psid:
+            return
 
         while True:
+            # Rotating immediately invalidates the XSRF token fetched for the
+            # request that started this task. Refresh only between intervals.
+            await asyncio.sleep(cls.refresh_interval)
             new_1psidts = None
             try:
-                new_1psidts = await rotate_1psidts(cls.url, cls._cookies, proxy)
+                new_1psidts = await rotate_1psidts(
+                    cls.url,
+                    refresh_cookies,
+                    proxy,
+                )
             except Exception as e:
                 debug.error(f"Failed to refresh cookies: {e}")
                 debug.error(
@@ -310,10 +354,15 @@ class Gemini(AsyncGeneratorProvider, ProviderModelMixin):
 
             debug.log("Gemini: Cookies refreshed successfully")
             if new_1psidts:
-                cls._cookies["__Secure-1PSIDTS"] = new_1psidts
-                cls._metadata_fetched_at = 0
-                cls._account_models_fetched_at = 0
-            await asyncio.sleep(cls.refresh_interval)
+                refresh_cookies[GOOGLE_SIDTS_COOKIE] = new_1psidts
+                current_cookies = cls._cookies
+                if (
+                    current_cookies
+                    and current_cookies.get(GOOGLE_SID_COOKIE) == secure_1psid
+                ):
+                    current_cookies.update(refresh_cookies)
+                    cls._metadata_fetched_at = 0
+                    cls._account_models_fetched_at = 0
 
     @classmethod
     async def fetch_account_models(
@@ -432,6 +481,7 @@ class Gemini(AsyncGeneratorProvider, ProviderModelMixin):
         think_override: int = None,
         **kwargs
     ) -> AsyncResult:
+        messages = _normalize_messages(messages)
         model = model or cls.default_model
         if cls.model_aliases and model in cls.model_aliases:
             model = cls.model_aliases[model]
@@ -459,9 +509,10 @@ class Gemini(AsyncGeneratorProvider, ProviderModelMixin):
             cls._cookies = cookies
         elif cls._cookies is None:
             cls._cookies = get_cookies(GOOGLE_COOKIE_DOMAIN, False, True)
+        request_cookies = dict(cls._cookies or {})
         if conversation is not None and getattr(conversation, "model", None) != model:
             conversation = None
-        prompt = format_prompt(messages) if conversation is None else get_last_user_message(messages)
+        prompt = _resolve_gemini_prompt(messages, prompt, conversation)
         if not isinstance(prompt, str) or not prompt.strip():
             raise ValueError("Prompt cannot be empty")
         if len(prompt) > MAX_PROMPT_CHARACTERS:
@@ -475,8 +526,8 @@ class Gemini(AsyncGeneratorProvider, ProviderModelMixin):
             connector=base_connector
         ) as session:
             cookie_key = (
-                (cls._cookies or {}).get(GOOGLE_SID_COOKIE),
-                (cls._cookies or {}).get(GOOGLE_SIDTS_COOKIE),
+                request_cookies.get(GOOGLE_SID_COOKIE),
+                request_cookies.get(GOOGLE_SIDTS_COOKIE),
             )
             if (
                 cookie_key != cls._metadata_cookie_key
@@ -495,7 +546,7 @@ class Gemini(AsyncGeneratorProvider, ProviderModelMixin):
             )
             if not cls._metadata_fetched_at or metadata_expired:
                 try:
-                    await cls.fetch_snlm0e(session, cls._cookies or {}, auth_user)
+                    await cls.fetch_snlm0e(session, request_cookies, auth_user)
                 except (ClientError, MissingAuthError, ResponseError) as error:
                     cls._metadata_fetched_at = time.time()
                     debug.log(f"Gemini metadata discovery failed: {error}")
@@ -505,7 +556,7 @@ class Gemini(AsyncGeneratorProvider, ProviderModelMixin):
             if not cls._account_models_fetched_at or models_expired:
                 try:
                     await cls.fetch_account_models(
-                        session, cls._cookies or {}, auth_user
+                        session, request_cookies, auth_user
                     )
                 except (ClientError, ResponseError, ValueError) as error:
                     cls._account_models_fetched_at = time.time()
@@ -514,14 +565,25 @@ class Gemini(AsyncGeneratorProvider, ProviderModelMixin):
                 model,
                 allow_model_fallback=bool(kwargs.get("allow_model_fallback", False)),
             )
-            if cls.auto_refresh and cls._cookies and GOOGLE_SID_COOKIE in cls._cookies:
-                task = cls.rotate_tasks.get(cls._cookies[GOOGLE_SID_COOKIE])
+            if (
+                cls.auto_refresh
+                and GOOGLE_SID_COOKIE in request_cookies
+            ):
+                secure_1psid = request_cookies[GOOGLE_SID_COOKIE]
+                task = cls.rotate_tasks.get(secure_1psid)
                 if task is None or task.done():
-                    cls.rotate_tasks[cls._cookies[GOOGLE_SID_COOKIE]] = asyncio.create_task(
-                        cls.start_auto_refresh(proxy)
+                    cls.rotate_tasks[secure_1psid] = asyncio.create_task(
+                        cls.start_auto_refresh(
+                            proxy=proxy,
+                            cookies=request_cookies,
+                        )
                     )
 
-            uploads = await cls.upload_images(session, merge_media(media, messages))
+            uploads = await cls.upload_images(
+                session,
+                merge_media(media, messages),
+                request_cookies,
+            )
             params = {
                 'bl': cls._bl,
                 'hl': language,
@@ -550,7 +612,7 @@ class Gemini(AsyncGeneratorProvider, ProviderModelMixin):
             request_headers["Referer"] = f"{cls.url}{prefix}/app"
             if prefix:
                 request_headers["X-Goog-AuthUser"] = str(auth_user)
-            authorization = _make_sapisid_hash(cls._cookies or {})
+            authorization = _make_sapisid_hash(request_cookies)
             if authorization:
                 request_headers["Authorization"] = authorization
             model_headers = cls.get_model_headers(model)
@@ -576,17 +638,42 @@ class Gemini(AsyncGeneratorProvider, ProviderModelMixin):
                         data=data,
                         params=params,
                         headers=request_headers or None,
-                        cookies=cls._cookies,
+                        cookies=request_cookies,
                     )
                     await raise_for_status(response)
                     break
                 except (ClientError, RateLimitError, ResponseStatusError) as error:
                     status = response.status if response is not None else None
-                    retryable = isinstance(error, ClientError) or status in RETRYABLE_STATUS_CODES
+                    xsrf_error = _is_xsrf_error(error, status)
+                    retryable = (
+                        isinstance(error, ClientError)
+                        or status in RETRYABLE_STATUS_CODES
+                        or xsrf_error
+                    )
                     if response is not None:
                         response.release()
                     if not retryable or attempt >= max_retries:
                         raise
+                    if xsrf_error:
+                        cls._snlm0e = None
+                        cls._sid = None
+                        cls._metadata_fetched_at = 0
+                        await cls.fetch_snlm0e(
+                            session,
+                            request_cookies,
+                            auth_user,
+                        )
+                        params["bl"] = cls._bl
+                        if cls._sid:
+                            params["f.sid"] = cls._sid
+                        else:
+                            params.pop("f.sid", None)
+                        if cls._snlm0e:
+                            data["at"] = cls._snlm0e
+                        else:
+                            data.pop("at", None)
+                        response = None
+                        continue
                     retry_after = None
                     if response is not None:
                         try:
@@ -725,7 +812,7 @@ class Gemini(AsyncGeneratorProvider, ProviderModelMixin):
                                     images.append(img_data + "=s2048")
                             if images:
                                 prompt = image_prompt.replace("a fake image", "") if image_prompt else "Generated Image"
-                                yield ImageResponse(images, prompt, {"cookies": cls._cookies})
+                                yield ImageResponse(images, prompt, {"cookies": request_cookies})
                                 image_prompt = None
                                 images_yielded = True
                         except (TypeError, IndexError, KeyError):
@@ -814,7 +901,13 @@ class Gemini(AsyncGeneratorProvider, ProviderModelMixin):
         return request
 
     @classmethod
-    async def upload_images(cls, session: ClientSession, media: MediaListType) -> list:
+    async def upload_images(
+        cls,
+        session: ClientSession,
+        media: MediaListType,
+        cookies: Cookies = None,
+    ) -> list:
+        request_cookies = cookies if cookies is not None else cls._cookies
         semaphore = asyncio.Semaphore(MAX_CONCURRENT_UPLOADS)
 
         async def upload_image(image: bytes, image_name: str = None):
@@ -829,7 +922,7 @@ class Gemini(AsyncGeneratorProvider, ProviderModelMixin):
                 async with session.options(
                     UPLOAD_IMAGE_URL,
                     headers=upload_headers,
-                    cookies=cls._cookies,
+                    cookies=request_cookies,
                 ) as response:
                     await raise_for_status(response)
 
@@ -843,7 +936,7 @@ class Gemini(AsyncGeneratorProvider, ProviderModelMixin):
                     UPLOAD_IMAGE_URL,
                     headers=headers,
                     data=data,
-                    cookies=cls._cookies,
+                    cookies=request_cookies,
                 ) as response:
                     await raise_for_status(response)
                     upload_url = response.headers.get("X-Goog-Upload-Url")
@@ -853,7 +946,7 @@ class Gemini(AsyncGeneratorProvider, ProviderModelMixin):
                 async with session.options(
                     upload_url,
                     headers=headers,
-                    cookies=cls._cookies,
+                    cookies=request_cookies,
                 ) as response:
                     await raise_for_status(response)
 
@@ -863,7 +956,7 @@ class Gemini(AsyncGeneratorProvider, ProviderModelMixin):
                     upload_url,
                     headers=headers,
                     data=image,
-                    cookies=cls._cookies,
+                    cookies=request_cookies,
                 ) as response:
                     await raise_for_status(response)
                     identifier = (await response.text()).strip()

--- a/g4f/Provider/needs_auth/Gemini.py
+++ b/g4f/Provider/needs_auth/Gemini.py
@@ -258,6 +258,27 @@ def _resolve_gemini_prompt(
     return get_last_user_message(messages)
 
 
+def _has_authenticated_session(cookies: Cookies) -> bool:
+    return bool(cookies.get(GOOGLE_SID_COOKIE))
+
+
+def _resolve_gemini_conversation(
+    conversation,
+    model: str,
+    cookies: Cookies,
+):
+    if conversation is None:
+        return None
+    if getattr(conversation, "model", None) != model:
+        return None
+    # Gemini currently returns conversation identifiers to anonymous sessions,
+    # but rejects those identifiers with BardErrorInfo 1096 when they are used
+    # on the next turn. Keep the full message history for anonymous requests.
+    if not _has_authenticated_session(cookies):
+        return None
+    return conversation
+
+
 def _is_xsrf_error(error: Exception, status: int | None) -> bool:
     return status == 400 and "xsrf" in str(error).lower()
 
@@ -510,8 +531,12 @@ class Gemini(AsyncGeneratorProvider, ProviderModelMixin):
         elif cls._cookies is None:
             cls._cookies = get_cookies(GOOGLE_COOKIE_DOMAIN, False, True)
         request_cookies = dict(cls._cookies or {})
-        if conversation is not None and getattr(conversation, "model", None) != model:
-            conversation = None
+        authenticated_session = _has_authenticated_session(request_cookies)
+        conversation = _resolve_gemini_conversation(
+            conversation,
+            model,
+            request_cookies,
+        )
         prompt = _resolve_gemini_prompt(messages, prompt, conversation)
         if not isinstance(prompt, str) or not prompt.strip():
             raise ValueError("Prompt cannot be empty")
@@ -719,7 +744,7 @@ class Gemini(AsyncGeneratorProvider, ProviderModelMixin):
                             yield TitleGeneration(response_part[2].get("11"))
                         if len(response_part) < 5:
                             continue
-                        if return_conversation:
+                        if return_conversation and authenticated_session:
                             try:
                                 yield Conversation(
                                     response_part[1][0],


### PR DESCRIPTION
Add robust cookie handling, XSRF retry logic and prompt normalization for the Gemini provider.

- Introduce _normalize_messages and _resolve_gemini_prompt to handle prompt-only and messages inputs.
- Improve unknown-model error to list supported models.
- Use a request-local cookie snapshot (request_cookies) so original cookie dict isn't mutated during requests.
- start_auto_refresh now accepts cookies, waits before rotating, and updates stored cookies only when appropriate.
- Detect XSRF errors (_is_xsrf_error) and retry by refetching snlm0e/sid and updating params/data.
- Propagate request_cookies through upload_images, image responses and Authorization generation.
- Add/adjust unit tests to cover prompt-only requests, XSRF retry flow, and auto-refresh behaviors.