### PR TITLE
Enhance DeepSeek streaming, uploads, and testing support

### DIFF
--- a/etc/testing/deepseek_chunk_log.py
+++ b/etc/testing/deepseek_chunk_log.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, TextIO
+
+from g4f.providers.response import JsonResponse, ProviderInfo, Reasoning
+
+
+def _json_default(value: Any) -> Any:
+    get_dict = getattr(value, "get_dict", None)
+    if callable(get_dict):
+        return get_dict()
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, (bytes, bytearray)):
+        return bytes(value).decode("utf-8", errors="replace")
+    attributes = getattr(value, "__dict__", None)
+    if isinstance(attributes, dict):
+        return {
+            key: item
+            for key, item in attributes.items()
+            if not key.startswith("__")
+        }
+    return str(value)
+
+
+class ChunkJsonlWriter:
+    """Append response metadata chunks to a durable, readable JSONL journal."""
+
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        run_id: str | None = None,
+    ) -> None:
+        self.path = Path(path)
+        self.run_id = run_id or str(uuid.uuid4())
+        self.count = 0
+        self._file: TextIO | None = None
+
+    def __enter__(self) -> ChunkJsonlWriter:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._file = self.path.open("a", encoding="utf-8", newline="\n")
+        return self
+
+    def __exit__(self, _exc_type, _exc, _traceback) -> None:
+        if self._file is not None:
+            self._file.close()
+            self._file = None
+
+    def write(self, chunk: Any) -> dict[str, Any]:
+        if self._file is None:
+            raise RuntimeError("ChunkJsonlWriter must be used as a context manager")
+
+        get_dict = getattr(chunk, "get_dict", None)
+        data = get_dict() if callable(get_dict) else vars(chunk)
+        self.count += 1
+        record = {
+            "run_id": self.run_id,
+            "sequence": self.count,
+            "recorded_at": datetime.now(timezone.utc)
+            .isoformat(timespec="milliseconds")
+            .replace("+00:00", "Z"),
+            "chunk_type": type(chunk).__name__,
+            "data": data,
+        }
+        self._file.write(
+            json.dumps(record, ensure_ascii=False, default=_json_default) + "\n"
+        )
+        self._file.flush()
+        return record
+
+
+def store_or_collect_chunk(
+    chunk: Any,
+    writer: ChunkJsonlWriter,
+    visible_chunks: list[str],
+) -> None:
+    if isinstance(chunk, Exception):
+        raise chunk
+    if isinstance(chunk, (ProviderInfo, JsonResponse, Reasoning)):
+        writer.write(chunk)
+        return
+    visible_chunks.append(str(chunk))
+
+
+def read_chunk_records(
+    path: str | Path,
+    *,
+    run_id: str | None = None,
+) -> list[dict[str, Any]]:
+    log_path = Path(path)
+    if not log_path.exists():
+        return []
+
+    records = []
+    with log_path.open("r", encoding="utf-8") as file:
+        for line_number, line in enumerate(file, start=1):
+            if not line.strip():
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError as error:
+                raise ValueError(
+                    f"Invalid JSONL record at {log_path}:{line_number}"
+                ) from error
+            if run_id is None or record.get("run_id") == run_id:
+                records.append(record)
+    return records

--- a/etc/unittest/__main__.py
+++ b/etc/unittest/__main__.py
@@ -19,5 +19,8 @@ from .mcp import *
 from .tool_support_provider import *
 from .config_provider import *
 from .test_gemini import *
+from .test_deepseek_chunk_log import *
+from .test_deepseek_stream import *
+from .test_deepseek_upload import *
 
 unittest.main()

--- a/etc/unittest/test_deepseek_chunk_log.py
+++ b/etc/unittest/test_deepseek_chunk_log.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from g4f.providers.response import JsonResponse, ProviderInfo, Reasoning
+from projects.test.deepseek_chunk_log import (
+    ChunkJsonlWriter,
+    read_chunk_records,
+    store_or_collect_chunk,
+)
+
+
+class DeepSeekChunkLogTest(unittest.TestCase):
+    def test_stores_metadata_chunks_and_collects_visible_text(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            log_path = Path(temporary_directory) / "chunks.jsonl"
+            visible_chunks = []
+
+            with ChunkJsonlWriter(log_path, run_id="run-1") as writer:
+                store_or_collect_chunk(
+                    ProviderInfo(name="DeepSeek"), writer, visible_chunks
+                )
+                store_or_collect_chunk(
+                    Reasoning(token="thinking"), writer, visible_chunks
+                )
+                store_or_collect_chunk(
+                    JsonResponse(result="metadata"), writer, visible_chunks
+                )
+                store_or_collect_chunk("visible answer", writer, visible_chunks)
+
+            self.assertEqual(visible_chunks, ["visible answer"])
+            self.assertEqual(
+                [record["chunk_type"] for record in read_chunk_records(log_path)],
+                ["ProviderInfo", "Reasoning", "JsonResponse"],
+            )
+
+    def test_chunk_exception_is_raised_instead_of_stored(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            log_path = Path(temporary_directory) / "chunks.jsonl"
+
+            with ChunkJsonlWriter(log_path, run_id="run-1") as writer:
+                with self.assertRaisesRegex(RuntimeError, "stream failed"):
+                    store_or_collect_chunk(
+                        RuntimeError("stream failed"), writer, []
+                    )
+
+            self.assertEqual(read_chunk_records(log_path), [])
+
+    def test_writes_each_supported_chunk_as_flushed_unicode_jsonl(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            log_path = Path(temporary_directory) / "nested" / "chunks.jsonl"
+
+            with ChunkJsonlWriter(log_path, run_id="run-1") as writer:
+                writer.write(ProviderInfo(name="DeepSeek", model="deepseek-v3"))
+                writer.write(Reasoning(token="تفكير"))
+                writer.write(JsonResponse(result={"answer": "إجابة"}))
+
+                records_before_close = read_chunk_records(log_path)
+
+            self.assertEqual(writer.count, 3)
+            self.assertEqual(
+                [record["chunk_type"] for record in records_before_close],
+                ["ProviderInfo", "Reasoning", "JsonResponse"],
+            )
+            self.assertEqual(
+                [record["sequence"] for record in records_before_close],
+                [1, 2, 3],
+            )
+            self.assertTrue(
+                all(record["run_id"] == "run-1" for record in records_before_close)
+            )
+            self.assertEqual(records_before_close[1]["data"], {"token": "تفكير"})
+            self.assertEqual(
+                records_before_close[2]["data"],
+                {"result": {"answer": "إجابة"}},
+            )
+            self.assertTrue(
+                all(record["recorded_at"].endswith("Z") for record in records_before_close)
+            )
+            self.assertIn("تفكير", log_path.read_text(encoding="utf-8"))
+
+    def test_appends_runs_and_can_read_one_run_later(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            log_path = Path(temporary_directory) / "chunks.jsonl"
+
+            with ChunkJsonlWriter(log_path, run_id="first-run") as writer:
+                writer.write(Reasoning(token="first"))
+            with ChunkJsonlWriter(log_path, run_id="second-run") as writer:
+                writer.write(Reasoning(token="second"))
+
+            self.assertEqual(len(read_chunk_records(log_path)), 2)
+            self.assertEqual(
+                read_chunk_records(log_path, run_id="second-run")[0]["data"],
+                {"token": "second"},
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/etc/unittest/test_deepseek_chunk_log.py
+++ b/etc/unittest/test_deepseek_chunk_log.py
@@ -5,7 +5,7 @@ import unittest
 from pathlib import Path
 
 from g4f.providers.response import JsonResponse, ProviderInfo, Reasoning
-from projects.test.deepseek_chunk_log import (
+from etc.testing.deepseek_chunk_log import (
     ChunkJsonlWriter,
     read_chunk_records,
     store_or_collect_chunk,

--- a/etc/unittest/test_deepseek_stream.py
+++ b/etc/unittest/test_deepseek_stream.py
@@ -8,13 +8,20 @@ from unittest.mock import AsyncMock, patch
 from g4f.Provider.needs_auth.DeepSeek import (
     CHAT_COMPLETION_ENDPOINT,
     CHAT_SESSION_CONTINUE_ENDPOINT,
+    CHAT_SESSION_DELETE_ENDPOINT,
     CHAT_SESSION_RESUME_STREAM_ENDPOINT,
     DeepSeek,
     _build_chat_headers,
     _extract_chat_session_id,
     iter_deepseek_sse,
 )
-from g4f.providers.response import FinishReason, JsonConversation, Reasoning
+from g4f.errors import MissingAuthError
+from g4f.providers.response import (
+    FinishReason,
+    JsonConversation,
+    JsonRequest,
+    Reasoning,
+)
 
 
 DEEPSEEK_MODULE = importlib.import_module("g4f.Provider.needs_auth.DeepSeek")
@@ -29,10 +36,17 @@ def sse_event(event: str, payload: dict) -> list[bytes]:
 
 
 class FakeStreamResponse:
-    def __init__(self, lines: list[bytes]):
+    def __init__(
+        self,
+        lines: list[bytes] | None = None,
+        *,
+        payload: dict | None = None,
+        content_type: str = "text/event-stream",
+    ):
         self.status = 200
-        self.headers = {"content-type": "text/event-stream"}
-        self.lines = lines
+        self.headers = {"content-type": content_type}
+        self.lines = lines or []
+        self.payload = payload
 
     async def __aenter__(self):
         return self
@@ -44,6 +58,9 @@ class FakeStreamResponse:
         for line in self.lines:
             yield line
 
+    async def json(self):
+        return self.payload
+
 
 class FakeStreamSession:
     def __init__(self, responses: list[FakeStreamResponse]):
@@ -54,8 +71,209 @@ class FakeStreamSession:
         self.post_calls.append((url, kwargs))
         return next(self.responses)
 
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, _exc_type, _exc, _traceback):
+        return False
+
 
 class DeepSeekSSETest(unittest.IsolatedAsyncioTestCase):
+    async def test_explicit_authorization_survives_cookie_lookup(self):
+        with (
+            patch.object(DEEPSEEK_MODULE, "get_cookies", return_value={}),
+            patch.object(DEEPSEEK_MODULE, "get_headers", return_value={}),
+        ):
+            generator = DeepSeek.create_async_generator(
+                "deepseek-v3",
+                [{"role": "user", "content": "hello"}],
+                cookies=None,
+                headers={"Authorization": "Bearer supplied"},
+            )
+            request = await generator.__anext__()
+            await generator.aclose()
+
+        self.assertIsInstance(request, JsonRequest)
+
+    async def test_reasoning_effort_none_disables_r1_thinking(self):
+        generator = DeepSeek.create_async_generator(
+            "deepseek-r1",
+            [{"role": "user", "content": "hello"}],
+            cookies={},
+            headers={"Authorization": "Bearer supplied"},
+            reasoning_effort="none",
+        )
+        request = await generator.__anext__()
+        await generator.aclose()
+
+        self.assertFalse(request.get_dict()["thinking_enabled"])
+
+    async def test_get_quota_reports_missing_auth_when_headers_are_unavailable(self):
+        with (
+            patch.object(DEEPSEEK_MODULE, "get_cookies", return_value={"sid": "x"}),
+            patch.object(DEEPSEEK_MODULE, "get_headers", return_value=None),
+        ):
+            with self.assertRaises(MissingAuthError):
+                await DeepSeek.get_quota()
+
+    async def test_non_sse_resume_code_22_emits_full_message(self):
+        response = FakeStreamResponse(
+            payload={
+                "data": {
+                    "biz_code": 22,
+                    "biz_msg": "resume returned full message",
+                    "biz_data": {
+                        "response": {
+                            "message_id": 7,
+                            "status": "FINISHED",
+                            "fragments": [
+                                {"type": "THINK", "content": "thought"},
+                                {"type": "RESPONSE", "content": "answer"},
+                            ],
+                        }
+                    },
+                }
+            },
+            content_type="application/json",
+        )
+        session = FakeStreamSession([response])
+        conversation = JsonConversation(parent_message_id=None)
+
+        with patch.object(DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock):
+            chunks = [
+                chunk
+                async for chunk in DeepSeek.iter_chat_stream(
+                    session,
+                    conversation,
+                    {"chat_session_id": "session-1", "prompt": "prompt"},
+                )
+            ]
+
+        self.assertEqual(
+            "".join(str(chunk) for chunk in chunks if isinstance(chunk, Reasoning)),
+            "thought",
+        )
+        self.assertEqual(
+            "".join(chunk for chunk in chunks if isinstance(chunk, str)),
+            "answer",
+        )
+        self.assertEqual(
+            [chunk.reason for chunk in chunks if isinstance(chunk, FinishReason)],
+            ["stop"],
+        )
+        self.assertEqual(conversation.parent_message_id, 7)
+
+    async def test_non_sse_business_error_exposes_biz_message(self):
+        response = FakeStreamResponse(
+            payload={
+                "data": {
+                    "biz_code": 40101,
+                    "biz_msg": "authorization expired",
+                    "biz_data": None,
+                }
+            },
+            content_type="application/json",
+        )
+        session = FakeStreamSession([response])
+
+        with patch.object(DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock):
+            with self.assertRaisesRegex(RuntimeError, "authorization expired"):
+                _ = [
+                    chunk
+                    async for chunk in DeepSeek.iter_chat_stream(
+                        session,
+                        JsonConversation(parent_message_id=None),
+                        {"chat_session_id": "session-1", "prompt": "prompt"},
+                    )
+                ]
+
+    async def test_session_creation_exposes_biz_message(self):
+        session = FakeStreamSession(
+            [
+                FakeStreamResponse(
+                    payload={
+                        "data": {
+                            "biz_code": 50301,
+                            "biz_msg": "session unavailable",
+                            "biz_data": None,
+                        }
+                    },
+                    content_type="application/json",
+                )
+            ]
+        )
+        generator = DeepSeek.create_async_generator(
+            "deepseek-v3",
+            [{"role": "user", "content": "hello"}],
+            cookies={},
+            headers={"Authorization": "Bearer supplied"},
+        )
+
+        await generator.__anext__()
+        with (
+            patch.object(DEEPSEEK_MODULE, "StreamSession", return_value=session),
+            patch.object(DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "session unavailable"):
+                await generator.__anext__()
+
+    async def test_delete_session_uses_one_observed_request(self):
+        session = FakeStreamSession(
+            [
+                FakeStreamResponse(
+                    payload={"data": {"biz_code": 0, "biz_data": {}}},
+                    content_type="application/json",
+                )
+            ]
+        )
+
+        with patch.object(DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock):
+            deleted = await DeepSeek.delete_chat_session(
+                session,
+                "session-1",
+                {"authorization": "Bearer redacted"},
+            )
+
+        self.assertTrue(deleted)
+        self.assertEqual(
+            session.post_calls,
+            [
+                (
+                    CHAT_SESSION_DELETE_ENDPOINT,
+                    {
+                        "headers": {"authorization": "Bearer redacted"},
+                        "json": {"chat_session_id": "session-1"},
+                    },
+                )
+            ],
+        )
+
+    async def test_delete_session_business_error_returns_false_without_retry(self):
+        session = FakeStreamSession(
+            [
+                FakeStreamResponse(
+                    payload={
+                        "data": {
+                            "biz_code": 50001,
+                            "biz_msg": "delete unavailable",
+                            "biz_data": None,
+                        }
+                    },
+                    content_type="application/json",
+                )
+            ]
+        )
+
+        with patch.object(DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock):
+            deleted = await DeepSeek.delete_chat_session(
+                session,
+                "session-1",
+                {"authorization": "Bearer redacted"},
+            )
+
+        self.assertIs(deleted, False)
+        self.assertEqual(len(session.post_calls), 1)
+
     def test_extracts_current_and_legacy_chat_session_ids(self):
         self.assertEqual(
             _extract_chat_session_id(
@@ -645,6 +863,7 @@ class DeepSeekSSETest(unittest.IsolatedAsyncioTestCase):
             {
                 "Authorization": "Bearer redacted",
                 "X-Hif-Leim": "hif-redacted",
+                "X-Hif-Dliq": "dliq-redacted",
                 "X-Client-Version": "2.4.0",
                 "X-Ds-Pow-Response": "stale-pow",
             },
@@ -652,8 +871,52 @@ class DeepSeekSSETest(unittest.IsolatedAsyncioTestCase):
         )
 
         self.assertEqual(headers["x-hif-leim"], "hif-redacted")
+        self.assertEqual(headers["x-hif-dliq"], "dliq-redacted")
         self.assertEqual(headers["x-client-version"], "2.4.0")
+        self.assertEqual(headers["referer"], "https://chat.deepseek.com/a/chat/")
+        self.assertNotIn("x-app-version", headers)
         self.assertNotIn("x-ds-pow-response", headers)
+
+    def test_completion_payload_matches_current_web_contract(self):
+        conversation = JsonConversation(parent_message_id=None)
+        conversation.chat_session_id = "session-1"
+
+        payload = DEEPSEEK_MODULE._build_completion_payload(
+            conversation,
+            prompt="hello",
+            model_type="default",
+            ref_file_ids=["file-1"],
+            thinking_enabled=True,
+            search_enabled=False,
+        )
+
+        self.assertEqual(
+            payload,
+            {
+                "action": None,
+                "chat_session_id": "session-1",
+                "parent_message_id": None,
+                "model_type": "default",
+                "prompt": "hello",
+                "ref_file_ids": ["file-1"],
+                "thinking_enabled": True,
+                "search_enabled": False,
+                "preempt": False,
+            },
+        )
+
+        conversation.parent_message_id = 9
+        self.assertEqual(
+            DEEPSEEK_MODULE._build_completion_payload(
+                conversation,
+                prompt="follow up",
+                model_type="default",
+                ref_file_ids=[],
+                thinking_enabled=False,
+                search_enabled=True,
+            )["parent_message_id"],
+            9,
+        )
 
 
 if __name__ == "__main__":

--- a/etc/unittest/test_deepseek_stream.py
+++ b/etc/unittest/test_deepseek_stream.py
@@ -80,9 +80,10 @@ class FakeStreamSession:
 
 class DeepSeekSSETest(unittest.IsolatedAsyncioTestCase):
     async def test_explicit_authorization_survives_cookie_lookup(self):
-        with (
-            patch.object(DEEPSEEK_MODULE, "get_cookies", return_value={}),
-            patch.object(DEEPSEEK_MODULE, "get_headers", return_value={}),
+        with patch.object(
+            DEEPSEEK_MODULE, "get_cookies", return_value={}
+        ), patch.object(
+            DEEPSEEK_MODULE, "get_headers", return_value={}
         ):
             generator = DeepSeek.create_async_generator(
                 "deepseek-v3",
@@ -109,9 +110,10 @@ class DeepSeekSSETest(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(request.get_dict()["thinking_enabled"])
 
     async def test_get_quota_reports_missing_auth_when_headers_are_unavailable(self):
-        with (
-            patch.object(DEEPSEEK_MODULE, "get_cookies", return_value={"sid": "x"}),
-            patch.object(DEEPSEEK_MODULE, "get_headers", return_value=None),
+        with patch.object(
+            DEEPSEEK_MODULE, "get_cookies", return_value={"sid": "x"}
+        ), patch.object(
+            DEEPSEEK_MODULE, "get_headers", return_value=None
         ):
             with self.assertRaises(MissingAuthError):
                 await DeepSeek.get_quota()
@@ -278,12 +280,11 @@ class DeepSeekSSETest(unittest.IsolatedAsyncioTestCase):
         conversation = JsonConversation(parent_message_id=None)
         chunks = []
 
-        with (
-            patch.object(DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock),
-            self.assertRaisesRegex(
-                ResponseError,
-                "DeepSeek finished without a response",
-            ),
+        with patch.object(
+            DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock
+        ), self.assertRaisesRegex(
+            ResponseError,
+            "DeepSeek finished without a response",
         ):
             async for chunk in DeepSeek.iter_chat_stream(
                     session,
@@ -317,12 +318,11 @@ class DeepSeekSSETest(unittest.IsolatedAsyncioTestCase):
         session = FakeStreamSession([response])
         conversation = JsonConversation(parent_message_id=None)
 
-        with (
-            patch.object(DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock),
-            self.assertRaisesRegex(
-                ResponseError,
-                "DeepSeek finished without a response",
-            ),
+        with patch.object(
+            DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock
+        ), self.assertRaisesRegex(
+            ResponseError,
+            "DeepSeek finished without a response",
         ):
             async for _chunk in DeepSeek.iter_chat_stream(
                     session,
@@ -354,12 +354,11 @@ class DeepSeekSSETest(unittest.IsolatedAsyncioTestCase):
         )
         conversation = JsonConversation(parent_message_id=None)
 
-        with (
-            patch.object(DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock),
-            self.assertRaisesRegex(
-                RuntimeError,
-                "did not close normally after 1 resume attempt",
-            ),
+        with patch.object(
+            DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock
+        ), self.assertRaisesRegex(
+            RuntimeError,
+            "did not close normally after 1 resume attempt",
         ):
             async for _chunk in DeepSeek.iter_chat_stream(
                     session,
@@ -396,12 +395,11 @@ class DeepSeekSSETest(unittest.IsolatedAsyncioTestCase):
         session = FakeStreamSession([response])
         conversation = JsonConversation(parent_message_id=None)
 
-        with (
-            patch.object(DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock),
-            self.assertRaisesRegex(
-                ResponseError,
-                "DeepSeek finished without a response",
-            ),
+        with patch.object(
+            DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock
+        ), self.assertRaisesRegex(
+            ResponseError,
+            "DeepSeek finished without a response",
         ):
             async for _chunk in DeepSeek.iter_chat_stream(
                     session,
@@ -587,9 +585,10 @@ class DeepSeekSSETest(unittest.IsolatedAsyncioTestCase):
         )
 
         await generator.__anext__()
-        with (
-            patch.object(DEEPSEEK_MODULE, "StreamSession", return_value=session),
-            patch.object(DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock),
+        with patch.object(
+            DEEPSEEK_MODULE, "StreamSession", return_value=session
+        ), patch.object(
+            DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock
         ):
             with self.assertRaisesRegex(RuntimeError, "session unavailable"):
                 await generator.__anext__()
@@ -712,10 +711,11 @@ class DeepSeekSSETest(unittest.IsolatedAsyncioTestCase):
         session = FakeStreamSession([first_response, continued_response])
         conversation = JsonConversation(parent_message_id=None)
 
-        with (
-            patch.object(DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock),
-            patch.object(DEEPSEEK_MODULE.debug, "log") as log,
-        ):
+        with patch.object(
+            DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock
+        ), patch.object(
+            DEEPSEEK_MODULE.debug, "log"
+        ) as log:
             chunks = [
                 chunk
                 async for chunk in DeepSeek.iter_chat_stream(
@@ -787,10 +787,11 @@ class DeepSeekSSETest(unittest.IsolatedAsyncioTestCase):
         session = FakeStreamSession([incomplete_response, continued_response])
         conversation = JsonConversation(parent_message_id=None)
 
-        with (
-            patch.object(DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock),
-            patch.object(DEEPSEEK_MODULE.debug, "log") as log,
-        ):
+        with patch.object(
+            DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock
+        ), patch.object(
+            DEEPSEEK_MODULE.debug, "log"
+        ) as log:
             chunks = [
                 chunk
                 async for chunk in DeepSeek.iter_chat_stream(
@@ -863,10 +864,11 @@ class DeepSeekSSETest(unittest.IsolatedAsyncioTestCase):
         session = FakeStreamSession([incomplete_response, continued_response])
         conversation = JsonConversation(parent_message_id=None)
 
-        with (
-            patch.object(DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock),
-            patch.object(DEEPSEEK_MODULE.debug, "log") as log,
-        ):
+        with patch.object(
+            DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock
+        ), patch.object(
+            DEEPSEEK_MODULE.debug, "log"
+        ) as log:
             chunks = [
                 chunk
                 async for chunk in DeepSeek.iter_chat_stream(
@@ -930,10 +932,11 @@ class DeepSeekSSETest(unittest.IsolatedAsyncioTestCase):
         )
         conversation = JsonConversation(parent_message_id=None)
 
-        with (
-            patch.object(DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock),
-            patch.object(DEEPSEEK_MODULE.debug, "log") as log,
-        ):
+        with patch.object(
+            DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock
+        ), patch.object(
+            DEEPSEEK_MODULE.debug, "log"
+        ) as log:
             chunks = [
                 chunk
                 async for chunk in DeepSeek.iter_chat_stream(

--- a/etc/unittest/test_deepseek_stream.py
+++ b/etc/unittest/test_deepseek_stream.py
@@ -15,7 +15,7 @@ from g4f.Provider.needs_auth.DeepSeek import (
     _extract_chat_session_id,
     iter_deepseek_sse,
 )
-from g4f.errors import MissingAuthError
+from g4f.errors import MissingAuthError, ResponseError
 from g4f.providers.response import (
     FinishReason,
     JsonConversation,
@@ -162,6 +162,383 @@ class DeepSeekSSETest(unittest.IsolatedAsyncioTestCase):
             ["stop"],
         )
         self.assertEqual(conversation.parent_message_id, 7)
+
+    async def test_finished_reasoning_only_stream_resumes_full_message_once(self):
+        reasoning_only_response = FakeStreamResponse(
+            sse_event("ready", {"response_message_id": 4})
+            + sse_event(
+                "message",
+                {
+                    "p": "response/fragments",
+                    "o": "APPEND",
+                    "v": [{"type": "THINK", "content": "thought"}],
+                },
+            )
+            + sse_event(
+                "message",
+                {"p": "response/status", "o": "SET", "v": "FINISHED"},
+            )
+            + sse_event("close", {"auto_resume": False})
+        )
+        full_message_response = FakeStreamResponse(
+            payload={
+                "data": {
+                    "biz_code": 22,
+                    "biz_msg": "resume returned full message",
+                    "biz_data": {
+                        "response": {
+                            "message_id": 4,
+                            "status": "FINISHED",
+                            "fragments": [
+                                {"type": "THINK", "content": "thought"},
+                                {"type": "RESPONSE", "content": "answer"},
+                            ],
+                        }
+                    },
+                }
+            },
+            content_type="application/json",
+        )
+        session = FakeStreamSession(
+            [reasoning_only_response, full_message_response]
+        )
+        conversation = JsonConversation(parent_message_id=None)
+
+        with patch.object(DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock):
+            chunks = [
+                chunk
+                async for chunk in DeepSeek.iter_chat_stream(
+                    session,
+                    conversation,
+                    {"chat_session_id": "session-1", "prompt": "prompt"},
+                    max_resume_attempts=3,
+                )
+            ]
+
+        self.assertEqual(
+            [url for url, _kwargs in session.post_calls],
+            [CHAT_COMPLETION_ENDPOINT, CHAT_SESSION_RESUME_STREAM_ENDPOINT],
+        )
+        self.assertEqual(
+            session.post_calls[1][1]["json"],
+            {"chat_session_id": "session-1", "message_id": 4},
+        )
+        self.assertEqual(
+            "".join(str(chunk) for chunk in chunks if isinstance(chunk, Reasoning)),
+            "thought",
+        )
+        self.assertEqual(
+            "".join(chunk for chunk in chunks if isinstance(chunk, str)),
+            "answer",
+        )
+        self.assertEqual(
+            [chunk.reason for chunk in chunks if isinstance(chunk, FinishReason)],
+            ["stop"],
+        )
+        self.assertEqual(conversation.parent_message_id, 4)
+
+    async def test_finished_stream_raises_when_resumed_message_has_no_response(self):
+        reasoning_only_response = FakeStreamResponse(
+            sse_event("ready", {"response_message_id": 4})
+            + sse_event(
+                "message",
+                {
+                    "p": "response/fragments",
+                    "o": "APPEND",
+                    "v": [{"type": "THINK", "content": "thought"}],
+                },
+            )
+            + sse_event(
+                "message",
+                {"p": "response/status", "o": "SET", "v": "FINISHED"},
+            )
+            + sse_event("close", {"auto_resume": False})
+        )
+        full_message_response = FakeStreamResponse(
+            payload={
+                "data": {
+                    "biz_code": 22,
+                    "biz_msg": "resume returned full message",
+                    "biz_data": {
+                        "response": {
+                            "message_id": 4,
+                            "status": "FINISHED",
+                            "fragments": [
+                                {"type": "THINK", "content": "thought"},
+                            ],
+                        }
+                    },
+                }
+            },
+            content_type="application/json",
+        )
+        session = FakeStreamSession(
+            [reasoning_only_response, full_message_response]
+        )
+        conversation = JsonConversation(parent_message_id=None)
+        chunks = []
+
+        with (
+            patch.object(DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock),
+            self.assertRaisesRegex(
+                ResponseError,
+                "DeepSeek finished without a response",
+            ),
+        ):
+            async for chunk in DeepSeek.iter_chat_stream(
+                    session,
+                    conversation,
+                    {"chat_session_id": "session-1", "prompt": "prompt"},
+            ):
+                chunks.append(chunk)
+
+        self.assertEqual(
+            [url for url, _kwargs in session.post_calls],
+            [CHAT_COMPLETION_ENDPOINT, CHAT_SESSION_RESUME_STREAM_ENDPOINT],
+        )
+        self.assertEqual(
+            "".join(str(chunk) for chunk in chunks if isinstance(chunk, Reasoning)),
+            "thought",
+        )
+        self.assertEqual(
+            "".join(chunk for chunk in chunks if isinstance(chunk, str)),
+            "",
+        )
+
+    async def test_finished_empty_stream_does_not_resume_when_disabled(self):
+        response = FakeStreamResponse(
+            sse_event("ready", {"response_message_id": 4})
+            + sse_event(
+                "message",
+                {"p": "response/status", "o": "SET", "v": "FINISHED"},
+            )
+            + sse_event("close", {"auto_resume": False})
+        )
+        session = FakeStreamSession([response])
+        conversation = JsonConversation(parent_message_id=None)
+
+        with (
+            patch.object(DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock),
+            self.assertRaisesRegex(
+                ResponseError,
+                "DeepSeek finished without a response",
+            ),
+        ):
+            async for _chunk in DeepSeek.iter_chat_stream(
+                    session,
+                    conversation,
+                    {"chat_session_id": "session-1", "prompt": "prompt"},
+                    max_resume_attempts=0,
+            ):
+                pass
+
+        self.assertEqual(
+            [url for url, _kwargs in session.post_calls],
+            [CHAT_COMPLETION_ENDPOINT],
+        )
+
+    async def test_empty_response_resume_counts_toward_resume_limit(self):
+        reasoning_only_response = FakeStreamResponse(
+            sse_event("ready", {"response_message_id": 4})
+            + sse_event(
+                "message",
+                {"p": "response/status", "o": "SET", "v": "FINISHED"},
+            )
+            + sse_event("close", {"auto_resume": False})
+        )
+        interrupted_resume = FakeStreamResponse(
+            sse_event("ready", {"response_message_id": 4})
+        )
+        session = FakeStreamSession(
+            [reasoning_only_response, interrupted_resume]
+        )
+        conversation = JsonConversation(parent_message_id=None)
+
+        with (
+            patch.object(DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock),
+            self.assertRaisesRegex(
+                RuntimeError,
+                "did not close normally after 1 resume attempt",
+            ),
+        ):
+            async for _chunk in DeepSeek.iter_chat_stream(
+                    session,
+                    conversation,
+                    {"chat_session_id": "session-1", "prompt": "prompt"},
+                    max_resume_attempts=1,
+            ):
+                pass
+
+        self.assertEqual(
+            [url for url, _kwargs in session.post_calls],
+            [CHAT_COMPLETION_ENDPOINT, CHAT_SESSION_RESUME_STREAM_ENDPOINT],
+        )
+
+    async def test_full_message_without_response_always_raises(self):
+        response = FakeStreamResponse(
+            payload={
+                "data": {
+                    "biz_code": 22,
+                    "biz_msg": "resume returned full message",
+                    "biz_data": {
+                        "response": {
+                            "message_id": 4,
+                            "status": "WIP",
+                            "fragments": [
+                                {"type": "THINK", "content": "thought"},
+                            ],
+                        }
+                    },
+                }
+            },
+            content_type="application/json",
+        )
+        session = FakeStreamSession([response])
+        conversation = JsonConversation(parent_message_id=None)
+
+        with (
+            patch.object(DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock),
+            self.assertRaisesRegex(
+                ResponseError,
+                "DeepSeek finished without a response",
+            ),
+        ):
+            async for _chunk in DeepSeek.iter_chat_stream(
+                    session,
+                    conversation,
+                    {"chat_session_id": "session-1", "prompt": "prompt"},
+            ):
+                pass
+
+    async def test_indexed_response_fragment_switches_from_reasoning(self):
+        response = FakeStreamResponse(
+            sse_event("ready", {"response_message_id": 4})
+            + sse_event(
+                "message",
+                {
+                    "v": {
+                        "response": {
+                            "message_id": 4,
+                            "fragments": [
+                                {"type": "THINK", "content": "thought"},
+                            ],
+                        }
+                    }
+                },
+            )
+            + sse_event(
+                "message",
+                {
+                    "p": "response/fragments/-1",
+                    "o": "APPEND",
+                    "v": {"type": "RESPONSE", "content": ""},
+                },
+            )
+            + sse_event(
+                "message",
+                {
+                    "p": "response/fragments/-1",
+                    "o": "SET",
+                    "v": {"type": "RESPONSE", "content": "answer"},
+                },
+            )
+            + sse_event(
+                "message",
+                {"p": "response/status", "o": "SET", "v": "FINISHED"},
+            )
+            + sse_event("close", {"auto_resume": False})
+        )
+        session = FakeStreamSession([response])
+        conversation = JsonConversation(parent_message_id=None)
+
+        with patch.object(DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock):
+            chunks = [
+                chunk
+                async for chunk in DeepSeek.iter_chat_stream(
+                    session,
+                    conversation,
+                    {"chat_session_id": "session-1", "prompt": "prompt"},
+                )
+            ]
+
+        self.assertEqual(len(session.post_calls), 1)
+        self.assertEqual(
+            "".join(str(chunk) for chunk in chunks if isinstance(chunk, Reasoning)),
+            "thought",
+        )
+        self.assertEqual(
+            "".join(chunk for chunk in chunks if isinstance(chunk, str)),
+            "answer",
+        )
+
+    async def test_indexed_content_uses_its_fragment_type(self):
+        response = FakeStreamResponse(
+            sse_event("ready", {"response_message_id": 4})
+            + sse_event(
+                "message",
+                {
+                    "v": {
+                        "response": {
+                            "message_id": 4,
+                            "fragments": [
+                                {"type": "THINK", "content": ""},
+                                {"type": "RESPONSE", "content": ""},
+                            ],
+                        }
+                    }
+                },
+            )
+            + sse_event(
+                "message",
+                {
+                    "p": "response/fragments/-1/type",
+                    "o": "SET",
+                    "v": "TEMPLATE_RESPONSE",
+                },
+            )
+            + sse_event(
+                "message",
+                {
+                    "p": "response/fragments/0/content",
+                    "o": "APPEND",
+                    "v": "thought",
+                },
+            )
+            + sse_event(
+                "message",
+                {
+                    "p": "response/fragments/1/content",
+                    "o": "APPEND",
+                    "v": "answer",
+                },
+            )
+            + sse_event(
+                "message",
+                {"p": "response/status", "o": "SET", "v": "FINISHED"},
+            )
+            + sse_event("close", {"auto_resume": False})
+        )
+        session = FakeStreamSession([response])
+        conversation = JsonConversation(parent_message_id=None)
+
+        with patch.object(DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock):
+            chunks = [
+                chunk
+                async for chunk in DeepSeek.iter_chat_stream(
+                    session,
+                    conversation,
+                    {"chat_session_id": "session-1", "prompt": "prompt"},
+                )
+            ]
+
+        self.assertEqual(
+            "".join(str(chunk) for chunk in chunks if isinstance(chunk, Reasoning)),
+            "thought",
+        )
+        self.assertEqual(
+            "".join(chunk for chunk in chunks if isinstance(chunk, str)),
+            "answer",
+        )
 
     async def test_non_sse_business_error_exposes_biz_message(self):
         response = FakeStreamResponse(
@@ -681,6 +1058,14 @@ class DeepSeekSSETest(unittest.IsolatedAsyncioTestCase):
             with self.subTest(status=status):
                 response = FakeStreamResponse(
                     sse_event("ready", {"response_message_id": 4})
+                    + sse_event(
+                        "message",
+                        {
+                            "p": "response/fragments",
+                            "o": "APPEND",
+                            "v": [{"type": "RESPONSE", "content": "answer"}],
+                        },
+                    )
                     + sse_event(
                         "message",
                         {"p": "response/status", "o": "SET", "v": status},

--- a/etc/unittest/test_deepseek_stream.py
+++ b/etc/unittest/test_deepseek_stream.py
@@ -1,0 +1,660 @@
+from __future__ import annotations
+
+import importlib
+import json
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from g4f.Provider.needs_auth.DeepSeek import (
+    CHAT_COMPLETION_ENDPOINT,
+    CHAT_SESSION_CONTINUE_ENDPOINT,
+    CHAT_SESSION_RESUME_STREAM_ENDPOINT,
+    DeepSeek,
+    _build_chat_headers,
+    _extract_chat_session_id,
+    iter_deepseek_sse,
+)
+from g4f.providers.response import FinishReason, JsonConversation, Reasoning
+
+
+DEEPSEEK_MODULE = importlib.import_module("g4f.Provider.needs_auth.DeepSeek")
+
+
+def sse_event(event: str, payload: dict) -> list[bytes]:
+    return [
+        f"event: {event}".encode(),
+        f"data: {json.dumps(payload)}".encode(),
+        b"",
+    ]
+
+
+class FakeStreamResponse:
+    def __init__(self, lines: list[bytes]):
+        self.status = 200
+        self.headers = {"content-type": "text/event-stream"}
+        self.lines = lines
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, _exc_type, _exc, _traceback):
+        return False
+
+    async def iter_lines(self):
+        for line in self.lines:
+            yield line
+
+
+class FakeStreamSession:
+    def __init__(self, responses: list[FakeStreamResponse]):
+        self.responses = iter(responses)
+        self.post_calls = []
+
+    def post(self, url, **kwargs):
+        self.post_calls.append((url, kwargs))
+        return next(self.responses)
+
+
+class DeepSeekSSETest(unittest.IsolatedAsyncioTestCase):
+    def test_extracts_current_and_legacy_chat_session_ids(self):
+        self.assertEqual(
+            _extract_chat_session_id(
+                {
+                    "data": {
+                        "biz_data": {
+                            "chat_session": {"id": "current-session-id"}
+                        }
+                    }
+                }
+            ),
+            "current-session-id",
+        )
+        self.assertEqual(
+            _extract_chat_session_id(
+                {"data": {"biz_data": {"id": "legacy-session-id"}}}
+            ),
+            "legacy-session-id",
+        )
+
+    async def test_parser_preserves_close_event(self):
+        response = FakeStreamResponse(
+            sse_event("message", {"v": "chunk"})
+            + sse_event("update_session", {"updated_at": 1})
+            + sse_event("close", {"auto_resume": False})
+        )
+
+        events = [event async for event in iter_deepseek_sse(response)]
+
+        self.assertEqual(
+            [event_type for event_type, _payload in events],
+            ["message", "update_session", "close"],
+        )
+
+    async def test_incomplete_closed_stream_continues_same_message(self):
+        first_response = FakeStreamResponse(
+            sse_event("ready", {"response_message_id": 4})
+            + sse_event(
+                "message",
+                {"p": "response/fragments/-1/content", "o": "APPEND", "v": "A"},
+            )
+            + sse_event(
+                "message",
+                {"p": "response/status", "o": "SET", "v": "INCOMPLETE"},
+            )
+            + sse_event("close", {"auto_resume": False})
+        )
+        continued_response = FakeStreamResponse(
+            sse_event(
+                "message",
+                {"p": "response/fragments/-1/content", "o": "APPEND", "v": "B"},
+            )
+            + sse_event(
+                "message",
+                {"p": "response/status", "o": "SET", "v": "FINISHED"},
+            )
+            + sse_event("close", {"auto_resume": False})
+        )
+        session = FakeStreamSession([first_response, continued_response])
+        conversation = JsonConversation(parent_message_id=None)
+
+        with (
+            patch.object(DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock),
+            patch.object(DEEPSEEK_MODULE.debug, "log") as log,
+        ):
+            chunks = [
+                chunk
+                async for chunk in DeepSeek.iter_chat_stream(
+                    session,
+                    conversation,
+                    {"chat_session_id": "session-1", "prompt": "prompt"},
+                    {"x-ds-pow-response": "completion-pow"},
+                    auto_continue=True,
+                    max_continue_attempts=3,
+                    max_resume_attempts=3,
+                )
+            ]
+
+        log_output = "\n".join(
+            str(call.args[0]) for call in log.call_args_list if call.args
+        )
+
+        self.assertEqual("".join(map(str, chunks)), "AB")
+        self.assertEqual(conversation.parent_message_id, 4)
+        self.assertEqual(
+            [url for url, _kwargs in session.post_calls],
+            [CHAT_COMPLETION_ENDPOINT, CHAT_SESSION_CONTINUE_ENDPOINT],
+        )
+        self.assertEqual(
+            session.post_calls[1][1]["json"],
+            {
+                "chat_session_id": "session-1",
+                "message_id": 4,
+                "fallback_to_resume": True,
+            },
+        )
+        self.assertIn(
+            "DeepSeekAuth: Stream status: status=INCOMPLETE source=patch "
+            "operation=SET interpretation=requires_continue",
+            log_output,
+        )
+        self.assertIn(
+            "DeepSeekAuth: Stream closed: status=INCOMPLETE action=continue "
+            "reason=incomplete_status finish_reason=none auto_resume=false "
+            "click_behavior=none response_chars=1 reasoning_chars=0 "
+            "message_id_present=true",
+            log_output,
+        )
+
+    async def test_incomplete_without_operation_continues(self):
+        incomplete_response = FakeStreamResponse(
+            sse_event("ready", {"response_message_id": 4})
+            + sse_event(
+                "message",
+                {"p": "response/fragments/-1/content", "o": "APPEND", "v": "A"},
+            )
+            + sse_event(
+                "message",
+                {"p": "response/status", "v": "INCOMPLETE"},
+            )
+            + sse_event("close", {"auto_resume": False})
+        )
+        continued_response = FakeStreamResponse(
+            sse_event(
+                "message",
+                {"p": "response/fragments/-1/content", "o": "APPEND", "v": "B"},
+            )
+            + sse_event(
+                "message",
+                {"p": "response/status", "v": "FINISHED"},
+            )
+            + sse_event("close", {"auto_resume": False})
+        )
+        session = FakeStreamSession([incomplete_response, continued_response])
+        conversation = JsonConversation(parent_message_id=None)
+
+        with (
+            patch.object(DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock),
+            patch.object(DEEPSEEK_MODULE.debug, "log") as log,
+        ):
+            chunks = [
+                chunk
+                async for chunk in DeepSeek.iter_chat_stream(
+                    session,
+                    conversation,
+                    {"chat_session_id": "session-1", "prompt": "prompt"},
+                    auto_continue=True,
+                )
+            ]
+
+        log_output = "\n".join(
+            str(call.args[0]) for call in log.call_args_list if call.args
+        )
+
+        self.assertEqual(
+            "".join(chunk for chunk in chunks if isinstance(chunk, str)),
+            "AB",
+        )
+        self.assertEqual(
+            [chunk.reason for chunk in chunks if isinstance(chunk, FinishReason)],
+            ["stop"],
+        )
+        self.assertEqual(
+            [url for url, _kwargs in session.post_calls],
+            [CHAT_COMPLETION_ENDPOINT, CHAT_SESSION_CONTINUE_ENDPOINT],
+        )
+        self.assertIn(
+            "DeepSeekAuth: Stream status: status=INCOMPLETE source=patch "
+            "operation=none interpretation=requires_continue",
+            log_output,
+        )
+        self.assertIn(
+            "DeepSeekAuth: Stream closed: status=INCOMPLETE action=continue "
+            "reason=incomplete_status finish_reason=none auto_resume=false "
+            "click_behavior=none response_chars=1 reasoning_chars=0 "
+            "message_id_present=true",
+            log_output,
+        )
+
+    async def test_incomplete_snapshot_continues_without_prior_status_patch(self):
+        incomplete_response = FakeStreamResponse(
+            sse_event("ready", {"response_message_id": 4})
+            + sse_event(
+                "message",
+                {
+                    "v": {
+                        "response": {
+                            "message_id": 4,
+                            "status": "INCOMPLETE",
+                            "fragments": [
+                                {"type": "RESPONSE", "content": "A"}
+                            ],
+                        }
+                    }
+                },
+            )
+            + sse_event("close", {"auto_resume": False})
+        )
+        continued_response = FakeStreamResponse(
+            sse_event(
+                "message",
+                {"p": "response/fragments/-1/content", "o": "APPEND", "v": "B"},
+            )
+            + sse_event(
+                "message",
+                {"p": "response/status", "v": "FINISHED"},
+            )
+            + sse_event("close", {"auto_resume": False})
+        )
+        session = FakeStreamSession([incomplete_response, continued_response])
+        conversation = JsonConversation(parent_message_id=None)
+
+        with (
+            patch.object(DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock),
+            patch.object(DEEPSEEK_MODULE.debug, "log") as log,
+        ):
+            chunks = [
+                chunk
+                async for chunk in DeepSeek.iter_chat_stream(
+                    session,
+                    conversation,
+                    {"chat_session_id": "session-1", "prompt": "prompt"},
+                    auto_continue=True,
+                )
+            ]
+
+        log_output = "\n".join(
+            str(call.args[0]) for call in log.call_args_list if call.args
+        )
+        self.assertEqual("".join(map(str, chunks)), "AB")
+        self.assertEqual(
+            [url for url, _kwargs in session.post_calls],
+            [CHAT_COMPLETION_ENDPOINT, CHAT_SESSION_CONTINUE_ENDPOINT],
+        )
+        self.assertIn(
+            "DeepSeekAuth: Stream status: status=INCOMPLETE source=snapshot "
+            "operation=none interpretation=requires_continue",
+            log_output,
+        )
+
+    async def test_unclosed_stream_resumes_until_close_without_snapshot_duplicates(self):
+        interrupted_response = FakeStreamResponse(
+            sse_event("ready", {"response_message_id": 4})
+            + sse_event(
+                "message",
+                {"p": "response/fragments/-1/content", "o": "APPEND", "v": "A"},
+            )
+        )
+        resumed_but_unclosed_response = FakeStreamResponse(
+            sse_event(
+                "message",
+                {
+                    "v": {
+                        "response": {
+                            "message_id": 4,
+                            "fragments": [
+                                {"type": "RESPONSE", "content": "AB"}
+                            ],
+                        }
+                    }
+                },
+            )
+            + sse_event(
+                "message",
+                {"p": "response/status", "o": "SET", "v": "FINISHED"},
+            )
+        )
+        finally_closed_response = FakeStreamResponse(
+            sse_event("close", {"auto_resume": False})
+        )
+        session = FakeStreamSession(
+            [
+                interrupted_response,
+                resumed_but_unclosed_response,
+                finally_closed_response,
+            ]
+        )
+        conversation = JsonConversation(parent_message_id=None)
+
+        with (
+            patch.object(DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock),
+            patch.object(DEEPSEEK_MODULE.debug, "log") as log,
+        ):
+            chunks = [
+                chunk
+                async for chunk in DeepSeek.iter_chat_stream(
+                    session,
+                    conversation,
+                    {"chat_session_id": "session-1", "prompt": "prompt"},
+                    {"x-ds-pow-response": "completion-pow"},
+                    max_continue_attempts=3,
+                    max_resume_attempts=3,
+                )
+            ]
+
+        log_output = "\n".join(
+            str(call.args[0]) for call in log.call_args_list if call.args
+        )
+
+        self.assertEqual("".join(map(str, chunks)), "AB")
+        self.assertEqual(
+            [url for url, _kwargs in session.post_calls],
+            [
+                CHAT_COMPLETION_ENDPOINT,
+                CHAT_SESSION_RESUME_STREAM_ENDPOINT,
+                CHAT_SESSION_RESUME_STREAM_ENDPOINT,
+            ],
+        )
+        for _url, kwargs in session.post_calls[1:]:
+            self.assertEqual(
+                kwargs["json"],
+                {"chat_session_id": "session-1", "message_id": 4},
+            )
+        self.assertIn(
+            "DeepSeekAuth: Stream ended without close: status=none "
+            "message_id_present=true error=none",
+            log_output,
+        )
+        self.assertIn(
+            "DeepSeekAuth: Resuming interrupted response stream: "
+            "action=resume_stream attempt=1",
+            log_output,
+        )
+
+    async def test_unclosed_incomplete_stream_resumes_before_it_continues(self):
+        interrupted_response = FakeStreamResponse(
+            sse_event("ready", {"response_message_id": 4})
+            + sse_event(
+                "message",
+                {"p": "response/fragments/-1/content", "o": "APPEND", "v": "A"},
+            )
+            + sse_event(
+                "message",
+                {"p": "response/status", "o": "SET", "v": "INCOMPLETE"},
+            )
+        )
+        resumed_response = FakeStreamResponse(
+            sse_event(
+                "message",
+                {
+                    "v": {
+                        "response": {
+                            "message_id": 4,
+                            "status": "INCOMPLETE",
+                            "fragments": [
+                                {"type": "RESPONSE", "content": "A"}
+                            ],
+                        }
+                    }
+                },
+            )
+            + sse_event("update_session", {"v": "must-not-be-output"})
+            + sse_event("close", {"auto_resume": False})
+        )
+        continued_response = FakeStreamResponse(
+            sse_event(
+                "message",
+                {"p": "response/fragments/-1/content", "o": "APPEND", "v": "B"},
+            )
+            + sse_event(
+                "message",
+                {"p": "response/status", "o": "SET", "v": "FINISHED"},
+            )
+            + sse_event("close", {"auto_resume": False})
+        )
+        session = FakeStreamSession(
+            [interrupted_response, resumed_response, continued_response]
+        )
+        conversation = JsonConversation(parent_message_id=None)
+
+        with patch.object(DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock):
+            chunks = [
+                chunk
+                async for chunk in DeepSeek.iter_chat_stream(
+                    session,
+                    conversation,
+                    {"chat_session_id": "session-1", "prompt": "prompt"},
+                    {"x-ds-pow-response": "completion-pow"},
+                    max_continue_attempts=3,
+                    max_resume_attempts=3,
+                )
+            ]
+
+        self.assertEqual("".join(map(str, chunks)), "AB")
+        self.assertEqual(
+            [url for url, _kwargs in session.post_calls],
+            [
+                CHAT_COMPLETION_ENDPOINT,
+                CHAT_SESSION_RESUME_STREAM_ENDPOINT,
+                CHAT_SESSION_CONTINUE_ENDPOINT,
+            ],
+        )
+
+    async def test_terminal_statuses_are_exposed_as_finish_reasons(self):
+        expected_reasons = {
+            "FINISHED": "stop",
+            "CONTENT_FILTER": "content_filter",
+            "CONTEXT_LENGTH_EXCEEDED": "length",
+            "INCOMPLETE": "incomplete",
+            "WIP": "wip",
+            "TIMEOUT": "timeout",
+        }
+
+        for status, expected_reason in expected_reasons.items():
+            with self.subTest(status=status):
+                response = FakeStreamResponse(
+                    sse_event("ready", {"response_message_id": 4})
+                    + sse_event(
+                        "message",
+                        {"p": "response/status", "o": "SET", "v": status},
+                    )
+                    + sse_event("close", {"auto_resume": False})
+                )
+                session = FakeStreamSession([response])
+                conversation = JsonConversation(parent_message_id=None)
+
+                with patch.object(
+                    DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock
+                ):
+                    chunks = [
+                        chunk
+                        async for chunk in DeepSeek.iter_chat_stream(
+                            session,
+                            conversation,
+                            {"chat_session_id": "session-1", "prompt": "prompt"},
+                            auto_continue=False,
+                        )
+                    ]
+
+                finish_reasons = [
+                    chunk.reason for chunk in chunks if isinstance(chunk, FinishReason)
+                ]
+                self.assertEqual(finish_reasons, [expected_reason])
+                self.assertEqual(len(session.post_calls), 1)
+
+    async def test_fragment_types_separate_response_reasoning_and_metadata(self):
+        response = FakeStreamResponse(
+            sse_event("ready", {"response_message_id": 4})
+            + sse_event(
+                "message",
+                {
+                    "v": {
+                        "response": {
+                            "message_id": 4,
+                            "fragments": [
+                                {"type": "REQUEST", "content": "prompt"},
+                                {"type": "THINK", "content": "think"},
+                                {"type": "SEARCH", "content": "search"},
+                                {"type": "TOOL_FIND", "content": "tool"},
+                                {"type": "RESPONSE", "content": "answer"},
+                                {
+                                    "type": "TEMPLATE_RESPONSE",
+                                    "content": "template",
+                                },
+                                {"type": "FILE", "content": "file"},
+                                {"type": "TIP", "content": "tip"},
+                                {"type": "READ_LINK", "content": "link"},
+                                {"type": "UNKNOWN", "content": "unknown"},
+                            ],
+                        }
+                    }
+                },
+            )
+            + sse_event(
+                "message",
+                {"p": "response/status", "o": "SET", "v": "FINISHED"},
+            )
+            + sse_event("close", {"auto_resume": False})
+        )
+        session = FakeStreamSession([response])
+        conversation = JsonConversation(parent_message_id=None)
+
+        with patch.object(DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock):
+            chunks = [
+                chunk
+                async for chunk in DeepSeek.iter_chat_stream(
+                    session,
+                    conversation,
+                    {"chat_session_id": "session-1", "prompt": "prompt"},
+                )
+            ]
+
+        self.assertEqual(
+            "".join(str(chunk) for chunk in chunks if isinstance(chunk, Reasoning)),
+            "thinksearchtool",
+        )
+        self.assertEqual(
+            "".join(chunk for chunk in chunks if isinstance(chunk, str)),
+            "answertemplate",
+        )
+
+    async def test_set_fragments_emits_only_snapshot_delta(self):
+        response = FakeStreamResponse(
+            sse_event("ready", {"response_message_id": 4})
+            + sse_event(
+                "message",
+                {
+                    "p": "response/fragments",
+                    "o": "SET",
+                    "v": [{"type": "RESPONSE", "content": "A"}],
+                },
+            )
+            + sse_event(
+                "message",
+                {
+                    "p": "response/fragments",
+                    "o": "SET",
+                    "v": [{"type": "RESPONSE", "content": "AB"}],
+                },
+            )
+            + sse_event(
+                "message",
+                {"p": "response/status", "o": "SET", "v": "FINISHED"},
+            )
+            + sse_event("close", {"auto_resume": False})
+        )
+        session = FakeStreamSession([response])
+        conversation = JsonConversation(parent_message_id=None)
+
+        with patch.object(DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock):
+            chunks = [
+                chunk
+                async for chunk in DeepSeek.iter_chat_stream(
+                    session,
+                    conversation,
+                    {"chat_session_id": "session-1", "prompt": "prompt"},
+                )
+            ]
+
+        self.assertEqual(
+            "".join(chunk for chunk in chunks if isinstance(chunk, str)),
+            "AB",
+        )
+
+    async def test_batch_applies_append_fragments_and_status(self):
+        response = FakeStreamResponse(
+            sse_event("ready", {"response_message_id": 4})
+            + sse_event(
+                "message",
+                {
+                    "o": "BATCH",
+                    "v": [
+                        {
+                            "p": "response/fragments",
+                            "o": "APPEND",
+                            "v": [
+                                {
+                                    "type": "TEMPLATE_RESPONSE",
+                                    "content": "answer",
+                                }
+                            ],
+                        },
+                        {
+                            "p": "response/status",
+                            "o": "SET",
+                            "v": "FINISHED",
+                        },
+                    ],
+                },
+            )
+            + sse_event("close", {"auto_resume": False})
+        )
+        session = FakeStreamSession([response])
+        conversation = JsonConversation(parent_message_id=None)
+
+        with patch.object(DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock):
+            chunks = [
+                chunk
+                async for chunk in DeepSeek.iter_chat_stream(
+                    session,
+                    conversation,
+                    {"chat_session_id": "session-1", "prompt": "prompt"},
+                )
+            ]
+
+        self.assertEqual(
+            "".join(chunk for chunk in chunks if isinstance(chunk, str)),
+            "answer",
+        )
+        self.assertEqual(
+            [chunk.reason for chunk in chunks if isinstance(chunk, FinishReason)],
+            ["stop"],
+        )
+
+    def test_chat_headers_forward_hif_but_drop_stale_pow(self):
+        headers = _build_chat_headers(
+            {
+                "Authorization": "Bearer redacted",
+                "X-Hif-Leim": "hif-redacted",
+                "X-Client-Version": "2.4.0",
+                "X-Ds-Pow-Response": "stale-pow",
+            },
+            "Bearer redacted",
+        )
+
+        self.assertEqual(headers["x-hif-leim"], "hif-redacted")
+        self.assertEqual(headers["x-client-version"], "2.4.0")
+        self.assertNotIn("x-ds-pow-response", headers)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/etc/unittest/test_deepseek_upload.py
+++ b/etc/unittest/test_deepseek_upload.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 import importlib
 import unittest
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 from g4f.Provider.needs_auth.DeepSeek import (
     FILE_UPLOAD_ENDPOINT,
     FILE_UPLOAD_PATH,
     POW_CHALLENGE_ENDPOINT,
     DeepSeek,
+    DeepSeekPOW,
     _build_upload_session_headers,
 )
 
@@ -72,6 +73,98 @@ class FakePowSolver:
 
 
 class DeepSeekUploadTest(unittest.IsolatedAsyncioTestCase):
+    async def test_pow_rejects_unsupported_algorithm_before_solving(self):
+        challenge = {
+            "algorithm": "FutureHashV2",
+            "challenge": "challenge",
+            "salt": "salt",
+            "difficulty": 1,
+            "expire_at": 1,
+            "signature": "signature",
+            "target_path": FILE_UPLOAD_PATH,
+        }
+        session = FakeSession(
+            post_responses=[
+                FakeResponse({"data": {"biz_data": {"challenge": challenge}}})
+            ]
+        )
+
+        with patch.object(DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock):
+            with patch.object(
+                DEEPSEEK_MODULE,
+                "DeepSeekPOW",
+                side_effect=AssertionError("solver must not be created"),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "FutureHashV2"):
+                    await DeepSeek.create_pow_response(session, FILE_UPLOAD_PATH)
+
+    async def test_pow_solver_runs_off_the_event_loop(self):
+        challenge = {
+            "algorithm": "DeepSeekHashV1",
+            "challenge": "challenge",
+            "salt": "salt",
+            "difficulty": 1,
+            "expire_at": 1,
+            "signature": "signature",
+            "target_path": FILE_UPLOAD_PATH,
+        }
+        session = FakeSession(
+            post_responses=[
+                FakeResponse({"data": {"biz_data": {"challenge": challenge}}})
+            ]
+        )
+
+        with patch.object(DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock):
+            with patch.object(
+                DEEPSEEK_MODULE.asyncio,
+                "to_thread",
+                new_callable=AsyncMock,
+                return_value="pow-response",
+            ) as to_thread:
+                result = await DeepSeek.create_pow_response(
+                    session, FILE_UPLOAD_PATH
+                )
+
+        self.assertEqual(result, "pow-response")
+        to_thread.assert_awaited_once()
+
+    def test_pow_rejects_missing_answer(self):
+        solver = DeepSeekPOW.__new__(DeepSeekPOW)
+        solver.hasher = Mock()
+        solver.hasher.calculate_hash.return_value = None
+
+        with self.assertRaisesRegex(RuntimeError, "no answer"):
+            solver.solve_challenge(
+                {
+                    "algorithm": "DeepSeekHashV1",
+                    "challenge": "challenge",
+                    "salt": "salt",
+                    "difficulty": 1,
+                    "expire_at": 1,
+                    "signature": "signature",
+                    "target_path": FILE_UPLOAD_PATH,
+                }
+            )
+
+    async def test_pow_exposes_inner_business_error(self):
+        session = FakeSession(
+            post_responses=[
+                FakeResponse(
+                    {
+                        "data": {
+                            "biz_code": 42901,
+                            "biz_msg": "challenge rate limited",
+                            "biz_data": None,
+                        }
+                    }
+                )
+            ]
+        )
+
+        with patch.object(DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock):
+            with self.assertRaisesRegex(RuntimeError, "challenge rate limited"):
+                await DeepSeek.create_pow_response(session, FILE_UPLOAD_PATH)
+
     async def test_upload_uses_current_endpoint_dedicated_pow_and_nested_file_id(self):
         challenge = {
             "algorithm": "DeepSeekHashV1",
@@ -85,7 +178,15 @@ class DeepSeekUploadTest(unittest.IsolatedAsyncioTestCase):
         session = FakeSession(
             post_responses=[
                 FakeResponse({"data": {"biz_data": {"challenge": challenge}}}),
-                FakeResponse({"code": 0, "data": {"biz_data": {"id": "file-123"}}}),
+                FakeResponse(
+                    {
+                        "data": {
+                            "biz_code": 0,
+                            "biz_msg": "",
+                            "biz_data": {"id": "file-123"},
+                        }
+                    }
+                ),
             ]
         )
 
@@ -129,14 +230,96 @@ class DeepSeekUploadTest(unittest.IsolatedAsyncioTestCase):
             ],
         )
 
+    async def test_upload_rejects_inner_business_error(self):
+        challenge = {
+            "algorithm": "DeepSeekHashV1",
+            "challenge": "challenge",
+            "salt": "salt",
+            "difficulty": 1,
+            "expire_at": 1,
+            "signature": "signature",
+            "target_path": FILE_UPLOAD_PATH,
+        }
+        session = FakeSession(
+            post_responses=[
+                FakeResponse({"data": {"biz_data": {"challenge": challenge}}}),
+                FakeResponse(
+                    {
+                        "data": {
+                            "biz_code": 40012,
+                            "biz_msg": "file rejected",
+                            "biz_data": {"id": "must-not-be-used"},
+                        }
+                    }
+                ),
+            ]
+        )
+
+        with patch.object(DEEPSEEK_MODULE, "FormData", FakeFormData):
+            with patch.object(DEEPSEEK_MODULE, "DeepSeekPOW", return_value=FakePowSolver()):
+                with patch.object(
+                    DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock
+                ):
+                    with self.assertRaisesRegex(RuntimeError, "file rejected"):
+                        await DeepSeek.upload_file(session, b'{"a":1}', "sample.json")
+
+    async def test_upload_accepts_unicode_text_using_filename_mime(self):
+        challenge = {
+            "algorithm": "DeepSeekHashV1",
+            "challenge": "challenge",
+            "salt": "salt",
+            "difficulty": 1,
+            "expire_at": 1,
+            "signature": "signature",
+            "target_path": FILE_UPLOAD_PATH,
+        }
+        session = FakeSession(
+            post_responses=[
+                FakeResponse({"data": {"biz_data": {"challenge": challenge}}}),
+                FakeResponse(
+                    {
+                        "data": {
+                            "biz_code": 0,
+                            "biz_data": {"id": "text-file"},
+                        }
+                    }
+                ),
+            ]
+        )
+
+        with patch.object(DEEPSEEK_MODULE, "FormData", FakeFormData):
+            with patch.object(DEEPSEEK_MODULE, "DeepSeekPOW", return_value=FakePowSolver()):
+                with patch.object(
+                    DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock
+                ):
+                    result = await DeepSeek.upload_file(
+                        session,
+                        "مرحبا DeepSeek".encode("utf-8"),
+                        "notes.txt",
+                    )
+
+        self.assertEqual(result["file_id"], "text-file")
+        upload_form = session.post_calls[1][1]["data"]
+        self.assertEqual(upload_form.fields[0]["content_type"], "text/plain")
+
     async def test_wait_for_file_parsing_polls_until_success(self):
         session = FakeSession(
             get_responses=[
                 FakeResponse(
-                    {"data": {"biz_data": {"files": [{"status": "PROCESSING"}]}}}
+                    {
+                        "data": {
+                            "biz_code": 0,
+                            "biz_data": {"files": [{"status": "PROCESSING"}]},
+                        }
+                    }
                 ),
                 FakeResponse(
-                    {"data": {"biz_data": {"files": [{"status": "SUCCESS"}]}}}
+                    {
+                        "data": {
+                            "biz_code": 0,
+                            "biz_data": {"files": [{"status": "SUCCESS"}]},
+                        }
+                    }
                 ),
             ]
         )
@@ -154,6 +337,80 @@ class DeepSeekUploadTest(unittest.IsolatedAsyncioTestCase):
             session.get_calls[0][1]["params"], {"file_ids": "file-123"}
         )
         sleep.assert_awaited_once_with(0.01)
+
+    async def test_wait_for_file_parsing_rejects_inner_business_error(self):
+        session = FakeSession(
+            get_responses=[
+                FakeResponse(
+                    {
+                        "data": {
+                            "biz_code": 40404,
+                            "biz_msg": "file not found",
+                            "biz_data": None,
+                        }
+                    }
+                )
+            ]
+        )
+
+        with patch.object(DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock):
+            with self.assertRaisesRegex(RuntimeError, "file not found"):
+                await DeepSeek.wait_for_file_parsed(session, "missing", timeout=0)
+
+    async def test_wait_for_file_parsing_rejects_current_terminal_statuses(self):
+        terminal_statuses = {
+            "FAILED",
+            "CONTENT_FILTER",
+            "CONTENT_TOO_LONG",
+            "CANCELLED",
+            "CONTENT_EMPTY",
+            "_CUSTOM_SYSTEM_ERROR_FAIL",
+            "_CUSTOM_FROM_SHARE",
+        }
+
+        for status in terminal_statuses:
+            with self.subTest(status=status):
+                session = FakeSession(
+                    get_responses=[
+                        FakeResponse(
+                            {
+                                "data": {
+                                    "biz_code": 0,
+                                    "biz_data": {"files": [{"status": status}]},
+                                }
+                            }
+                        )
+                    ]
+                )
+                with patch.object(
+                    DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock
+                ):
+                    with self.assertRaisesRegex(RuntimeError, status):
+                        await DeepSeek.wait_for_file_parsed(
+                            session, "file-123", timeout=0
+                        )
+
+    async def test_upload_files_processes_every_media_item(self):
+        media = [(b"first", "first.txt"), (b"second", "second.txt")]
+        with patch.object(
+            DeepSeek,
+            "upload_file",
+            new_callable=AsyncMock,
+            side_effect=[{"file_id": "file-1"}, {"file_id": "file-2"}],
+        ) as upload_file:
+            with patch.object(
+                DeepSeek, "wait_for_file_parsed", new_callable=AsyncMock
+            ) as wait_for_file_parsed:
+                file_ids = await DeepSeek.upload_files(
+                    object(),
+                    media,
+                    thinking_enabled=True,
+                    model_type="default",
+                )
+
+        self.assertEqual(file_ids, ["file-1", "file-2"])
+        self.assertEqual(upload_file.await_count, 2)
+        self.assertEqual(wait_for_file_parsed.await_count, 2)
 
     def test_upload_session_does_not_inherit_json_or_chat_pow_headers(self):
         headers = {

--- a/etc/unittest/test_deepseek_upload.py
+++ b/etc/unittest/test_deepseek_upload.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import importlib
 import unittest
 from unittest.mock import AsyncMock, Mock, patch
@@ -114,19 +115,25 @@ class DeepSeekUploadTest(unittest.IsolatedAsyncioTestCase):
             ]
         )
 
+        result_future = asyncio.get_running_loop().create_future()
+        result_future.set_result("pow-response")
+        run_in_executor = Mock(return_value=result_future)
+        loop = Mock(run_in_executor=run_in_executor)
+
         with patch.object(DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock):
             with patch.object(
                 DEEPSEEK_MODULE.asyncio,
-                "to_thread",
-                new_callable=AsyncMock,
-                return_value="pow-response",
-            ) as to_thread:
+                "get_running_loop",
+                return_value=loop,
+            ):
                 result = await DeepSeek.create_pow_response(
                     session, FILE_UPLOAD_PATH
                 )
 
         self.assertEqual(result, "pow-response")
-        to_thread.assert_awaited_once()
+        run_in_executor.assert_called_once_with(
+            None, DEEPSEEK_MODULE._solve_pow_challenge, challenge
+        )
 
     def test_pow_rejects_missing_answer(self):
         solver = DeepSeekPOW.__new__(DeepSeekPOW)

--- a/etc/unittest/test_deepseek_upload.py
+++ b/etc/unittest/test_deepseek_upload.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import importlib
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from g4f.Provider.needs_auth.DeepSeek import (
+    FILE_UPLOAD_ENDPOINT,
+    FILE_UPLOAD_PATH,
+    POW_CHALLENGE_ENDPOINT,
+    DeepSeek,
+    _build_upload_session_headers,
+)
+
+
+DEEPSEEK_MODULE = importlib.import_module("g4f.Provider.needs_auth.DeepSeek")
+
+
+class FakeResponse:
+    def __init__(self, payload, content_type="application/json"):
+        self.status = 200
+        self.headers = {"content-type": content_type}
+        self.payload = payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, _exc_type, _exc, _traceback):
+        return False
+
+    async def json(self):
+        return self.payload
+
+    async def text(self):
+        return str(self.payload)
+
+
+class FakeSession:
+    def __init__(self, *, post_responses=None, get_responses=None):
+        self.post_responses = iter(post_responses or [])
+        self.get_responses = iter(get_responses or [])
+        self.post_calls = []
+        self.get_calls = []
+
+    def post(self, url, **kwargs):
+        self.post_calls.append((url, kwargs))
+        return next(self.post_responses)
+
+    def get(self, url, **kwargs):
+        self.get_calls.append((url, kwargs))
+        return next(self.get_responses)
+
+
+class FakeFormData:
+    def __init__(self):
+        self.fields = []
+
+    def add_field(self, name, data=None, content_type=None, filename=None):
+        self.fields.append(
+            {
+                "name": name,
+                "data": data,
+                "content_type": content_type,
+                "filename": filename,
+            }
+        )
+
+
+class FakePowSolver:
+    def solve_challenge(self, challenge):
+        return f"pow:{challenge['target_path']}"
+
+
+class DeepSeekUploadTest(unittest.IsolatedAsyncioTestCase):
+    async def test_upload_uses_current_endpoint_dedicated_pow_and_nested_file_id(self):
+        challenge = {
+            "algorithm": "DeepSeekHashV1",
+            "challenge": "challenge",
+            "salt": "salt",
+            "difficulty": 1,
+            "expire_at": 1,
+            "signature": "signature",
+            "target_path": FILE_UPLOAD_PATH,
+        }
+        session = FakeSession(
+            post_responses=[
+                FakeResponse({"data": {"biz_data": {"challenge": challenge}}}),
+                FakeResponse({"code": 0, "data": {"biz_data": {"id": "file-123"}}}),
+            ]
+        )
+
+        with patch.object(DEEPSEEK_MODULE, "FormData", FakeFormData):
+            with patch.object(DEEPSEEK_MODULE, "DeepSeekPOW", return_value=FakePowSolver()):
+                with patch.object(
+                    DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock
+                ):
+                    result = await DeepSeek.upload_file(
+                        session,
+                        b'{"a":1}',
+                        "sample.json",
+                        thinking_enabled=False,
+                    )
+
+        self.assertEqual(result["file_id"], "file-123")
+        self.assertEqual(session.post_calls[0][0], POW_CHALLENGE_ENDPOINT)
+        self.assertEqual(
+            session.post_calls[0][1]["json"], {"target_path": FILE_UPLOAD_PATH}
+        )
+        self.assertEqual(session.post_calls[1][0], FILE_UPLOAD_ENDPOINT)
+
+        upload_kwargs = session.post_calls[1][1]
+        self.assertEqual(upload_kwargs["headers"]["x-file-size"], "7")
+        self.assertEqual(upload_kwargs["headers"]["x-model-type"], "default")
+        self.assertEqual(upload_kwargs["headers"]["x-thinking-enabled"], "0")
+        self.assertEqual(
+            upload_kwargs["headers"]["x-ds-pow-response"],
+            f"pow:{FILE_UPLOAD_PATH}",
+        )
+        self.assertNotIn("content-type", upload_kwargs["headers"])
+        self.assertEqual(
+            upload_kwargs["data"].fields,
+            [
+                {
+                    "name": "file",
+                    "data": b'{"a":1}',
+                    "content_type": "application/json",
+                    "filename": "sample.json",
+                }
+            ],
+        )
+
+    async def test_wait_for_file_parsing_polls_until_success(self):
+        session = FakeSession(
+            get_responses=[
+                FakeResponse(
+                    {"data": {"biz_data": {"files": [{"status": "PROCESSING"}]}}}
+                ),
+                FakeResponse(
+                    {"data": {"biz_data": {"files": [{"status": "SUCCESS"}]}}}
+                ),
+            ]
+        )
+
+        with patch.object(DEEPSEEK_MODULE, "raise_for_status", new_callable=AsyncMock):
+            with patch.object(
+                DEEPSEEK_MODULE.asyncio, "sleep", new_callable=AsyncMock
+            ) as sleep:
+                await DeepSeek.wait_for_file_parsed(
+                    session, "file-123", timeout=5, poll_interval=0.01
+                )
+
+        self.assertEqual(len(session.get_calls), 2)
+        self.assertEqual(
+            session.get_calls[0][1]["params"], {"file_ids": "file-123"}
+        )
+        sleep.assert_awaited_once_with(0.01)
+
+    def test_upload_session_does_not_inherit_json_or_chat_pow_headers(self):
+        headers = {
+            "authorization": "Bearer redacted",
+            "content-type": "application/json",
+            "x-ds-pow-response": "chat-pow",
+            "x-client-platform": "web",
+        }
+
+        upload_headers = _build_upload_session_headers(headers)
+
+        self.assertEqual(upload_headers["authorization"], "Bearer redacted")
+        self.assertEqual(upload_headers["x-client-platform"], "web")
+        self.assertNotIn("content-type", upload_headers)
+        self.assertNotIn("x-ds-pow-response", upload_headers)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/g4f/Provider/needs_auth/DeepSeek.py
+++ b/g4f/Provider/needs_auth/DeepSeek.py
@@ -7,7 +7,7 @@ from typing import Any, Optional, Literal
 
 from g4f import debug
 from g4f.cookies import get_cookies, get_headers
-from g4f.errors import MissingAuthError
+from g4f.errors import MissingAuthError, ResponseError
 from g4f.image import to_bytes, detect_file_type
 from g4f.providers.base_provider import AsyncGeneratorProvider, ProviderModelMixin
 from g4f.providers.helper import get_last_user_message
@@ -504,6 +504,7 @@ class DeepSeek(AsyncGeneratorProvider, ProviderModelMixin):
         state = _DeepSeekStreamState()
         continue_attempts = 0
         resume_attempts = 0
+        empty_response_resume_attempted = False
 
         while True:
             state.closed = False
@@ -528,6 +529,17 @@ class DeepSeek(AsyncGeneratorProvider, ProviderModelMixin):
                                 biz_data, state, conversation
                         ):
                             yield chunk
+                        if not state.emitted["response"]:
+                            debug.log(
+                                "DeepSeekAuth: Stream closed: "
+                                f"status={_stream_log_value(state.status)} "
+                                "action=error "
+                                "reason=empty_response_after_resume "
+                                "finish_reason=none"
+                            )
+                            raise ResponseError(
+                                "DeepSeek finished without a response"
+                            )
                         finish_reason = DEEPSEEK_FINISH_REASONS.get(state.status)
                         if finish_reason is not None:
                             yield FinishReason(finish_reason)
@@ -577,6 +589,60 @@ class DeepSeek(AsyncGeneratorProvider, ProviderModelMixin):
                     "message_id_present="
                     f"{_stream_log_value(state.message_id is not None)}"
                 )
+                if (
+                        state.status == "FINISHED"
+                        and not state.emitted["response"]
+                ):
+                    can_resume_empty_response = (
+                        state.message_id is not None
+                        and not empty_response_resume_attempted
+                        and (
+                            max_resume_attempts is None
+                            or resume_attempts < max_resume_attempts
+                        )
+                    )
+                    if can_resume_empty_response:
+                        empty_response_resume_attempted = True
+                        resume_attempts += 1
+                        debug.log(
+                            "DeepSeekAuth: Stream closed: "
+                            "status=FINISHED action=resume_stream "
+                            "reason=empty_response finish_reason=none "
+                            f"attempt={resume_attempts} "
+                            f"{close_details}"
+                        )
+                        endpoint = CHAT_SESSION_RESUME_STREAM_ENDPOINT
+                        payload = {
+                            "chat_session_id": chat_session_id,
+                            "message_id": state.message_id,
+                        }
+                        request_headers = None
+                        continue
+
+                    debug.log(
+                        "DeepSeekAuth: Stream closed: "
+                        "status=FINISHED action=error "
+                        "reason=empty_response finish_reason=none "
+                        f"{close_details}"
+                    )
+                    raise ResponseError(
+                        "DeepSeek finished without a response"
+                    )
+                if (
+                        empty_response_resume_attempted
+                        and not state.emitted["response"]
+                        and not should_continue
+                ):
+                    debug.log(
+                        "DeepSeekAuth: Stream closed: "
+                        f"status={_stream_log_value(state.status)} "
+                        "action=error reason=empty_response_after_resume "
+                        "finish_reason=none "
+                        f"{close_details}"
+                    )
+                    raise ResponseError(
+                        "DeepSeek finished without a response"
+                    )
                 if not should_continue:
                     finish_reason = DEEPSEEK_FINISH_REASONS.get(state.status)
                     if state.status == "INCOMPLETE":

--- a/g4f/Provider/needs_auth/DeepSeek.py
+++ b/g4f/Provider/needs_auth/DeepSeek.py
@@ -307,7 +307,10 @@ class DeepSeek(AsyncGeneratorProvider, ProviderModelMixin):
             f"algorithm={challenge.get('algorithm')}, "
             f"difficulty={challenge.get('difficulty')}"
         )
-        pow_response = await asyncio.to_thread(_solve_pow_challenge, challenge)
+        loop = asyncio.get_running_loop()
+        pow_response = await loop.run_in_executor(
+            None, _solve_pow_challenge, challenge
+        )
         debug.log(f"DeepSeekAuth: PoW challenge solved for {target_path}")
         return pow_response
 

--- a/g4f/Provider/needs_auth/DeepSeek.py
+++ b/g4f/Provider/needs_auth/DeepSeek.py
@@ -1,14 +1,9 @@
 from __future__ import annotations
 
 import asyncio
-import base64
-import json
-import os
-import uuid
-from dataclasses import dataclass, field
+import mimetypes
 from datetime import datetime
-from pathlib import Path
-from typing import Any, AsyncIterator, Optional, Literal
+from typing import Any, Optional, Literal
 
 from g4f import debug
 from g4f.cookies import get_cookies, get_headers
@@ -20,21 +15,33 @@ from g4f.providers.response import (
     FinishReason,
     JsonConversation,
     JsonRequest,
-    Reasoning,
 )
 from g4f.requests import StreamSession, raise_for_status, FormData
 from g4f.typing import AsyncResult, Messages, Cookies
-
-# Inline PoW (Proof of Work) implementation for DeepSeek
-# Based on reference implementation in gpt4free/projects/deepseek4free/dsk/pow.py
-
-try:
-    import wasmtime
-    import numpy
-
-    has_wasmtime_and_numpy = True
-except ImportError:
-    has_wasmtime_and_numpy = False
+from .deepseek.pow import (
+    DEEPSEEK_POW_ALGORITHM,
+    WASM_PATH,
+    DeepSeekHash,
+    DeepSeekPOW,
+    has_wasmtime_and_numpy,
+)
+from .deepseek.stream import (
+    DEEPSEEK_FINISH_REASONS,
+    DEEPSEEK_MESSAGE_STATUSES,
+    DEEPSEEK_METADATA_FRAGMENT_TYPES,
+    DEEPSEEK_REASONING_FRAGMENT_TYPES,
+    DEEPSEEK_RESPONSE_FRAGMENT_TYPES,
+    _DeepSeekStreamState,
+    _fragment_kind,
+    _process_fragments,
+    _process_full_message,
+    _process_stream_payload,
+    _record_response_message_id,
+    _record_stream_status,
+    _stream_log_value,
+    _stream_output,
+    iter_deepseek_sse,
+)
 
 try:
     from curl_cffi import CurlHttpVersion
@@ -43,120 +50,9 @@ try:
 except ImportError:
     has_curl_cffi = False
 
-WASM_PATH = os.path.join(os.path.dirname(__file__), "deepseek", "pow_solver.wasm")
-
-
-class DeepSeekHash:
-    """Custom SHA3 hash solver using WebAssembly"""
-
-    def __init__(self):
-        self.instance = None
-        self.memory = None
-        self.store = None
-
-    def init(self, wasm_path: str):
-        if not has_wasmtime_and_numpy:
-            raise ImportError("wasmtime and numpy are required for PoW solving")
-
-        if not Path(wasm_path).exists():
-            raise FileNotFoundError(f"WASM file not found: {wasm_path}")
-
-        engine = wasmtime.Engine()
-
-        with open(wasm_path, "rb") as f:
-            wasm_bytes = f.read()
-
-        module = wasmtime.Module(engine, wasm_bytes)
-
-        self.store = wasmtime.Store(engine)
-        linker = wasmtime.Linker(engine)
-        linker.define_wasi()
-
-        self.instance = linker.instantiate(self.store, module)
-        self.memory = self.instance.exports(self.store)["memory"]
-
-        return self
-
-    def _write_to_memory(self, text: str) -> tuple[int, int]:
-        encoded = text.encode("utf-8")
-        length = len(encoded)
-        ptr = self.instance.exports(self.store)["__wbindgen_export_0"](
-            self.store, length, 1
-        )
-
-        memory_view = self.memory.data_ptr(self.store)
-        for i, byte in enumerate(encoded):
-            memory_view[ptr + i] = byte
-
-        return ptr, length
-
-    def calculate_hash(
-            self, algorithm: str, challenge: str, salt: str, difficulty: int, expire_at: int
-    ) -> int:
-        prefix = f"{salt}_{expire_at}_"
-        retptr = self.instance.exports(self.store)["__wbindgen_add_to_stack_pointer"](
-            self.store, -16
-        )
-
-        try:
-            challenge_ptr, challenge_len = self._write_to_memory(challenge)
-            prefix_ptr, prefix_len = self._write_to_memory(prefix)
-
-            self.instance.exports(self.store)["wasm_solve"](
-                self.store,
-                retptr,
-                challenge_ptr,
-                challenge_len,
-                prefix_ptr,
-                prefix_len,
-                float(difficulty),
-            )
-
-            memory_view = self.memory.data_ptr(self.store)
-            status = int.from_bytes(
-                bytes(memory_view[retptr: retptr + 4]), byteorder="little", signed=True
-            )
-
-            if status == 0:
-                return None
-
-            value_bytes = bytes(memory_view[retptr + 8: retptr + 16])
-            value = numpy.frombuffer(value_bytes, dtype=numpy.float64)[0]
-
-            return int(value)
-
-        finally:
-            self.instance.exports(self.store)["__wbindgen_add_to_stack_pointer"](
-                self.store, 16
-            )
-
-
-class DeepSeekPOW:
-    """Proof of Work solver for DeepSeek challenges"""
-
-    def __init__(self):
-        self.hasher = DeepSeekHash().init(WASM_PATH)
-
-    def solve_challenge(self, config: dict) -> str:
-        """Solves a proof-of-work challenge and returns the encoded response"""
-        answer = self.hasher.calculate_hash(
-            config["algorithm"],
-            config["challenge"],
-            config["salt"],
-            config["difficulty"],
-            config["expire_at"],
-        )
-
-        result = {
-            "algorithm": config["algorithm"],
-            "challenge": config["challenge"],
-            "salt": config["salt"],
-            "answer": answer,
-            "signature": config["signature"],
-            "target_path": config.get("target_path", ""),
-        }
-
-        return base64.b64encode(json.dumps(result).encode()).decode()
+def _solve_pow_challenge(challenge: dict) -> str:
+    """Create the WASM solver and solve entirely outside the event loop."""
+    return DeepSeekPOW().solve_challenge(challenge)
 
 
 # DeepSeek API endpoints
@@ -172,58 +68,27 @@ CHAT_COMPLETION_PATH = "/api/v0/chat/completion"
 FILE_UPLOAD_PATH = "/api/v0/file/upload_file"
 FILE_UPLOAD_ENDPOINT = f"{DEEPSEEK_URL}{FILE_UPLOAD_PATH}"
 FILE_FETCH_ENDPOINT = f"{DEEPSEEK_URL}/api/v0/file/fetch_files"
-
-DEEPSEEK_MESSAGE_STATUSES = {
-    "FINISHED",
+RESUME_MESSAGE_GOT_FULL_MESSAGE_CODE = 22
+DEEPSEEK_FILE_FAILURE_STATUSES = {
+    "FAILED",
+    "ERROR",
     "CONTENT_FILTER",
-    "CONTEXT_LENGTH_EXCEEDED",
-    "INCOMPLETE",
-    "WIP",
-    "TIMEOUT",
+    "CONTENT_TOO_LONG",
+    "CANCELLED",
+    "CONTENT_EMPTY",
+    "_CUSTOM_SYSTEM_ERROR_FAIL",
+    "_CUSTOM_FROM_SHARE",
 }
-DEEPSEEK_FINISH_REASONS = {
-    "FINISHED": "stop",
-    "CONTENT_FILTER": "content_filter",
-    "CONTEXT_LENGTH_EXCEEDED": "length",
-    "INCOMPLETE": "incomplete",
-    "WIP": "wip",
-    "TIMEOUT": "timeout",
-}
-
-DEEPSEEK_RESPONSE_FRAGMENT_TYPES = {"RESPONSE", "TEMPLATE_RESPONSE"}
-DEEPSEEK_REASONING_FRAGMENT_TYPES = {
-    "THINK",
-    "THINKING",
-    "REASONING",
-    "SEARCH",
-    "TOOL_SEARCH",
-    "TOOL_OPEN",
-    "TOOL_FIND",
-}
-DEEPSEEK_METADATA_FRAGMENT_TYPES = {
-    "REQUEST",
-    "FILE",
-    "TIP",
-    "READ_LINK",
-}
-DEEPSEEK_STREAM_OPERATIONS = {"SET", "BATCH", "APPEND"}
 
 CHAT_HEADER_DEFAULTS = {
     "accept": "*/*",
-    "accept-language": "en-US,en;q=0.9",
     "cache-control": "no-cache",
     "content-type": "application/json",
     "origin": DEEPSEEK_URL,
-    "referer": f"{DEEPSEEK_URL}/",
-    "user-agent": (
-        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
-        "(KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36"
-    ),
-    "x-app-version": "20241129.1",
+    "referer": f"{DEEPSEEK_URL}/a/chat/",
     "x-client-bundle-id": "com.deepseek.chat",
     "x-client-locale": "en_US",
     "x-client-platform": "web",
-    "x-client-timezone-offset": "-28800",
     "x-client-version": "2.4.0",
 }
 
@@ -251,6 +116,7 @@ CHAT_HEADER_PASSTHROUGH = {
     "x-client-platform",
     "x-client-timezone-offset",
     "x-client-version",
+    "x-hif-dliq",
     "x-hif-leim",
 }
 
@@ -276,10 +142,41 @@ def _extract_chat_session_id(session_data: Any) -> Optional[str]:
     return biz_data.get("id")
 
 
+def _unwrap_biz_response(
+        payload: Any,
+        context: str,
+        *,
+        allowed_codes: tuple[int, ...] = (),
+) -> tuple[Any, Any, Optional[str]]:
+    """Validate DeepSeek's current business envelope and return its payload."""
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"DeepSeek {context} returned an invalid JSON response")
+
+    response_data = payload.get("data")
+    if isinstance(response_data, dict):
+        code = response_data.get("biz_code", payload.get("code"))
+        message = response_data.get("biz_msg") or payload.get("msg")
+        biz_data = response_data.get("biz_data")
+    else:
+        code = payload.get("code")
+        message = payload.get("msg")
+        biz_data = None
+
+    allowed_code_strings = {str(value) for value in allowed_codes}
+    if code not in (None, 0, "0") and str(code) not in allowed_code_strings:
+        detail = message or "unknown business error"
+        raise RuntimeError(f"DeepSeek {context} failed ({code}): {detail}")
+    return code, biz_data, message
+
+
 def _build_chat_headers(source_headers: Optional[dict], authorization: str) -> dict:
     """Build JSON request headers while retaining current browser-bound values."""
     normalized = _normalized_headers(source_headers)
     headers = dict(CHAT_HEADER_DEFAULTS)
+    timezone_offset = datetime.now().astimezone().utcoffset()
+    headers["x-client-timezone-offset"] = str(
+        -int(timezone_offset.total_seconds()) if timezone_offset else 0
+    )
     headers.update(
         {
             name: normalized[name]
@@ -293,297 +190,6 @@ def _build_chat_headers(source_headers: Optional[dict], authorization: str) -> d
     return headers
 
 
-async def iter_deepseek_sse(response) -> AsyncIterator[tuple[str, Any]]:
-    """Parse DeepSeek SSE frames without losing their ``event`` field."""
-    event_type = "message"
-    data_lines: list[str] = []
-
-    def decode_event() -> Optional[tuple[str, Any]]:
-        if not data_lines:
-            return None
-        raw_data = "\n".join(data_lines)
-        if raw_data.strip() == "[DONE]":
-            return None
-        try:
-            return event_type, json.loads(raw_data)
-        except json.JSONDecodeError as error:
-            raise ValueError(f"Invalid DeepSeek SSE JSON data: {raw_data!r}") from error
-
-    async for raw_line in response.iter_lines():
-        line = (
-            raw_line.decode("utf-8")
-            if isinstance(raw_line, (bytes, bytearray))
-            else str(raw_line)
-        ).rstrip("\r")
-
-        if not line:
-            event = decode_event()
-            if event is not None:
-                yield event
-            event_type = "message"
-            data_lines = []
-            continue
-
-        if line.startswith(":"):
-            continue
-
-        field_name, separator, field_value = line.partition(":")
-        if not separator:
-            continue
-        if field_value.startswith(" "):
-            field_value = field_value[1:]
-        if field_name == "event":
-            event_type = field_value or "message"
-        elif field_name == "data":
-            data_lines.append(field_value)
-
-    event = decode_event()
-    if event is not None:
-        yield event
-
-
-@dataclass
-class _DeepSeekStreamState:
-    message_id: Any = None
-    status: Optional[str] = None
-    closed: bool = False
-    active_kind: Optional[str] = "response"
-    emitted: dict[str, str] = field(
-        default_factory=lambda: {"reasoning": "", "response": ""}
-    )
-
-    def append(self, kind: str, content: str) -> str:
-        self.emitted[kind] += content
-        return content
-
-    def snapshot_delta(self, kind: str, content: str) -> str:
-        """Return only text not already emitted by an earlier stream attempt."""
-        previous = self.emitted[kind]
-        if content.startswith(previous):
-            delta = content[len(previous):]
-            self.emitted[kind] = content
-            return delta
-        if previous.startswith(content):
-            return ""
-
-        max_overlap = min(len(previous), len(content))
-        for overlap in range(max_overlap, 0, -1):
-            if previous.endswith(content[:overlap]):
-                delta = content[overlap:]
-                self.emitted[kind] += delta
-                return delta
-
-        self.emitted[kind] += content
-        return content
-
-
-def _fragment_kind(fragment: dict) -> Optional[str]:
-    fragment_type = str(fragment.get("type", "")).upper()
-    if not fragment_type:
-        # Preserve compatibility with older snapshots that omitted the type.
-        return "response"
-    if fragment_type in DEEPSEEK_RESPONSE_FRAGMENT_TYPES:
-        return "response"
-    if fragment_type in DEEPSEEK_REASONING_FRAGMENT_TYPES:
-        return "reasoning"
-    if fragment_type in DEEPSEEK_METADATA_FRAGMENT_TYPES:
-        return None
-    return None
-
-
-def _stream_output(kind: str, content: str):
-    if not content:
-        return None
-    return Reasoning(content) if kind == "reasoning" else content
-
-
-def _record_response_message_id(
-        state: _DeepSeekStreamState,
-        conversation: JsonConversation,
-        message_id: Any,
-) -> None:
-    if message_id is not None:
-        state.message_id = message_id
-        conversation.parent_message_id = message_id
-
-
-def _record_stream_status(
-        state: _DeepSeekStreamState,
-        path: str,
-        value: Any,
-        *,
-        operation: Optional[str] = None,
-        source: Literal["patch", "snapshot"] = "snapshot",
-) -> bool:
-    if path not in {"response/status", "quasi_status", "response/quasi_status"}:
-        return False
-    status = str(value).upper()
-    if status in DEEPSEEK_MESSAGE_STATUSES:
-        state.status = status
-        if status == "INCOMPLETE":
-            interpretation = "requires_continue"
-        else:
-            interpretation = None
-
-        operation_label = operation if operation is not None else "none"
-        message = (
-            "DeepSeekAuth: Stream status: "
-            f"status={status} source={source} operation={operation_label}"
-        )
-        if interpretation is not None:
-            message += f" interpretation={interpretation}"
-        debug.log(message)
-    return True
-
-
-def _stream_log_value(value: Any) -> str:
-    """Format a small, non-content stream field for diagnostic logging."""
-    if value is None:
-        return "none"
-    if isinstance(value, bool):
-        return str(value).lower()
-    if isinstance(value, (int, float)):
-        return str(value)
-    if isinstance(value, str):
-        sanitized = "".join(
-            character
-            if character.isalnum() or character in {"_", "-", "."}
-            else "_"
-            for character in value[:64]
-        )
-        return sanitized or "empty"
-    return type(value).__name__
-
-
-def _process_fragments(
-        fragments: list,
-        state: _DeepSeekStreamState,
-        *,
-        snapshot: bool,
-) -> list:
-    chunks = []
-    content_by_kind = {"reasoning": "", "response": ""}
-    kind_order = []
-
-    for fragment in fragments:
-        if not isinstance(fragment, dict):
-            continue
-        kind = _fragment_kind(fragment)
-        state.active_kind = kind
-        content = fragment.get("content")
-        if kind is None or not isinstance(content, str):
-            continue
-
-        if snapshot:
-            if kind not in kind_order:
-                kind_order.append(kind)
-            content_by_kind[kind] += content
-            continue
-
-        output = _stream_output(kind, state.append(kind, content))
-        if output is not None:
-            chunks.append(output)
-
-    if snapshot:
-        for kind in kind_order:
-            output = _stream_output(
-                kind,
-                state.snapshot_delta(kind, content_by_kind[kind]),
-            )
-            if output is not None:
-                chunks.append(output)
-
-    return chunks
-
-
-def _process_stream_payload(
-        payload: Any,
-        state: _DeepSeekStreamState,
-        conversation: JsonConversation,
-) -> list:
-    """Apply one DeepSeek message event and return newly visible output chunks."""
-    if not isinstance(payload, dict):
-        return []
-
-    chunks = []
-    _record_response_message_id(
-        state, conversation, payload.get("response_message_id")
-    )
-
-    operation = payload.get("o")
-    value = payload.get("v")
-
-    if operation == "BATCH" and isinstance(value, list):
-        for batch_item in value:
-            chunks.extend(
-                _process_stream_payload(batch_item, state, conversation)
-            )
-        return chunks
-
-    if isinstance(value, dict) and isinstance(value.get("response"), dict):
-        response_obj = value["response"]
-        _record_response_message_id(
-            state, conversation, response_obj.get("message_id")
-        )
-        response_status = response_obj.get("status")
-        if response_status is not None:
-            _record_stream_status(
-                state,
-                "response/status",
-                response_status,
-                source="snapshot",
-            )
-
-        fragments = response_obj.get("fragments", [])
-        if isinstance(fragments, list):
-            chunks.extend(_process_fragments(fragments, state, snapshot=True))
-        return chunks
-
-    path = payload.get("p")
-    if (
-            path == "response/fragments"
-            and operation in {"SET", "APPEND"}
-            and isinstance(value, list)
-    ):
-        chunks.extend(
-            _process_fragments(value, state, snapshot=operation == "SET")
-        )
-        return chunks
-
-    if isinstance(path, str) and "v" in payload:
-        if _record_stream_status(
-                state,
-                path,
-                value,
-                operation=operation,
-                source="patch",
-        ):
-            return chunks
-        if path.endswith("/content") and isinstance(value, str):
-            kind = state.active_kind
-            if kind is None:
-                return chunks
-            content = (
-                state.snapshot_delta(kind, value)
-                if operation == "SET"
-                else state.append(kind, value)
-            )
-            output = _stream_output(kind, content)
-            if output is not None:
-                chunks.append(output)
-        return chunks
-
-    if isinstance(value, str):
-        kind = state.active_kind
-        if kind is None:
-            return chunks
-        output = _stream_output(kind, state.append(kind, value))
-        if output is not None:
-            chunks.append(output)
-
-    return chunks
-
-
 def _build_upload_session_headers(headers: dict) -> dict:
     """Copy shared headers without values that would corrupt a multipart upload."""
     excluded_headers = {"content-type", "x-ds-pow-response"}
@@ -594,15 +200,47 @@ def _build_upload_session_headers(headers: dict) -> dict:
     }
 
 
-def generate_client_stream_id() -> str:
-    """
-    Generate DeepSeek client_stream_id in format: YYYYMMDD-<hex_string>
-    Based on HAR file analysis of DeepSeek web client.
-    """
-    date_str = datetime.now().strftime("%Y%m%d")
-    # Generate a random hex string (16 chars like in HAR)
-    hex_part = uuid.uuid4().hex[:16]
-    return f"{date_str}-{hex_part}"
+def _resolve_upload_metadata(data: bytes, filename: Optional[str]) -> tuple[str, str]:
+    """Resolve a stable filename and MIME type without rejecting text/code files."""
+    if filename:
+        guessed_type, _encoding = mimetypes.guess_type(filename, strict=False)
+        if guessed_type:
+            return filename, guessed_type
+        try:
+            _extension, detected_type = detect_file_type(data)
+        except ValueError:
+            detected_type = "application/octet-stream"
+        return filename, detected_type
+
+    extension, detected_type = detect_file_type(data)
+    return f"file-{len(data)}{extension}", detected_type
+
+
+def _build_completion_payload(
+        conversation: JsonConversation,
+        *,
+        prompt: str,
+        model_type: str,
+        ref_file_ids: list[str],
+        thinking_enabled: bool,
+        search_enabled: bool,
+) -> dict:
+    """Build the current DeepSeek web completion request contract."""
+    chat_session_id = getattr(conversation, "chat_session_id", None)
+    if not chat_session_id:
+        raise ValueError("DeepSeek chat_session_id is required for completion")
+
+    return {
+        "action": None,
+        "chat_session_id": chat_session_id,
+        "parent_message_id": getattr(conversation, "parent_message_id", None),
+        "model_type": model_type,
+        "prompt": prompt,
+        "ref_file_ids": ref_file_ids,
+        "thinking_enabled": thinking_enabled,
+        "search_enabled": search_enabled,
+        "preempt": False,
+    }
 
 
 class DeepSeek(AsyncGeneratorProvider, ProviderModelMixin):
@@ -643,8 +281,11 @@ class DeepSeek(AsyncGeneratorProvider, ProviderModelMixin):
             await raise_for_status(response)
             pow_data = await response.json()
 
+        _code, biz_data, _message = _unwrap_biz_response(
+            pow_data, "PoW challenge"
+        )
         try:
-            challenge = pow_data["data"]["biz_data"]["challenge"]
+            challenge = biz_data["challenge"]
         except (KeyError, TypeError) as error:
             raise RuntimeError(
                 f"DeepSeek returned an invalid PoW challenge for {target_path}"
@@ -655,13 +296,18 @@ class DeepSeek(AsyncGeneratorProvider, ProviderModelMixin):
                 "DeepSeek returned a PoW challenge for an unexpected target path: "
                 f"{challenge.get('target_path')!r}"
             )
+        if challenge.get("algorithm") != DEEPSEEK_POW_ALGORITHM:
+            raise RuntimeError(
+                "DeepSeek returned an unsupported PoW algorithm: "
+                f"{challenge.get('algorithm')!r}"
+            )
 
         debug.log(
             "DeepSeekAuth: Challenge: "
             f"algorithm={challenge.get('algorithm')}, "
             f"difficulty={challenge.get('difficulty')}"
         )
-        pow_response = DeepSeekPOW().solve_challenge(challenge)
+        pow_response = await asyncio.to_thread(_solve_pow_challenge, challenge)
         debug.log(f"DeepSeekAuth: PoW challenge solved for {target_path}")
         return pow_response
 
@@ -680,8 +326,7 @@ class DeepSeek(AsyncGeneratorProvider, ProviderModelMixin):
         Returns dict with file info including file_id
         """
         data_bytes = to_bytes(file)
-        extension, file_type = detect_file_type(data_bytes)
-        filename = filename or f"file-{len(data_bytes)}{extension}"
+        filename, file_type = _resolve_upload_metadata(data_bytes, filename)
 
         debug.log(f"DeepSeekAuth: Starting file upload: {filename} ({len(data_bytes)} bytes)")
         debug.log(f"DeepSeekAuth: Upload endpoint: {FILE_UPLOAD_ENDPOINT}")
@@ -714,16 +359,17 @@ class DeepSeek(AsyncGeneratorProvider, ProviderModelMixin):
                 )
             result = await response.json()
 
+        _code, biz_data, _message = _unwrap_biz_response(result, "file upload")
         response_data = result.get("data") if isinstance(result, dict) else None
-        biz_data = response_data.get("biz_data") if isinstance(response_data, dict) else None
         file_id = biz_data.get("id") if isinstance(biz_data, dict) else None
         if not file_id and isinstance(response_data, dict):
             # Keep compatibility with the older, unnested response shape.
             file_id = response_data.get("id")
 
-        if result.get("code") not in (None, 0) or not file_id:
-            message = result.get("msg") or "missing data.biz_data.id"
-            raise RuntimeError(f"DeepSeek file upload failed: {message}")
+        if not file_id:
+            raise RuntimeError(
+                "DeepSeek file upload failed: missing data.biz_data.id"
+            )
 
         debug.log(f"DeepSeekAuth: File uploaded successfully, file_id: {file_id}")
         return {
@@ -731,6 +377,31 @@ class DeepSeek(AsyncGeneratorProvider, ProviderModelMixin):
             "filename": filename,
             "size": len(data_bytes),
         }
+
+    @classmethod
+    async def upload_files(
+            cls,
+            session: StreamSession,
+            media: list,
+            *,
+            thinking_enabled: bool = False,
+            model_type: str = "default",
+    ) -> list[str]:
+        """Upload and parse every media item, preserving caller order."""
+        file_ids = []
+        for file_bytes, filename in media:
+            upload_result = await cls.upload_file(
+                session,
+                file_bytes,
+                filename,
+                thinking_enabled=thinking_enabled,
+                model_type=model_type,
+            )
+            file_id = upload_result["file_id"]
+            await cls.wait_for_file_parsed(session, file_id)
+            file_ids.append(file_id)
+            debug.log(f"DeepSeekAuth: Using file_id: {file_id}")
+        return file_ids
 
     @classmethod
     async def wait_for_file_parsed(
@@ -753,8 +424,9 @@ class DeepSeek(AsyncGeneratorProvider, ProviderModelMixin):
                 await raise_for_status(response)
                 result = await response.json()
 
-            response_data = result.get("data") if isinstance(result, dict) else None
-            biz_data = response_data.get("biz_data") if isinstance(response_data, dict) else None
+            _code, biz_data, _message = _unwrap_biz_response(
+                result, "file status"
+            )
             files = biz_data.get("files") if isinstance(biz_data, dict) else None
             file_info = files[0] if isinstance(files, list) and files else {}
             status = str(file_info.get("status", "")).upper()
@@ -762,8 +434,8 @@ class DeepSeek(AsyncGeneratorProvider, ProviderModelMixin):
             if status == "SUCCESS":
                 debug.log(f"DeepSeekAuth: File parsing completed, file_id: {file_id}")
                 return
-            if status in {"FAILED", "ERROR"}:
-                error_code = file_info.get("error_code") or "unknown"
+            if status in DEEPSEEK_FILE_FAILURE_STATUSES:
+                error_code = file_info.get("error_code") or status
                 raise RuntimeError(
                     f"DeepSeek file parsing failed for {file_id}: {error_code}"
                 )
@@ -777,111 +449,28 @@ class DeepSeek(AsyncGeneratorProvider, ProviderModelMixin):
     @classmethod
     async def delete_chat_session(
             cls, session: StreamSession, chat_session_id: str, headers: dict
-    ):
-        """
-        Delete a chat session from DeepSeek.
+    ) -> bool:
+        """Delete one session with the observed POST contract."""
+        try:
+            async with session.post(
+                    CHAT_SESSION_DELETE_ENDPOINT,
+                    headers=headers,
+                    json={"chat_session_id": chat_session_id},
+            ) as response:
+                await raise_for_status(response)
+                result = await response.json()
+            _unwrap_biz_response(result, "chat session deletion")
+        except Exception as error:
+            debug.error(f"DeepSeekAuth: Chat session deletion failed: {error}")
+            return False
 
-        Tries multiple approaches (DELETE/POST with JSON body/query params) until one succeeds.
-
-        Args:
-            session: StreamSession instance
-            chat_session_id: The session ID to delete
-            headers: Request headers including authorization
-        """
-
-        # Try different deletion approaches - POST with JSON body first (as seen in HAR)
-        deletion_methods = [
-            {
-                "name": "POST with JSON body",
-                "method": "post",
-                "url": CHAT_SESSION_DELETE_ENDPOINT,
-                "use_json_body": True,
-            },
-            {
-                "name": "POST with query params",
-                "method": "post",
-                "url": f"{CHAT_SESSION_DELETE_ENDPOINT}?chat_session_id={chat_session_id}",
-                "use_json_body": False,
-            },
-            {
-                "name": "DELETE with JSON body",
-                "method": "delete",
-                "url": CHAT_SESSION_DELETE_ENDPOINT,
-                "use_json_body": True,
-            },
-            {
-                "name": "DELETE with query params",
-                "method": "delete",
-                "url": f"{CHAT_SESSION_DELETE_ENDPOINT}?chat_session_id={chat_session_id}",
-                "use_json_body": False,
-            },
-        ]
-
-        for method_info in deletion_methods:
-            try:
-                debug.log(f"DeepSeekAuth: Attempting deletion - {method_info['name']}")
-                debug.log(f"DeepSeekAuth:   URL: {method_info['url']}")
-
-                # Prepare request parameters
-                request_params = {}
-                if method_info["use_json_body"]:
-                    request_params["json"] = {"chat_session_id": chat_session_id}
-                    debug.log(
-                        f"DeepSeekAuth:   JSON body: {{'chat_session_id': '{chat_session_id}'}}"
-                    )
-                else:
-                    debug.log(
-                        f"DeepSeekAuth:   Query params: chat_session_id={chat_session_id}"
-                    )
-
-                # Make the request - pass headers to each request
-                if method_info["method"] == "delete":
-                    async with session.delete(
-                            method_info["url"], headers=headers, **request_params
-                    ) as response:
-                        debug.log(f"DeepSeekAuth:   Response status: {response.status}")
-                        debug.log(
-                            f"DeepSeekAuth:   Response headers: {dict(response.headers)}"
-                        )
-                        await raise_for_status(response)
-                        result = await response.json()
-                        debug.log(f"DeepSeekAuth:   Response body: {result}")
-                        debug.log(
-                            f"DeepSeekAuth: Chat session deleted successfully using {method_info['name']}"
-                        )
-                        return  # Success - exit early
-                else:  # POST
-                    async with session.post(
-                            method_info["url"], headers=headers, **request_params
-                    ) as response:
-                        debug.log(f"DeepSeekAuth:   Response status: {response.status}")
-                        debug.log(
-                            f"DeepSeekAuth:   Response headers: {dict(response.headers)}"
-                        )
-                        await raise_for_status(response)
-                        result = await response.json()
-                        debug.log(f"DeepSeekAuth:   Response body: {result}")
-                        debug.log(
-                            f"DeepSeekAuth: Chat session deleted successfully using {method_info['name']}"
-                        )
-                        return  # Success - exit early
-
-            except Exception as e:
-                debug.error(
-                    f"DeepSeekAuth: Failed to delete using {method_info['name']}: {e}"
-                )
-                # Continue to next method
-
-        # All methods failed
-        debug.error(
-            f"DeepSeekAuth: All deletion methods failed for session {chat_session_id}"
-        )
-        # Don't raise - deletion is not critical
+        debug.log("DeepSeekAuth: Chat session deleted successfully")
+        return True
 
     @classmethod
     async def get_quota(cls, **kwargs):
         cookies = get_cookies(cls.cookie_domain, False)
-        headers = get_headers(cls.cookie_domain)
+        headers = _normalized_headers(get_headers(cls.cookie_domain) or {})
         if cookies and headers.get("authorization"):
             return {"success": True}
         raise MissingAuthError("DeepSeekAuth: No authentication found.")
@@ -928,6 +517,21 @@ class DeepSeek(AsyncGeneratorProvider, ProviderModelMixin):
                 await raise_for_status(response)
                 content_type = response.headers.get("content-type", "")
                 if "text/event-stream" not in content_type.lower():
+                    result = await response.json()
+                    code, biz_data, _message = _unwrap_biz_response(
+                        result,
+                        "chat stream",
+                        allowed_codes=(RESUME_MESSAGE_GOT_FULL_MESSAGE_CODE,),
+                    )
+                    if str(code) == str(RESUME_MESSAGE_GOT_FULL_MESSAGE_CODE):
+                        for chunk in _process_full_message(
+                                biz_data, state, conversation
+                        ):
+                            yield chunk
+                        finish_reason = DEEPSEEK_FINISH_REASONS.get(state.status)
+                        if finish_reason is not None:
+                            yield FinishReason(finish_reason)
+                        return
                     raise RuntimeError(
                         "Expected SSE response but got content-type: "
                         f"{content_type or 'unknown'}"
@@ -1135,7 +739,10 @@ class DeepSeek(AsyncGeneratorProvider, ProviderModelMixin):
         # Try to get auth from HAR file first
         if cookies is None:
             cookies = get_cookies(cls.cookie_domain, False)
-            source_headers = get_headers(cls.cookie_domain) or {}
+            discovered_headers = get_headers(cls.cookie_domain) or {}
+            # Explicit caller headers override browser/HAR values, including when
+            # their casing differs (normalization happens below).
+            source_headers = {**discovered_headers, **source_headers}
             normalized_source_headers = _normalized_headers(source_headers)
             if cookies and normalized_source_headers.get("authorization"):
                 debug.log(
@@ -1174,8 +781,8 @@ class DeepSeek(AsyncGeneratorProvider, ProviderModelMixin):
         prompt = get_last_user_message(messages)
 
         # Determine thinking mode
-        if reasoning_effort is not None and reasoning_effort != "none":
-            thinking_enabled = True
+        if reasoning_effort is not None:
+            thinking_enabled = reasoning_effort != "none"
         else:
             thinking_enabled = bool(model) and "deepseek-r1" in model
         model_type = kwargs.get("model_type", "default")  # "default", "expert", "vision"
@@ -1200,6 +807,9 @@ class DeepSeek(AsyncGeneratorProvider, ProviderModelMixin):
                 async with session.post(CHAT_SESSION_CREATE_ENDPOINT) as response:
                     await raise_for_status(response)
                     session_data = await response.json()
+                    _unwrap_biz_response(
+                        session_data, "chat session creation"
+                    )
                     chat_session_id = _extract_chat_session_id(session_data)
                     if chat_session_id:
                         conversation.chat_session_id = chat_session_id
@@ -1208,10 +818,10 @@ class DeepSeek(AsyncGeneratorProvider, ProviderModelMixin):
                         )
                     else:
                         debug.error(
-                            f"DeepSeekAuth: Unexpected session response: {session_data}"
+                            "DeepSeekAuth: Session response did not include an id"
                         )
-                        raise Exception(
-                            f"Failed to parse session response: {session_data}"
+                        raise RuntimeError(
+                            "DeepSeek chat session creation failed: missing session id"
                         )
         else:
             debug.log(
@@ -1224,8 +834,6 @@ class DeepSeek(AsyncGeneratorProvider, ProviderModelMixin):
         # Upload file if provided - use HTTP/1.1 to avoid HTTP/2 stream errors
         ref_file_ids = []
         if media is not None and len(media) > 0:
-            # Take first file from media list
-            file_bytes, filename = media[0]
             upload_session_headers = _build_upload_session_headers(headers)
             async with StreamSession(
                     headers=upload_session_headers,
@@ -1236,40 +844,23 @@ class DeepSeek(AsyncGeneratorProvider, ProviderModelMixin):
                     if has_curl_cffi
                     else None,  # Force HTTP/1.1 to avoid HTTP/2 stream errors
             ) as session:
-                upload_result = await cls.upload_file(
+                ref_file_ids = await cls.upload_files(
                     session,
-                    file_bytes,
-                    filename,
+                    media,
                     thinking_enabled=thinking_enabled,
                     model_type=model_type,
                 )
-                await cls.wait_for_file_parsed(session, upload_result["file_id"])
-                ref_file_ids.append(upload_result["file_id"])
-                debug.log(f"DeepSeekAuth: Using file_id: {upload_result['file_id']}")
 
         # Build request data
 
-        json_data = {
-            "action": None,
-            "chat_session_id": getattr(
-                conversation, "chat_session_id", str(uuid.uuid4())
-            ),
-            "model_type": model_type,
-            # "parent_message_id":None,
-            # "preempt":False,
-            "prompt": prompt,
-            "ref_file_ids": ref_file_ids,
-            "thinking_enabled": thinking_enabled,
-            "search_enabled": web_search,
-            "client_stream_id": generate_client_stream_id(),
-        }
-
-        # Add parent_message_id if continuing conversation
-        if (
-                hasattr(conversation, "parent_message_id")
-                and conversation.parent_message_id
-        ):
-            json_data["parent_message_id"] = conversation.parent_message_id
+        json_data = _build_completion_payload(
+            conversation,
+            prompt=prompt,
+            model_type=model_type,
+            ref_file_ids=ref_file_ids,
+            thinking_enabled=thinking_enabled,
+            search_enabled=web_search,
+        )
 
         async with StreamSession(
                 headers=headers, cookies=cookies, proxy=proxy, impersonate="chrome"

--- a/g4f/Provider/needs_auth/DeepSeek.py
+++ b/g4f/Provider/needs_auth/DeepSeek.py
@@ -1,28 +1,29 @@
 from __future__ import annotations
 
-import os
-import json
-import uuid
+import asyncio
 import base64
+import json
+import os
+import uuid
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Optional, Literal
+from typing import Any, AsyncIterator, Optional, Literal
 
-from g4f.typing import AsyncResult, Messages, Cookies
-from g4f.requests import StreamSession, raise_for_status, sse_stream, FormData
-from g4f.cookies import get_cookies, get_headers, get_cookies_dir
-from g4f.providers.response import (
-    JsonConversation,
-    JsonRequest,
-    JsonResponse,
-    Reasoning,
-    FinishReason,
-)
+from g4f import debug
+from g4f.cookies import get_cookies, get_headers
+from g4f.errors import MissingAuthError
+from g4f.image import to_bytes, detect_file_type
 from g4f.providers.base_provider import AsyncGeneratorProvider, ProviderModelMixin
 from g4f.providers.helper import get_last_user_message
-from g4f import debug
-from g4f.errors import MissingAuthError
-from g4f.image import to_bytes
+from g4f.providers.response import (
+    FinishReason,
+    JsonConversation,
+    JsonRequest,
+    Reasoning,
+)
+from g4f.requests import StreamSession, raise_for_status, FormData
+from g4f.typing import AsyncResult, Messages, Cookies
 
 # Inline PoW (Proof of Work) implementation for DeepSeek
 # Based on reference implementation in gpt4free/projects/deepseek4free/dsk/pow.py
@@ -90,7 +91,7 @@ class DeepSeekHash:
         return ptr, length
 
     def calculate_hash(
-        self, algorithm: str, challenge: str, salt: str, difficulty: int, expire_at: int
+            self, algorithm: str, challenge: str, salt: str, difficulty: int, expire_at: int
     ) -> int:
         prefix = f"{salt}_{expire_at}_"
         retptr = self.instance.exports(self.store)["__wbindgen_add_to_stack_pointer"](
@@ -113,13 +114,13 @@ class DeepSeekHash:
 
             memory_view = self.memory.data_ptr(self.store)
             status = int.from_bytes(
-                bytes(memory_view[retptr : retptr + 4]), byteorder="little", signed=True
+                bytes(memory_view[retptr: retptr + 4]), byteorder="little", signed=True
             )
 
             if status == 0:
                 return None
 
-            value_bytes = bytes(memory_view[retptr + 8 : retptr + 16])
+            value_bytes = bytes(memory_view[retptr + 8: retptr + 16])
             value = numpy.frombuffer(value_bytes, dtype=numpy.float64)[0]
 
             return int(value)
@@ -162,10 +163,435 @@ class DeepSeekPOW:
 DEEPSEEK_URL = "https://chat.deepseek.com"
 DEEPSEEK_DOMAIN = "chat.deepseek.com"
 CHAT_SESSION_CREATE_ENDPOINT = f"{DEEPSEEK_URL}/api/v0/chat_session/create"
+CHAT_SESSION_CONTINUE_ENDPOINT = f"{DEEPSEEK_URL}/api/v0/chat/continue"
+CHAT_SESSION_RESUME_STREAM_ENDPOINT = f"{DEEPSEEK_URL}/api/v0/chat/resume_stream"
 CHAT_SESSION_DELETE_ENDPOINT = f"{DEEPSEEK_URL}/api/v0/chat_session/delete"
 CHAT_COMPLETION_ENDPOINT = f"{DEEPSEEK_URL}/api/v0/chat/completion"
 POW_CHALLENGE_ENDPOINT = f"{DEEPSEEK_URL}/api/v0/chat/create_pow_challenge"
-FILE_UPLOAD_ENDPOINT = f"{DEEPSEEK_URL}/v0/file/upload_file"
+CHAT_COMPLETION_PATH = "/api/v0/chat/completion"
+FILE_UPLOAD_PATH = "/api/v0/file/upload_file"
+FILE_UPLOAD_ENDPOINT = f"{DEEPSEEK_URL}{FILE_UPLOAD_PATH}"
+FILE_FETCH_ENDPOINT = f"{DEEPSEEK_URL}/api/v0/file/fetch_files"
+
+DEEPSEEK_MESSAGE_STATUSES = {
+    "FINISHED",
+    "CONTENT_FILTER",
+    "CONTEXT_LENGTH_EXCEEDED",
+    "INCOMPLETE",
+    "WIP",
+    "TIMEOUT",
+}
+DEEPSEEK_FINISH_REASONS = {
+    "FINISHED": "stop",
+    "CONTENT_FILTER": "content_filter",
+    "CONTEXT_LENGTH_EXCEEDED": "length",
+    "INCOMPLETE": "incomplete",
+    "WIP": "wip",
+    "TIMEOUT": "timeout",
+}
+
+DEEPSEEK_RESPONSE_FRAGMENT_TYPES = {"RESPONSE", "TEMPLATE_RESPONSE"}
+DEEPSEEK_REASONING_FRAGMENT_TYPES = {
+    "THINK",
+    "THINKING",
+    "REASONING",
+    "SEARCH",
+    "TOOL_SEARCH",
+    "TOOL_OPEN",
+    "TOOL_FIND",
+}
+DEEPSEEK_METADATA_FRAGMENT_TYPES = {
+    "REQUEST",
+    "FILE",
+    "TIP",
+    "READ_LINK",
+}
+DEEPSEEK_STREAM_OPERATIONS = {"SET", "BATCH", "APPEND"}
+
+CHAT_HEADER_DEFAULTS = {
+    "accept": "*/*",
+    "accept-language": "en-US,en;q=0.9",
+    "cache-control": "no-cache",
+    "content-type": "application/json",
+    "origin": DEEPSEEK_URL,
+    "referer": f"{DEEPSEEK_URL}/",
+    "user-agent": (
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36"
+    ),
+    "x-app-version": "20241129.1",
+    "x-client-bundle-id": "com.deepseek.chat",
+    "x-client-locale": "en_US",
+    "x-client-platform": "web",
+    "x-client-timezone-offset": "-28800",
+    "x-client-version": "2.4.0",
+}
+
+CHAT_HEADER_PASSTHROUGH = {
+    "accept-language",
+    "dnt",
+    "priority",
+    "referer",
+    "sec-ch-ua",
+    "sec-ch-ua-arch",
+    "sec-ch-ua-bitness",
+    "sec-ch-ua-full-version",
+    "sec-ch-ua-full-version-list",
+    "sec-ch-ua-mobile",
+    "sec-ch-ua-model",
+    "sec-ch-ua-platform",
+    "sec-ch-ua-platform-version",
+    "sec-fetch-dest",
+    "sec-fetch-mode",
+    "sec-fetch-site",
+    "user-agent",
+    "x-app-version",
+    "x-client-bundle-id",
+    "x-client-locale",
+    "x-client-platform",
+    "x-client-timezone-offset",
+    "x-client-version",
+    "x-hif-leim",
+}
+
+
+def _normalized_headers(headers: Optional[dict]) -> dict:
+    return {
+        str(key).lower(): value
+        for key, value in (headers or {}).items()
+        if value is not None
+    }
+
+
+def _extract_chat_session_id(session_data: Any) -> Optional[str]:
+    """Read the current and legacy chat-session response shapes."""
+    data = session_data.get("data") if isinstance(session_data, dict) else None
+    biz_data = data.get("biz_data") if isinstance(data, dict) else None
+    if not isinstance(biz_data, dict):
+        return None
+
+    chat_session = biz_data.get("chat_session")
+    if isinstance(chat_session, dict) and chat_session.get("id"):
+        return chat_session["id"]
+    return biz_data.get("id")
+
+
+def _build_chat_headers(source_headers: Optional[dict], authorization: str) -> dict:
+    """Build JSON request headers while retaining current browser-bound values."""
+    normalized = _normalized_headers(source_headers)
+    headers = dict(CHAT_HEADER_DEFAULTS)
+    headers.update(
+        {
+            name: normalized[name]
+            for name in CHAT_HEADER_PASSTHROUGH
+            if name in normalized
+        }
+    )
+    headers["authorization"] = authorization
+    # A PoW answer is valid only for the challenge/target that produced it.
+    headers.pop("x-ds-pow-response", None)
+    return headers
+
+
+async def iter_deepseek_sse(response) -> AsyncIterator[tuple[str, Any]]:
+    """Parse DeepSeek SSE frames without losing their ``event`` field."""
+    event_type = "message"
+    data_lines: list[str] = []
+
+    def decode_event() -> Optional[tuple[str, Any]]:
+        if not data_lines:
+            return None
+        raw_data = "\n".join(data_lines)
+        if raw_data.strip() == "[DONE]":
+            return None
+        try:
+            return event_type, json.loads(raw_data)
+        except json.JSONDecodeError as error:
+            raise ValueError(f"Invalid DeepSeek SSE JSON data: {raw_data!r}") from error
+
+    async for raw_line in response.iter_lines():
+        line = (
+            raw_line.decode("utf-8")
+            if isinstance(raw_line, (bytes, bytearray))
+            else str(raw_line)
+        ).rstrip("\r")
+
+        if not line:
+            event = decode_event()
+            if event is not None:
+                yield event
+            event_type = "message"
+            data_lines = []
+            continue
+
+        if line.startswith(":"):
+            continue
+
+        field_name, separator, field_value = line.partition(":")
+        if not separator:
+            continue
+        if field_value.startswith(" "):
+            field_value = field_value[1:]
+        if field_name == "event":
+            event_type = field_value or "message"
+        elif field_name == "data":
+            data_lines.append(field_value)
+
+    event = decode_event()
+    if event is not None:
+        yield event
+
+
+@dataclass
+class _DeepSeekStreamState:
+    message_id: Any = None
+    status: Optional[str] = None
+    closed: bool = False
+    active_kind: Optional[str] = "response"
+    emitted: dict[str, str] = field(
+        default_factory=lambda: {"reasoning": "", "response": ""}
+    )
+
+    def append(self, kind: str, content: str) -> str:
+        self.emitted[kind] += content
+        return content
+
+    def snapshot_delta(self, kind: str, content: str) -> str:
+        """Return only text not already emitted by an earlier stream attempt."""
+        previous = self.emitted[kind]
+        if content.startswith(previous):
+            delta = content[len(previous):]
+            self.emitted[kind] = content
+            return delta
+        if previous.startswith(content):
+            return ""
+
+        max_overlap = min(len(previous), len(content))
+        for overlap in range(max_overlap, 0, -1):
+            if previous.endswith(content[:overlap]):
+                delta = content[overlap:]
+                self.emitted[kind] += delta
+                return delta
+
+        self.emitted[kind] += content
+        return content
+
+
+def _fragment_kind(fragment: dict) -> Optional[str]:
+    fragment_type = str(fragment.get("type", "")).upper()
+    if not fragment_type:
+        # Preserve compatibility with older snapshots that omitted the type.
+        return "response"
+    if fragment_type in DEEPSEEK_RESPONSE_FRAGMENT_TYPES:
+        return "response"
+    if fragment_type in DEEPSEEK_REASONING_FRAGMENT_TYPES:
+        return "reasoning"
+    if fragment_type in DEEPSEEK_METADATA_FRAGMENT_TYPES:
+        return None
+    return None
+
+
+def _stream_output(kind: str, content: str):
+    if not content:
+        return None
+    return Reasoning(content) if kind == "reasoning" else content
+
+
+def _record_response_message_id(
+        state: _DeepSeekStreamState,
+        conversation: JsonConversation,
+        message_id: Any,
+) -> None:
+    if message_id is not None:
+        state.message_id = message_id
+        conversation.parent_message_id = message_id
+
+
+def _record_stream_status(
+        state: _DeepSeekStreamState,
+        path: str,
+        value: Any,
+        *,
+        operation: Optional[str] = None,
+        source: Literal["patch", "snapshot"] = "snapshot",
+) -> bool:
+    if path not in {"response/status", "quasi_status", "response/quasi_status"}:
+        return False
+    status = str(value).upper()
+    if status in DEEPSEEK_MESSAGE_STATUSES:
+        state.status = status
+        if status == "INCOMPLETE":
+            interpretation = "requires_continue"
+        else:
+            interpretation = None
+
+        operation_label = operation if operation is not None else "none"
+        message = (
+            "DeepSeekAuth: Stream status: "
+            f"status={status} source={source} operation={operation_label}"
+        )
+        if interpretation is not None:
+            message += f" interpretation={interpretation}"
+        debug.log(message)
+    return True
+
+
+def _stream_log_value(value: Any) -> str:
+    """Format a small, non-content stream field for diagnostic logging."""
+    if value is None:
+        return "none"
+    if isinstance(value, bool):
+        return str(value).lower()
+    if isinstance(value, (int, float)):
+        return str(value)
+    if isinstance(value, str):
+        sanitized = "".join(
+            character
+            if character.isalnum() or character in {"_", "-", "."}
+            else "_"
+            for character in value[:64]
+        )
+        return sanitized or "empty"
+    return type(value).__name__
+
+
+def _process_fragments(
+        fragments: list,
+        state: _DeepSeekStreamState,
+        *,
+        snapshot: bool,
+) -> list:
+    chunks = []
+    content_by_kind = {"reasoning": "", "response": ""}
+    kind_order = []
+
+    for fragment in fragments:
+        if not isinstance(fragment, dict):
+            continue
+        kind = _fragment_kind(fragment)
+        state.active_kind = kind
+        content = fragment.get("content")
+        if kind is None or not isinstance(content, str):
+            continue
+
+        if snapshot:
+            if kind not in kind_order:
+                kind_order.append(kind)
+            content_by_kind[kind] += content
+            continue
+
+        output = _stream_output(kind, state.append(kind, content))
+        if output is not None:
+            chunks.append(output)
+
+    if snapshot:
+        for kind in kind_order:
+            output = _stream_output(
+                kind,
+                state.snapshot_delta(kind, content_by_kind[kind]),
+            )
+            if output is not None:
+                chunks.append(output)
+
+    return chunks
+
+
+def _process_stream_payload(
+        payload: Any,
+        state: _DeepSeekStreamState,
+        conversation: JsonConversation,
+) -> list:
+    """Apply one DeepSeek message event and return newly visible output chunks."""
+    if not isinstance(payload, dict):
+        return []
+
+    chunks = []
+    _record_response_message_id(
+        state, conversation, payload.get("response_message_id")
+    )
+
+    operation = payload.get("o")
+    value = payload.get("v")
+
+    if operation == "BATCH" and isinstance(value, list):
+        for batch_item in value:
+            chunks.extend(
+                _process_stream_payload(batch_item, state, conversation)
+            )
+        return chunks
+
+    if isinstance(value, dict) and isinstance(value.get("response"), dict):
+        response_obj = value["response"]
+        _record_response_message_id(
+            state, conversation, response_obj.get("message_id")
+        )
+        response_status = response_obj.get("status")
+        if response_status is not None:
+            _record_stream_status(
+                state,
+                "response/status",
+                response_status,
+                source="snapshot",
+            )
+
+        fragments = response_obj.get("fragments", [])
+        if isinstance(fragments, list):
+            chunks.extend(_process_fragments(fragments, state, snapshot=True))
+        return chunks
+
+    path = payload.get("p")
+    if (
+            path == "response/fragments"
+            and operation in {"SET", "APPEND"}
+            and isinstance(value, list)
+    ):
+        chunks.extend(
+            _process_fragments(value, state, snapshot=operation == "SET")
+        )
+        return chunks
+
+    if isinstance(path, str) and "v" in payload:
+        if _record_stream_status(
+                state,
+                path,
+                value,
+                operation=operation,
+                source="patch",
+        ):
+            return chunks
+        if path.endswith("/content") and isinstance(value, str):
+            kind = state.active_kind
+            if kind is None:
+                return chunks
+            content = (
+                state.snapshot_delta(kind, value)
+                if operation == "SET"
+                else state.append(kind, value)
+            )
+            output = _stream_output(kind, content)
+            if output is not None:
+                chunks.append(output)
+        return chunks
+
+    if isinstance(value, str):
+        kind = state.active_kind
+        if kind is None:
+            return chunks
+        output = _stream_output(kind, state.append(kind, value))
+        if output is not None:
+            chunks.append(output)
+
+    return chunks
+
+
+def _build_upload_session_headers(headers: dict) -> dict:
+    """Copy shared headers without values that would corrupt a multipart upload."""
+    excluded_headers = {"content-type", "x-ds-pow-response"}
+    return {
+        key: value
+        for key, value in headers.items()
+        if key.lower() not in excluded_headers
+    }
 
 
 def generate_client_stream_id() -> str:
@@ -201,43 +627,156 @@ class DeepSeek(AsyncGeneratorProvider, ProviderModelMixin):
     model_aliases = {"deepseek-chat": "deepseek-v3"}
 
     @classmethod
+    async def create_pow_response(
+            cls, session: StreamSession, target_path: str
+    ) -> str:
+        """Request and solve a PoW challenge for one exact API target path."""
+        debug.log(
+            f"DeepSeekAuth: Requesting PoW challenge for {target_path} "
+            f"from {POW_CHALLENGE_ENDPOINT}"
+        )
+        async with session.post(
+                POW_CHALLENGE_ENDPOINT,
+                json={"target_path": target_path},
+                headers={"content-type": "application/json"},
+        ) as response:
+            await raise_for_status(response)
+            pow_data = await response.json()
+
+        try:
+            challenge = pow_data["data"]["biz_data"]["challenge"]
+        except (KeyError, TypeError) as error:
+            raise RuntimeError(
+                f"DeepSeek returned an invalid PoW challenge for {target_path}"
+            ) from error
+
+        if challenge.get("target_path") != target_path:
+            raise RuntimeError(
+                "DeepSeek returned a PoW challenge for an unexpected target path: "
+                f"{challenge.get('target_path')!r}"
+            )
+
+        debug.log(
+            "DeepSeekAuth: Challenge: "
+            f"algorithm={challenge.get('algorithm')}, "
+            f"difficulty={challenge.get('difficulty')}"
+        )
+        pow_response = DeepSeekPOW().solve_challenge(challenge)
+        debug.log(f"DeepSeekAuth: PoW challenge solved for {target_path}")
+        return pow_response
+
+    @classmethod
     async def upload_file(
-        cls, session: StreamSession, file: bytes, filename: str = None
+            cls,
+            session: StreamSession,
+            file: bytes,
+            filename: str = None,
+            thinking_enabled: bool = False,
+            model_type: str = "default",
     ) -> dict:
         """
         Upload a file to DeepSeek.
 
         Returns dict with file info including file_id
         """
-        if not filename:
-            filename = "document.pdf"
+        data_bytes = to_bytes(file)
+        extension, file_type = detect_file_type(data_bytes)
+        filename = filename or f"file-{len(data_bytes)}{extension}"
 
-        debug.log(f"DeepSeekAuth: Starting file upload: {filename} ({len(file)} bytes)")
+        debug.log(f"DeepSeekAuth: Starting file upload: {filename} ({len(data_bytes)} bytes)")
         debug.log(f"DeepSeekAuth: Upload endpoint: {FILE_UPLOAD_ENDPOINT}")
+
+        pow_response = await cls.create_pow_response(session, FILE_UPLOAD_PATH)
 
         # Create multipart form data
         data = FormData()
-        data.add_field("file", file, filename=filename, content_type="application/pdf")
+        data.add_field("file", data_bytes, filename=filename, content_type=file_type)
 
+        upload_headers = {
+            "accept": "*/*",
+            "x-client-bundle-id": "com.deepseek.chat",
+            "x-ds-pow-response": pow_response,
+            "x-file-size": str(len(data_bytes)),
+            "x-model-type": model_type,
+            "x-thinking-enabled": "1" if thinking_enabled else "0",
+        }
         async with session.post(
-            FILE_UPLOAD_ENDPOINT, data=data, headers={"accept": "application/json"}
+                FILE_UPLOAD_ENDPOINT, data=data, headers=upload_headers
         ) as response:
             debug.log(f"DeepSeekAuth: File upload response status: {response.status}")
             await raise_for_status(response)
+            content_type = response.headers.get("content-type", "")
+            if "json" not in content_type.lower():
+                raise RuntimeError(
+                    "DeepSeek file upload returned a non-JSON response "
+                    f"(content-type: {content_type or 'unknown'}) from "
+                    f"{FILE_UPLOAD_ENDPOINT}"
+                )
             result = await response.json()
-            debug.log(f"DeepSeekAuth: File upload response: {result}")
 
-        if "data" in result:
-            file_id = result["data"].get("id")
-            debug.log(f"DeepSeekAuth: File uploaded successfully, file_id: {file_id}")
-            return {"file_id": file_id, "filename": filename, "size": len(file)}
-        else:
-            debug.error(f"DeepSeekAuth: Failed to upload file: {result}")
-            raise Exception(f"Failed to upload file: {result}")
+        response_data = result.get("data") if isinstance(result, dict) else None
+        biz_data = response_data.get("biz_data") if isinstance(response_data, dict) else None
+        file_id = biz_data.get("id") if isinstance(biz_data, dict) else None
+        if not file_id and isinstance(response_data, dict):
+            # Keep compatibility with the older, unnested response shape.
+            file_id = response_data.get("id")
+
+        if result.get("code") not in (None, 0) or not file_id:
+            message = result.get("msg") or "missing data.biz_data.id"
+            raise RuntimeError(f"DeepSeek file upload failed: {message}")
+
+        debug.log(f"DeepSeekAuth: File uploaded successfully, file_id: {file_id}")
+        return {
+            "file_id": file_id,
+            "filename": filename,
+            "size": len(data_bytes),
+        }
+
+    @classmethod
+    async def wait_for_file_parsed(
+            cls,
+            session: StreamSession,
+            file_id: str,
+            timeout: float = 120,
+            poll_interval: float = 1,
+    ) -> None:
+        """Wait until DeepSeek finishes extracting the uploaded file."""
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout
+
+        while True:
+            async with session.get(
+                    FILE_FETCH_ENDPOINT,
+                    params={"file_ids": file_id},
+                    headers={"accept": "application/json"},
+            ) as response:
+                await raise_for_status(response)
+                result = await response.json()
+
+            response_data = result.get("data") if isinstance(result, dict) else None
+            biz_data = response_data.get("biz_data") if isinstance(response_data, dict) else None
+            files = biz_data.get("files") if isinstance(biz_data, dict) else None
+            file_info = files[0] if isinstance(files, list) and files else {}
+            status = str(file_info.get("status", "")).upper()
+
+            if status == "SUCCESS":
+                debug.log(f"DeepSeekAuth: File parsing completed, file_id: {file_id}")
+                return
+            if status in {"FAILED", "ERROR"}:
+                error_code = file_info.get("error_code") or "unknown"
+                raise RuntimeError(
+                    f"DeepSeek file parsing failed for {file_id}: {error_code}"
+                )
+            if loop.time() >= deadline:
+                raise TimeoutError(
+                    f"DeepSeek file parsing timed out after {timeout:g}s for {file_id}"
+                )
+
+            await asyncio.sleep(poll_interval)
 
     @classmethod
     async def delete_chat_session(
-        cls, session: StreamSession, chat_session_id: str, headers: dict
+            cls, session: StreamSession, chat_session_id: str, headers: dict
     ):
         """
         Delete a chat session from DeepSeek.
@@ -249,7 +788,6 @@ class DeepSeek(AsyncGeneratorProvider, ProviderModelMixin):
             chat_session_id: The session ID to delete
             headers: Request headers including authorization
         """
-        import json as json_module
 
         # Try different deletion approaches - POST with JSON body first (as seen in HAR)
         deletion_methods = [
@@ -299,7 +837,7 @@ class DeepSeek(AsyncGeneratorProvider, ProviderModelMixin):
                 # Make the request - pass headers to each request
                 if method_info["method"] == "delete":
                     async with session.delete(
-                        method_info["url"], headers=headers, **request_params
+                            method_info["url"], headers=headers, **request_params
                     ) as response:
                         debug.log(f"DeepSeekAuth:   Response status: {response.status}")
                         debug.log(
@@ -314,7 +852,7 @@ class DeepSeek(AsyncGeneratorProvider, ProviderModelMixin):
                         return  # Success - exit early
                 else:  # POST
                     async with session.post(
-                        method_info["url"], headers=headers, **request_params
+                            method_info["url"], headers=headers, **request_params
                     ) as response:
                         debug.log(f"DeepSeekAuth:   Response status: {response.status}")
                         debug.log(
@@ -349,21 +887,224 @@ class DeepSeek(AsyncGeneratorProvider, ProviderModelMixin):
         raise MissingAuthError("DeepSeekAuth: No authentication found.")
 
     @classmethod
+    async def iter_chat_stream(
+            cls,
+            session: StreamSession,
+            conversation: JsonConversation,
+            initial_payload: dict,
+            initial_headers: Optional[dict] = None,
+            auto_continue: bool = True,
+            max_continue_attempts: Optional[int] = 20,
+            max_resume_attempts: Optional[int] = 5,
+    ) -> AsyncResult:
+        """Consume one logical answer across completion, resume, and continue calls."""
+        for name, limit in (
+                ("max_continue_attempts", max_continue_attempts),
+                ("max_resume_attempts", max_resume_attempts),
+        ):
+            if limit is not None and limit < 0:
+                raise ValueError(f"{name} must be non-negative or None")
+
+        chat_session_id = initial_payload.get("chat_session_id")
+        if not chat_session_id:
+            raise ValueError("DeepSeek chat_session_id is required for streaming")
+
+        endpoint = CHAT_COMPLETION_ENDPOINT
+        payload = initial_payload
+        request_headers = initial_headers
+        state = _DeepSeekStreamState()
+        continue_attempts = 0
+        resume_attempts = 0
+
+        while True:
+            state.closed = False
+            stream_error = None
+            close_payload = {}
+            request_kwargs = {"json": payload}
+            if request_headers:
+                request_kwargs["headers"] = request_headers
+
+            async with session.post(endpoint, **request_kwargs) as response:
+                await raise_for_status(response)
+                content_type = response.headers.get("content-type", "")
+                if "text/event-stream" not in content_type.lower():
+                    raise RuntimeError(
+                        "Expected SSE response but got content-type: "
+                        f"{content_type or 'unknown'}"
+                    )
+
+                events = iter_deepseek_sse(response).__aiter__()
+                while True:
+                    try:
+                        event_type, stream_data = await events.__anext__()
+                    except StopAsyncIteration:
+                        break
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception as error:
+                        stream_error = error
+                        break
+
+                    if event_type == "close":
+                        state.closed = True
+                        if isinstance(stream_data, dict):
+                            close_payload = stream_data
+                        break
+                    if event_type not in {"message", "ready"}:
+                        continue
+                    for chunk in _process_stream_payload(
+                            stream_data, state, conversation
+                    ):
+                        yield chunk
+
+            if state.closed:
+                resume_attempts = 0
+                should_continue = (
+                        state.status == "INCOMPLETE"
+                        and auto_continue
+                )
+                close_details = (
+                    "auto_resume="
+                    f"{_stream_log_value(close_payload.get('auto_resume'))} "
+                    "click_behavior="
+                    f"{_stream_log_value(close_payload.get('click_behavior'))} "
+                    f"response_chars={len(state.emitted['response'])} "
+                    f"reasoning_chars={len(state.emitted['reasoning'])} "
+                    "message_id_present="
+                    f"{_stream_log_value(state.message_id is not None)}"
+                )
+                if not should_continue:
+                    finish_reason = DEEPSEEK_FINISH_REASONS.get(state.status)
+                    if state.status == "INCOMPLETE":
+                        stop_reason = "auto_continue_disabled"
+                    elif state.status is None:
+                        stop_reason = "no_status"
+                    elif finish_reason is not None:
+                        stop_reason = "terminal_status"
+                    else:
+                        stop_reason = "unknown_status"
+                    debug.log(
+                        "DeepSeekAuth: Stream closed: "
+                        f"status={_stream_log_value(state.status)} action=stop "
+                        f"reason={stop_reason} "
+                        f"finish_reason={_stream_log_value(finish_reason)} "
+                        f"{close_details}"
+                    )
+                    if finish_reason is not None:
+                        yield FinishReason(finish_reason)
+                    return
+                if state.message_id is None:
+                    debug.log(
+                        "DeepSeekAuth: Stream closed: "
+                        "status=INCOMPLETE action=error "
+                        "reason=missing_message_id finish_reason=none "
+                        f"{close_details}"
+                    )
+                    raise RuntimeError(
+                        "DeepSeek closed an incomplete stream without a message_id"
+                    )
+                if (
+                        max_continue_attempts is not None
+                        and continue_attempts >= max_continue_attempts
+                ):
+                    debug.log(
+                        "DeepSeekAuth: Stream closed: "
+                        "status=INCOMPLETE action=error "
+                        "reason=max_continue_attempts finish_reason=none "
+                        f"{close_details}"
+                    )
+                    raise RuntimeError(
+                        "DeepSeek response remained INCOMPLETE after "
+                        f"{continue_attempts} continue attempt(s)"
+                    )
+
+                debug.log(
+                    "DeepSeekAuth: Stream closed: "
+                    "status=INCOMPLETE action=continue "
+                    "reason=incomplete_status finish_reason=none "
+                    f"{close_details}"
+                )
+                continue_attempts += 1
+                debug.log(
+                    "DeepSeekAuth: Continuing incomplete response: "
+                    f"action=continue attempt={continue_attempts}"
+                )
+                endpoint = CHAT_SESSION_CONTINUE_ENDPOINT
+                payload = {
+                    "chat_session_id": chat_session_id,
+                    "message_id": state.message_id,
+                    "fallback_to_resume": True,
+                }
+                request_headers = None
+                state.status = None
+                continue
+
+            debug.log(
+                "DeepSeekAuth: Stream ended without close: "
+                f"status={_stream_log_value(state.status)} "
+                "message_id_present="
+                f"{_stream_log_value(state.message_id is not None)} "
+                "error="
+                f"{type(stream_error).__name__ if stream_error is not None else 'none'} "
+                f"response_chars={len(state.emitted['response'])} "
+                f"reasoning_chars={len(state.emitted['reasoning'])}"
+            )
+            if state.message_id is None:
+                debug.log(
+                    "DeepSeekAuth: Interrupted stream action: "
+                    "action=error reason=missing_message_id"
+                )
+                message = "DeepSeek stream ended without close or message_id"
+                if stream_error is not None:
+                    raise RuntimeError(message) from stream_error
+                raise RuntimeError(message)
+            if (
+                    max_resume_attempts is not None
+                    and resume_attempts >= max_resume_attempts
+            ):
+                debug.log(
+                    "DeepSeekAuth: Interrupted stream action: "
+                    "action=error reason=max_resume_attempts"
+                )
+                message = (
+                    "DeepSeek stream did not close normally after "
+                    f"{resume_attempts} resume attempt(s)"
+                )
+                if stream_error is not None:
+                    raise RuntimeError(message) from stream_error
+                raise RuntimeError(message)
+
+            resume_attempts += 1
+            debug.log(
+                "DeepSeekAuth: Resuming interrupted response stream: "
+                f"action=resume_stream attempt={resume_attempts}"
+            )
+            endpoint = CHAT_SESSION_RESUME_STREAM_ENDPOINT
+            payload = {
+                "chat_session_id": chat_session_id,
+                "message_id": state.message_id,
+            }
+            request_headers = None
+
+    @classmethod
     async def create_async_generator(
-        cls,
-        model: str,
-        messages: Messages,
-        cookies: Cookies = None,
-        headers: dict = None,
-        proxy: str = None,
-        conversation: JsonConversation = None,
-        web_search: bool = False,
-        media: list = None,
-        reasoning_effort: Optional[
-            Literal["none", "low", "medium", "high", "x-high"]
-        ] = None,
-        delete_session: bool = False,
-        **kwargs,
+            cls,
+            model: str,
+            messages: Messages,
+            cookies: Cookies = None,
+            headers: dict = None,
+            proxy: str = None,
+            conversation: JsonConversation = None,
+            web_search: bool = False,
+            media: list = None,
+            reasoning_effort: Optional[
+                Literal["none", "low", "medium", "high", "x-high"]
+            ] = None,
+            delete_session: bool = False,
+            auto_continue: bool = True,
+            max_continue_attempts: Optional[int] = 20,
+            max_resume_attempts: Optional[int] = 5,
+            **kwargs,
     ) -> AsyncResult:
         """
         Create async generator for DeepSeek requests with HAR file support.
@@ -383,35 +1124,43 @@ class DeepSeek(AsyncGeneratorProvider, ProviderModelMixin):
             conversation: JsonConversation object for continuing sessions
             web_search: Enable web search
             media: List of (file_bytes, filename) tuples for file upload
+            auto_continue: Continue responses that close with INCOMPLETE status
+            max_continue_attempts: Safety cap for consecutive continue requests
+            max_resume_attempts: Safety cap for resume requests before a close event
         """
         if not model:
             model = cls.default_model
 
+        source_headers = dict(headers or {})
         # Try to get auth from HAR file first
         if cookies is None:
             cookies = get_cookies(cls.cookie_domain, False)
-            headers = get_headers(cls.cookie_domain)
-            if cookies and headers.get("authorization"):
+            source_headers = get_headers(cls.cookie_domain) or {}
+            normalized_source_headers = _normalized_headers(source_headers)
+            if cookies and normalized_source_headers.get("authorization"):
                 debug.log(
-                    f"DeepSeekAuth: Using {len(cookies)} cookies and {len(headers)} headers from cookie jar"
+                    "DeepSeekAuth: Using "
+                    f"{len(cookies)} cookies and {len(source_headers)} headers "
+                    "from cookie jar"
                 )
-            else:
-                raise MissingAuthError(
-                    "DeepSeekAuth: No authentication found. "
-                    "Please add a DeepSeek HAR file to har_and_cookies/ directory "
-                    "with an authorization token."
-                )
+            # else:
+            #     raise MissingAuthError(
+            #         "DeepSeekAuth: No authentication found. "
+            #         "Please add a DeepSeek HAR file to har_and_cookies/ directory "
+            #         "with an authorization token."
+            #     )
 
         # Initialize conversation if needed
         if conversation is None:
             conversation = JsonConversation(parent_message_id=None)
 
+        token = kwargs.get("token", "") or kwargs.get("api_key", "")
+        authorization = (token if token.lower().startswith("bearer ") else f"Bearer {token}") if token else ""
         # Get auth token from HAR data or conversation
-        authorization = None
-        if headers:
-            authorization = headers.get("authorization")
-        elif hasattr(conversation, "authorization"):
-            authorization = conversation.authorization
+        if not authorization:
+            authorization = _normalized_headers(source_headers).get("authorization")
+            if not authorization and hasattr(conversation, "authorization"):
+                authorization = conversation.authorization
 
         if not authorization:
             raise MissingAuthError(
@@ -419,21 +1168,7 @@ class DeepSeek(AsyncGeneratorProvider, ProviderModelMixin):
                 "Please ensure HAR file contains authorization header."
             )
 
-        headers = {
-            "accept": "*/*",
-            "accept-language": "en-US,en;q=0.9",
-            "cache-control": "no-cache",
-            "content-type": "application/json",
-            "origin": cls.url,
-            "referer": f"{cls.url}/",
-            "user-agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36",
-            "x-app-version": "20241129.1",
-            "x-client-locale": "en_US",
-            "x-client-platform": "web",
-            "x-client-timezone-offset": "-28800",
-            "x-client-version": "1.7.0",
-            "authorization": authorization,
-        }
+        headers = _build_chat_headers(source_headers, authorization)
 
         # Extract query from messages
         prompt = get_last_user_message(messages)
@@ -443,6 +1178,7 @@ class DeepSeek(AsyncGeneratorProvider, ProviderModelMixin):
             thinking_enabled = True
         else:
             thinking_enabled = bool(model) and "deepseek-r1" in model
+        model_type = kwargs.get("model_type", "default")  # "default", "expert", "vision"
 
         yield JsonRequest.from_dict(
             {
@@ -452,52 +1188,20 @@ class DeepSeek(AsyncGeneratorProvider, ProviderModelMixin):
             }
         )
 
-        # Get proof-of-work challenge (required by DeepSeek)
-        debug.log(
-            f"DeepSeekAuth: Requesting PoW challenge from {POW_CHALLENGE_ENDPOINT}"
-        )
-        async with StreamSession(
-            headers=headers, cookies=cookies, proxy=proxy, impersonate="chrome"
-        ) as session:
-            async with session.post(
-                POW_CHALLENGE_ENDPOINT, json={"target_path": "/api/v0/chat/completion"}
-            ) as response:
-                await raise_for_status(response)
-                pow_data = await response.json()
-                debug.log("DeepSeekAuth: PoW challenge received")
-
-                # Extract challenge data
-                if pow_data.get("data") and "biz_data" in pow_data["data"]:
-                    challenge = pow_data["data"]["biz_data"]["challenge"]
-                    debug.log(
-                        f"DeepSeekAuth: Challenge: algorithm={challenge.get('algorithm')}, difficulty={challenge.get('difficulty')}"
-                    )
-
-                    # Use inline PoW solver to solve the challenge
-                    pow_solver = DeepSeekPOW()
-                    pow_response_str = pow_solver.solve_challenge(challenge)
-                    debug.log(f"DeepSeekAuth: PoW challenge solved successfully")
-                    headers["x-ds-pow-response"] = pow_response_str
-
         # Always create a new chat session for the first request
         if (
-            not hasattr(conversation, "chat_session_id")
-            or not conversation.chat_session_id
+                not hasattr(conversation, "chat_session_id")
+                or not conversation.chat_session_id
         ):
             debug.log(f"DeepSeekAuth: Creating new chat session...")
             async with StreamSession(
-                headers=headers, cookies=cookies, proxy=proxy, impersonate="chrome"
+                    headers=headers, cookies=cookies, proxy=proxy, impersonate="chrome"
             ) as session:
                 async with session.post(CHAT_SESSION_CREATE_ENDPOINT) as response:
                     await raise_for_status(response)
                     session_data = await response.json()
-                    # ID is nested in data.biz_data.id
-                    if (
-                        session_data.get("data")
-                        and "biz_data" in session_data["data"]
-                        and "id" in session_data["data"]["biz_data"]
-                    ):
-                        chat_session_id = session_data["data"]["biz_data"]["id"]
+                    chat_session_id = _extract_chat_session_id(session_data)
+                    if chat_session_id:
                         conversation.chat_session_id = chat_session_id
                         debug.log(
                             f"DeepSeekAuth: Chat session created: {chat_session_id}"
@@ -522,24 +1226,37 @@ class DeepSeek(AsyncGeneratorProvider, ProviderModelMixin):
         if media is not None and len(media) > 0:
             # Take first file from media list
             file_bytes, filename = media[0]
+            upload_session_headers = _build_upload_session_headers(headers)
             async with StreamSession(
-                headers=headers,
-                cookies=cookies,
-                proxy=proxy,
-                impersonate="chrome",
-                http_version=CurlHttpVersion.V1_1
-                if has_curl_cffi
-                else None,  # Force HTTP/1.1 to avoid HTTP/2 stream errors
+                    headers=upload_session_headers,
+                    cookies=cookies,
+                    proxy=proxy,
+                    impersonate="chrome",
+                    http_version=CurlHttpVersion.V1_1
+                    if has_curl_cffi
+                    else None,  # Force HTTP/1.1 to avoid HTTP/2 stream errors
             ) as session:
-                upload_result = await cls.upload_file(session, file_bytes, filename)
+                upload_result = await cls.upload_file(
+                    session,
+                    file_bytes,
+                    filename,
+                    thinking_enabled=thinking_enabled,
+                    model_type=model_type,
+                )
+                await cls.wait_for_file_parsed(session, upload_result["file_id"])
                 ref_file_ids.append(upload_result["file_id"])
                 debug.log(f"DeepSeekAuth: Using file_id: {upload_result['file_id']}")
 
         # Build request data
+
         json_data = {
+            "action": None,
             "chat_session_id": getattr(
                 conversation, "chat_session_id", str(uuid.uuid4())
             ),
+            "model_type": model_type,
+            # "parent_message_id":None,
+            # "preempt":False,
             "prompt": prompt,
             "ref_file_ids": ref_file_ids,
             "thinking_enabled": thinking_enabled,
@@ -549,132 +1266,42 @@ class DeepSeek(AsyncGeneratorProvider, ProviderModelMixin):
 
         # Add parent_message_id if continuing conversation
         if (
-            hasattr(conversation, "parent_message_id")
-            and conversation.parent_message_id
+                hasattr(conversation, "parent_message_id")
+                and conversation.parent_message_id
         ):
             json_data["parent_message_id"] = conversation.parent_message_id
 
-        # debug.log(f"DeepSeekAuth: Sending request to {CHAT_COMPLETION_ENDPOINT}")
-
         async with StreamSession(
-            headers=headers, cookies=cookies, proxy=proxy, impersonate="chrome"
+                headers=headers, cookies=cookies, proxy=proxy, impersonate="chrome"
         ) as session:
-            async with session.post(
-                CHAT_COMPLETION_ENDPOINT, json=json_data
-            ) as response:
-                # debug.log(f"DeepSeekAuth: Processing response... status={response.status}, content-type={response.headers.get('content-type', 'unknown')}")
-                await raise_for_status(response)
+            chat_pow_response = await cls.create_pow_response(
+                session, CHAT_COMPLETION_PATH
+            )
+            async for chunk in cls.iter_chat_stream(
+                    session,
+                    conversation,
+                    json_data,
+                    {"x-ds-pow-response": chat_pow_response},
+                    auto_continue=auto_continue,
+                    max_continue_attempts=max_continue_attempts,
+                    max_resume_attempts=max_resume_attempts,
+            ):
+                yield chunk
 
-                # Check if response is actually SSE or regular JSON
-                content_type = response.headers.get("content-type", "")
-                if "text/event-stream" not in content_type.lower():
-                    raise RuntimeError(
-                        f"Expected SSE response but got content-type: {content_type}"
-                    )
+        # Yield the updated message ID only after the logical response has closed.
+        yield conversation
 
-                is_thinking = False
-                async for stream_data in sse_stream(response):
-                    # Handle different stream data formats
-                    if isinstance(stream_data, dict):
-                        # Handle first chunk with message IDs (for conversation continuity)
-                        if "response_message_id" in stream_data:
-                            conversation.parent_message_id = stream_data[
-                                "response_message_id"
-                            ]
-                            # debug.log(f"DeepSeekAuth: Set parent_message_id to {conversation.parent_message_id}")
-
-                        # Handle initial response with fragments (most common case)
-                        # Format: {'v': {'response': {'fragments': [{'content': '42', ...}]}}}
-                        if "v" in stream_data and isinstance(stream_data["v"], dict):
-                            response_obj = stream_data["v"].get("response", {})
-                            fragments = response_obj.get("fragments", [])
-                            for fragment in fragments:
-                                if isinstance(fragment, dict) and "content" in fragment:
-                                    if fragment.get("type") == "THINK":
-                                        is_thinking = True
-                                    content = fragment["content"]
-                                    if isinstance(content, str) and content:
-                                        yield Reasoning(
-                                            content
-                                        ) if is_thinking else content
-                                        # debug.log(f"DeepSeekAuth: Initial fragment content: '{content}'")
-
-                        # Handle APPEND operations that create new fragments with initial content
-                        elif (
-                            "p" in stream_data
-                            and stream_data["p"] == "response/fragments"
-                            and "o" in stream_data
-                            and stream_data["o"] == "APPEND"
-                            and "v" in stream_data
-                            and isinstance(stream_data["v"], list)
-                        ):
-                            # Extract content from the new fragment
-                            for fragment in stream_data["v"]:
-                                if (
-                                    isinstance(fragment, dict)
-                                    and "content" in fragment
-                                    and isinstance(fragment["content"], str)
-                                ):
-                                    is_thinking = False
-                                    yield fragment["content"]
-                                    # debug.log(f"DeepSeekAuth: APPEND fragment content: '{fragment['content']}'")
-
-                        # Handle path-based updates (like 'response/fragments/-1/content')
-                        elif "p" in stream_data and "v" in stream_data:
-                            path = stream_data["p"]
-                            value = stream_data["v"]
-
-                            # Handle content updates
-                            if path.endswith("/content") and isinstance(value, str):
-                                yield Reasoning(value) if is_thinking else value
-                                # debug.log(f"DeepSeekAuth: Content update: '{value}'")
-
-                            # Handle status updates
-                            elif path == "response/status" and value == "FINISHED":
-                                # debug.log("DeepSeekAuth: Stream finished")
-                                break
-
-                        # Handle batch updates
-                        elif (
-                            "o" in stream_data
-                            and stream_data["o"] == "BATCH"
-                            and "v" in stream_data
-                        ):
-                            for batch_item in stream_data["v"]:
-                                if (
-                                    isinstance(batch_item, dict)
-                                    and "p" in batch_item
-                                    and "v" in batch_item
-                                ):
-                                    if (
-                                        batch_item["p"] == "response/status"
-                                        and batch_item["v"] == "FINISHED"
-                                    ):
-                                        # debug.log("DeepSeekAuth: Stream finished (batch)")
-                                        break
-
-                        # Handle shorthand content updates
-                        elif "v" in stream_data and isinstance(stream_data["v"], str):
-                            yield Reasoning(
-                                stream_data["v"]
-                            ) if is_thinking else stream_data["v"]
-                            # debug.log(f"DeepSeekAuth: Shorthand content: '{stream_data['v']}'")
-
-                # Ensure we yield the conversation object at the end
-                yield conversation
-
-                # Delete chat session only if explicitly requested (when conversation is fully done)
-                if (
-                    delete_session
-                    and hasattr(conversation, "chat_session_id")
-                    and conversation.chat_session_id
-                ):
-                    async with StreamSession(
-                        headers=headers,
-                        cookies=cookies,
-                        proxy=proxy,
-                        impersonate="chrome",
-                    ) as delete_session_obj:
-                        await cls.delete_chat_session(
-                            delete_session_obj, conversation.chat_session_id, headers
-                        )
+        if (
+                delete_session
+                and hasattr(conversation, "chat_session_id")
+                and conversation.chat_session_id
+        ):
+            async with StreamSession(
+                    headers=headers,
+                    cookies=cookies,
+                    proxy=proxy,
+                    impersonate="chrome",
+            ) as delete_session_obj:
+                await cls.delete_chat_session(
+                    delete_session_obj, conversation.chat_session_id, headers
+                )

--- a/g4f/Provider/needs_auth/deepseek/__init__.py
+++ b/g4f/Provider/needs_auth/deepseek/__init__.py
@@ -1,2 +1,1 @@
 """Internal DeepSeek protocol helpers."""
-

--- a/g4f/Provider/needs_auth/deepseek/__init__.py
+++ b/g4f/Provider/needs_auth/deepseek/__init__.py
@@ -1,0 +1,2 @@
+"""Internal DeepSeek protocol helpers."""
+

--- a/g4f/Provider/needs_auth/deepseek/pow.py
+++ b/g4f/Provider/needs_auth/deepseek/pow.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+from typing import Optional
+
+
+try:
+    import numpy
+    import wasmtime
+
+    has_wasmtime_and_numpy = True
+except ImportError:
+    has_wasmtime_and_numpy = False
+
+
+WASM_PATH = str(Path(__file__).with_name("pow_solver.wasm"))
+DEEPSEEK_POW_ALGORITHM = "DeepSeekHashV1"
+
+
+class DeepSeekHash:
+    """Custom SHA3 hash solver using WebAssembly."""
+
+    def __init__(self):
+        self.instance = None
+        self.memory = None
+        self.store = None
+
+    def init(self, wasm_path: str):
+        if not has_wasmtime_and_numpy:
+            raise ImportError("wasmtime and numpy are required for PoW solving")
+
+        if not Path(wasm_path).exists():
+            raise FileNotFoundError(f"WASM file not found: {wasm_path}")
+
+        engine = wasmtime.Engine()
+        with open(wasm_path, "rb") as file:
+            wasm_bytes = file.read()
+        module = wasmtime.Module(engine, wasm_bytes)
+
+        self.store = wasmtime.Store(engine)
+        linker = wasmtime.Linker(engine)
+        linker.define_wasi()
+
+        self.instance = linker.instantiate(self.store, module)
+        self.memory = self.instance.exports(self.store)["memory"]
+        return self
+
+    def _write_to_memory(self, text: str) -> tuple[int, int]:
+        encoded = text.encode("utf-8")
+        length = len(encoded)
+        ptr = self.instance.exports(self.store)["__wbindgen_export_0"](
+            self.store, length, 1
+        )
+
+        memory_view = self.memory.data_ptr(self.store)
+        for index, byte in enumerate(encoded):
+            memory_view[ptr + index] = byte
+        return ptr, length
+
+    def calculate_hash(
+            self,
+            algorithm: str,
+            challenge: str,
+            salt: str,
+            difficulty: int,
+            expire_at: int,
+    ) -> Optional[int]:
+        prefix = f"{salt}_{expire_at}_"
+        retptr = self.instance.exports(self.store)["__wbindgen_add_to_stack_pointer"](
+            self.store, -16
+        )
+
+        try:
+            challenge_ptr, challenge_len = self._write_to_memory(challenge)
+            prefix_ptr, prefix_len = self._write_to_memory(prefix)
+
+            self.instance.exports(self.store)["wasm_solve"](
+                self.store,
+                retptr,
+                challenge_ptr,
+                challenge_len,
+                prefix_ptr,
+                prefix_len,
+                float(difficulty),
+            )
+
+            memory_view = self.memory.data_ptr(self.store)
+            status = int.from_bytes(
+                bytes(memory_view[retptr: retptr + 4]),
+                byteorder="little",
+                signed=True,
+            )
+            if status == 0:
+                return None
+
+            value_bytes = bytes(memory_view[retptr + 8: retptr + 16])
+            value = numpy.frombuffer(value_bytes, dtype=numpy.float64)[0]
+            return int(value)
+        finally:
+            self.instance.exports(self.store)["__wbindgen_add_to_stack_pointer"](
+                self.store, 16
+            )
+
+
+class DeepSeekPOW:
+    """Proof-of-work solver for DeepSeek challenges."""
+
+    def __init__(self):
+        self.hasher = DeepSeekHash().init(WASM_PATH)
+
+    def solve_challenge(self, config: dict) -> str:
+        answer = self.hasher.calculate_hash(
+            config["algorithm"],
+            config["challenge"],
+            config["salt"],
+            config["difficulty"],
+            config["expire_at"],
+        )
+        if answer is None:
+            raise RuntimeError("DeepSeek PoW solver returned no answer")
+
+        result = {
+            "algorithm": config["algorithm"],
+            "challenge": config["challenge"],
+            "salt": config["salt"],
+            "answer": answer,
+            "signature": config["signature"],
+            "target_path": config.get("target_path", ""),
+        }
+        return base64.b64encode(json.dumps(result).encode()).decode()
+

--- a/g4f/Provider/needs_auth/deepseek/pow.py
+++ b/g4f/Provider/needs_auth/deepseek/pow.py
@@ -130,4 +130,3 @@ class DeepSeekPOW:
             "target_path": config.get("target_path", ""),
         }
         return base64.b64encode(json.dumps(result).encode()).decode()
-

--- a/g4f/Provider/needs_auth/deepseek/stream.py
+++ b/g4f/Provider/needs_auth/deepseek/stream.py
@@ -100,6 +100,8 @@ class _DeepSeekStreamState:
     status: Optional[str] = None
     closed: bool = False
     active_kind: Optional[str] = "response"
+    fragment_kinds: dict[str, Optional[str]] = field(default_factory=dict)
+    next_fragment_index: int = 0
     emitted: dict[str, str] = field(
         default_factory=lambda: {"reasoning": "", "response": ""}
     )
@@ -144,6 +146,52 @@ def _stream_output(kind: str, content: str):
     if not content:
         return None
     return Reasoning(content) if kind == "reasoning" else content
+
+
+def _record_fragment_kind(
+        state: _DeepSeekStreamState,
+        fragment_index: str,
+        kind: Optional[str],
+        *,
+        append_fragment: bool = False,
+) -> None:
+    state.active_kind = kind
+    debug.log(
+        "DeepSeekAuth: Stream fragment: "
+        f"index={_stream_log_value(fragment_index)} "
+        f"kind={_stream_log_value(kind)} "
+        f"append={_stream_log_value(append_fragment)}"
+    )
+
+    if fragment_index == "-1":
+        state.fragment_kinds["-1"] = kind
+        if append_fragment:
+            state.fragment_kinds[str(state.next_fragment_index)] = kind
+            state.next_fragment_index += 1
+        elif state.next_fragment_index:
+            state.fragment_kinds[str(state.next_fragment_index - 1)] = kind
+        return
+
+    state.fragment_kinds[fragment_index] = kind
+    try:
+        numeric_index = int(fragment_index)
+    except ValueError:
+        return
+    if numeric_index >= state.next_fragment_index:
+        state.next_fragment_index = numeric_index + 1
+    if numeric_index == state.next_fragment_index - 1:
+        state.fragment_kinds["-1"] = kind
+
+
+def _fragment_index_from_path(path: str) -> Optional[str]:
+    path_parts = path.split("/")
+    if (
+            len(path_parts) >= 3
+            and path_parts[0] == "response"
+            and path_parts[1] == "fragments"
+    ):
+        return path_parts[2]
+    return None
 
 
 def _record_response_message_id(
@@ -210,11 +258,16 @@ def _process_fragments(
     content_by_kind = {"reasoning": "", "response": ""}
     kind_order = []
 
+    if snapshot:
+        state.fragment_kinds.clear()
+        state.next_fragment_index = 0
+
     for fragment in fragments:
         if not isinstance(fragment, dict):
             continue
         kind = _fragment_kind(fragment)
-        state.active_kind = kind
+        fragment_index = str(state.next_fragment_index)
+        _record_fragment_kind(state, fragment_index, kind)
         content = fragment.get("content")
         if kind is None or not isinstance(content, str):
             continue
@@ -291,6 +344,36 @@ def _process_stream_payload(
         )
         return chunks
 
+    fragment_index = (
+        _fragment_index_from_path(path)
+        if isinstance(path, str)
+        else None
+    )
+    if (
+            fragment_index is not None
+            and path.count("/") == 2
+            and operation in {"SET", "APPEND"}
+            and isinstance(value, dict)
+    ):
+        kind = _fragment_kind(value)
+        _record_fragment_kind(
+            state,
+            fragment_index,
+            kind,
+            append_fragment=operation == "APPEND",
+        )
+        content = value.get("content")
+        if kind is not None and isinstance(content, str):
+            delta = (
+                state.snapshot_delta(kind, content)
+                if operation == "SET"
+                else state.append(kind, content)
+            )
+            output = _stream_output(kind, delta)
+            if output is not None:
+                chunks.append(output)
+        return chunks
+
     if isinstance(path, str) and "v" in payload:
         if _record_stream_status(
                 state,
@@ -300,8 +383,23 @@ def _process_stream_payload(
                 source="patch",
         ):
             return chunks
+        if (
+                fragment_index is not None
+                and path.endswith("/type")
+                and isinstance(value, str)
+        ):
+            _record_fragment_kind(
+                state,
+                fragment_index,
+                _fragment_kind({"type": value}),
+            )
+            return chunks
         if path.endswith("/content") and isinstance(value, str):
-            kind = state.active_kind
+            kind = (
+                state.fragment_kinds[fragment_index]
+                if fragment_index in state.fragment_kinds
+                else state.active_kind
+            )
             if kind is None:
                 return chunks
             content = (

--- a/g4f/Provider/needs_auth/deepseek/stream.py
+++ b/g4f/Provider/needs_auth/deepseek/stream.py
@@ -1,0 +1,349 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, AsyncIterator, Literal, Optional
+
+from g4f import debug
+from g4f.providers.response import JsonConversation, Reasoning
+
+
+DEEPSEEK_MESSAGE_STATUSES = {
+    "FINISHED",
+    "CONTENT_FILTER",
+    "CONTEXT_LENGTH_EXCEEDED",
+    "INCOMPLETE",
+    "WIP",
+    "TIMEOUT",
+}
+DEEPSEEK_FINISH_REASONS = {
+    "FINISHED": "stop",
+    "CONTENT_FILTER": "content_filter",
+    "CONTEXT_LENGTH_EXCEEDED": "length",
+    "INCOMPLETE": "incomplete",
+    "WIP": "wip",
+    "TIMEOUT": "timeout",
+}
+
+DEEPSEEK_RESPONSE_FRAGMENT_TYPES = {"RESPONSE", "TEMPLATE_RESPONSE"}
+DEEPSEEK_REASONING_FRAGMENT_TYPES = {
+    "THINK",
+    "THINKING",
+    "REASONING",
+    "SEARCH",
+    "TOOL_SEARCH",
+    "TOOL_OPEN",
+    "TOOL_FIND",
+}
+DEEPSEEK_METADATA_FRAGMENT_TYPES = {
+    "REQUEST",
+    "FILE",
+    "TIP",
+    "READ_LINK",
+}
+
+
+async def iter_deepseek_sse(response) -> AsyncIterator[tuple[str, Any]]:
+    """Parse DeepSeek SSE frames without losing their ``event`` field."""
+    event_type = "message"
+    data_lines: list[str] = []
+
+    def decode_event() -> Optional[tuple[str, Any]]:
+        if not data_lines:
+            return None
+        raw_data = "\n".join(data_lines)
+        if raw_data.strip() == "[DONE]":
+            return None
+        try:
+            return event_type, json.loads(raw_data)
+        except json.JSONDecodeError as error:
+            raise ValueError(
+                f"Invalid DeepSeek SSE JSON data: {raw_data!r}"
+            ) from error
+
+    async for raw_line in response.iter_lines():
+        line = (
+            raw_line.decode("utf-8")
+            if isinstance(raw_line, (bytes, bytearray))
+            else str(raw_line)
+        ).rstrip("\r")
+
+        if not line:
+            event = decode_event()
+            if event is not None:
+                yield event
+            event_type = "message"
+            data_lines = []
+            continue
+
+        if line.startswith(":"):
+            continue
+
+        field_name, separator, field_value = line.partition(":")
+        if not separator:
+            continue
+        if field_value.startswith(" "):
+            field_value = field_value[1:]
+        if field_name == "event":
+            event_type = field_value or "message"
+        elif field_name == "data":
+            data_lines.append(field_value)
+
+    event = decode_event()
+    if event is not None:
+        yield event
+
+
+@dataclass
+class _DeepSeekStreamState:
+    message_id: Any = None
+    status: Optional[str] = None
+    closed: bool = False
+    active_kind: Optional[str] = "response"
+    emitted: dict[str, str] = field(
+        default_factory=lambda: {"reasoning": "", "response": ""}
+    )
+
+    def append(self, kind: str, content: str) -> str:
+        self.emitted[kind] += content
+        return content
+
+    def snapshot_delta(self, kind: str, content: str) -> str:
+        """Return only text not already emitted by an earlier stream attempt."""
+        previous = self.emitted[kind]
+        if content.startswith(previous):
+            delta = content[len(previous):]
+            self.emitted[kind] = content
+            return delta
+        if previous.startswith(content):
+            return ""
+
+        max_overlap = min(len(previous), len(content))
+        for overlap in range(max_overlap, 0, -1):
+            if previous.endswith(content[:overlap]):
+                delta = content[overlap:]
+                self.emitted[kind] += delta
+                return delta
+
+        self.emitted[kind] += content
+        return content
+
+
+def _fragment_kind(fragment: dict) -> Optional[str]:
+    fragment_type = str(fragment.get("type", "")).upper()
+    if not fragment_type:
+        return "response"
+    if fragment_type in DEEPSEEK_RESPONSE_FRAGMENT_TYPES:
+        return "response"
+    if fragment_type in DEEPSEEK_REASONING_FRAGMENT_TYPES:
+        return "reasoning"
+    return None
+
+
+def _stream_output(kind: str, content: str):
+    if not content:
+        return None
+    return Reasoning(content) if kind == "reasoning" else content
+
+
+def _record_response_message_id(
+        state: _DeepSeekStreamState,
+        conversation: JsonConversation,
+        message_id: Any,
+) -> None:
+    if message_id is not None:
+        state.message_id = message_id
+        conversation.parent_message_id = message_id
+
+
+def _record_stream_status(
+        state: _DeepSeekStreamState,
+        path: str,
+        value: Any,
+        *,
+        operation: Optional[str] = None,
+        source: Literal["patch", "snapshot"] = "snapshot",
+) -> bool:
+    if path not in {"response/status", "quasi_status", "response/quasi_status"}:
+        return False
+    status = str(value).upper()
+    if status in DEEPSEEK_MESSAGE_STATUSES:
+        state.status = status
+        interpretation = "requires_continue" if status == "INCOMPLETE" else None
+        operation_label = operation if operation is not None else "none"
+        message = (
+            "DeepSeekAuth: Stream status: "
+            f"status={status} source={source} operation={operation_label}"
+        )
+        if interpretation is not None:
+            message += f" interpretation={interpretation}"
+        debug.log(message)
+    return True
+
+
+def _stream_log_value(value: Any) -> str:
+    """Format a small, non-content stream field for diagnostic logging."""
+    if value is None:
+        return "none"
+    if isinstance(value, bool):
+        return str(value).lower()
+    if isinstance(value, (int, float)):
+        return str(value)
+    if isinstance(value, str):
+        sanitized = "".join(
+            character
+            if character.isalnum() or character in {"_", "-", "."}
+            else "_"
+            for character in value[:64]
+        )
+        return sanitized or "empty"
+    return type(value).__name__
+
+
+def _process_fragments(
+        fragments: list,
+        state: _DeepSeekStreamState,
+        *,
+        snapshot: bool,
+) -> list:
+    chunks = []
+    content_by_kind = {"reasoning": "", "response": ""}
+    kind_order = []
+
+    for fragment in fragments:
+        if not isinstance(fragment, dict):
+            continue
+        kind = _fragment_kind(fragment)
+        state.active_kind = kind
+        content = fragment.get("content")
+        if kind is None or not isinstance(content, str):
+            continue
+
+        if snapshot:
+            if kind not in kind_order:
+                kind_order.append(kind)
+            content_by_kind[kind] += content
+            continue
+
+        output = _stream_output(kind, state.append(kind, content))
+        if output is not None:
+            chunks.append(output)
+
+    if snapshot:
+        for kind in kind_order:
+            output = _stream_output(
+                kind,
+                state.snapshot_delta(kind, content_by_kind[kind]),
+            )
+            if output is not None:
+                chunks.append(output)
+    return chunks
+
+
+def _process_stream_payload(
+        payload: Any,
+        state: _DeepSeekStreamState,
+        conversation: JsonConversation,
+) -> list:
+    """Apply one DeepSeek message event and return newly visible output chunks."""
+    if not isinstance(payload, dict):
+        return []
+
+    chunks = []
+    _record_response_message_id(
+        state, conversation, payload.get("response_message_id")
+    )
+
+    operation = payload.get("o")
+    value = payload.get("v")
+    if operation == "BATCH" and isinstance(value, list):
+        for batch_item in value:
+            chunks.extend(_process_stream_payload(batch_item, state, conversation))
+        return chunks
+
+    if isinstance(value, dict) and isinstance(value.get("response"), dict):
+        response_obj = value["response"]
+        _record_response_message_id(
+            state, conversation, response_obj.get("message_id")
+        )
+        response_status = response_obj.get("status")
+        if response_status is not None:
+            _record_stream_status(
+                state,
+                "response/status",
+                response_status,
+                source="snapshot",
+            )
+
+        fragments = response_obj.get("fragments", [])
+        if isinstance(fragments, list):
+            chunks.extend(_process_fragments(fragments, state, snapshot=True))
+        return chunks
+
+    path = payload.get("p")
+    if (
+            path == "response/fragments"
+            and operation in {"SET", "APPEND"}
+            and isinstance(value, list)
+    ):
+        chunks.extend(
+            _process_fragments(value, state, snapshot=operation == "SET")
+        )
+        return chunks
+
+    if isinstance(path, str) and "v" in payload:
+        if _record_stream_status(
+                state,
+                path,
+                value,
+                operation=operation,
+                source="patch",
+        ):
+            return chunks
+        if path.endswith("/content") and isinstance(value, str):
+            kind = state.active_kind
+            if kind is None:
+                return chunks
+            content = (
+                state.snapshot_delta(kind, value)
+                if operation == "SET"
+                else state.append(kind, value)
+            )
+            output = _stream_output(kind, content)
+            if output is not None:
+                chunks.append(output)
+        return chunks
+
+    if isinstance(value, str):
+        kind = state.active_kind
+        if kind is None:
+            return chunks
+        output = _stream_output(kind, state.append(kind, value))
+        if output is not None:
+            chunks.append(output)
+    return chunks
+
+
+def _process_full_message(
+        biz_data: Any,
+        state: _DeepSeekStreamState,
+        conversation: JsonConversation,
+) -> list:
+    """Convert a non-SSE full-message response into normal provider chunks."""
+    if not isinstance(biz_data, dict):
+        raise RuntimeError("DeepSeek resume returned an invalid full message")
+
+    response = biz_data.get("response")
+    if not isinstance(response, dict):
+        response = biz_data.get("response_message") or biz_data.get("message")
+    if not isinstance(response, dict) and "fragments" in biz_data:
+        response = biz_data
+    if not isinstance(response, dict):
+        raise RuntimeError("DeepSeek resume returned an invalid full message")
+
+    return _process_stream_payload(
+        {"v": {"response": response}},
+        state,
+        conversation,
+    )
+

--- a/g4f/Provider/needs_auth/deepseek/stream.py
+++ b/g4f/Provider/needs_auth/deepseek/stream.py
@@ -346,4 +346,3 @@ def _process_full_message(
         state,
         conversation,
     )
-

--- a/g4f/image/__init__.py
+++ b/g4f/image/__init__.py
@@ -270,7 +270,7 @@ def is_accepted_format(binary_data: bytes) -> str:
         raise ValueError("Invalid image format (from magic code).")
 
 
-def detect_file_type(binary_data: bytes) -> tuple[str, str] | None:
+def detect_file_type(binary_data: bytes) -> tuple[str, str]:
     """
     Detect file type from magic number / header signature.
 


### PR DESCRIPTION
## Summary

This PR modernizes the authenticated DeepSeek provider to support the current web chat protocol, including reliable SSE streaming, proof-of-work challenges, file uploads, stream recovery, and comprehensive tests.

## What changed

### Streaming and response recovery

- Added a dedicated SSE parser that preserves DeepSeek event types and supports snapshots, patches, batches, and close events.
- Added support for continuing `INCOMPLETE` responses and resuming interrupted streams.
- Tracks fragment types and indexes, including indexed `SET`, `APPEND`, `/type`, `/content`, and `-1` patches.
- Emits `THINK`, search, and tool fragments as reasoning while keeping `RESPONSE` and `TEMPLATE_RESPONSE` as visible output.
- Prevents duplicate content when a stream is resumed or replaced by a full-message snapshot.
- Attempts one bounded recovery when DeepSeek closes with `FINISHED` but provides no visible response.
- Raises a clear `ResponseError` if the recovered message still contains no response instead of silently returning an empty result.
- Never promotes hidden reasoning content to the final response.

### File uploads and proof of work

- Added endpoint-specific DeepSeek PoW challenge generation and solving.
- Runs the CPU-intensive PoW solver outside the async event loop.
- Added multipart file uploads with MIME type and filename handling.
- Supports multiple uploaded files while preserving their order.
- Waits for server-side file parsing and handles terminal parsing failures explicitly.
- Updated `detect_file_type` to consistently return the detected extension and MIME type.

### Provider structure and protocol handling

- Moved PoW and streaming logic into dedicated `deepseek` helper modules.
- Added normalized chat and upload headers.
- Added explicit completion payload construction and business-response envelope validation.
- Updated chat session creation, deletion, upload, completion, continue, and resume handling to match the observed DeepSeek web contract.
- Improved diagnostic logging without exposing response content or authentication data.

### Testing and diagnostics

- Added unit coverage for SSE parsing, fragment classification, status handling, resume and continue flows, empty responses, PoW, uploads, file parsing, and error responses.
- Added a reusable JSONL chunk logger for inspecting provider metadata and reasoning chunks during development.

## Why

DeepSeek streams responses as incremental fragment patches and can occasionally close a message as `FINISHED` after emitting reasoning without a final response. Previously, this could result in a successful request with an empty visible answer.

The updated implementation recovers the complete message when possible and returns an explicit error when DeepSeek genuinely provides no final response.

## Validation

- `python -m unittest etc.unittest.test_deepseek_stream etc.unittest.test_deepseek_upload`
  - 40 tests, OK
- `python -m etc.unittest`
  - 235 tests run
  - 9 skipped
  - Suite OK

Final verification was performed locally without issuing an additional live DeepSeek request.