### PR TITLE
fix(Copilot): use getattr to access access_token safely (Fixes #3511)

### DIFF
--- a/g4f/Provider/Copilot.py
+++ b/g4f/Provider/Copilot.py
@@ -269,7 +269,7 @@ class Copilot(AsyncAuthedProvider, ProviderModelMixin):
             #     debug.log(f"Copilot: User: {user}")
 
             uploaded_attachments = []
-            if auth_result.access_token:
+            if getattr(auth_result, "access_token", None):
                 # Upload regular media (images)
                 for media, _ in merge_media(media, messages):
                     if not isinstance(media, str):


### PR DESCRIPTION
### Summary of Changes

This PR fixes an unhandled `AttributeError` in `g4f/Provider/Copilot.py` when using session cookies without an explicit `access_token` on `AuthResult`.

Fixes #3511

### Root Cause
In `Copilot.py`:
- Lines 166 and 244 safely use `getattr(auth_result, "access_token", None)`.
- Line 272 directly accessed `auth_result.access_token`, which crashes with `AttributeError: 'AuthResult' object has no attribute 'access_token'` when `auth_result` was instantiated without `access_token` (e.g. cookie-based auth).

### Solution
Use `getattr(auth_result, "access_token", None)` on line 272, consistent with lines 166 and 244.
