### PR TITLE
[#3508] [Bug] Trying to use 'gemini-3.8-flash' leads to error 500

### DIFF
--- a/etc/unittest/test_gemini.py
+++ b/etc/unittest/test_gemini.py
@@ -181,15 +181,27 @@ class GeminiHelpersTest(unittest.TestCase):
                 resolved, _ = _resolve_model(legacy_name)
                 self.assertEqual(resolved, current_name)
 
-    def test_unknown_model_lists_supported_models(self):
-        with self.assertRaises(ValueError) as context:
-            _resolve_model("gemini-3.7-flash")
+    def test_unknown_model_falls_back_to_known_model(self):
+        # New Gemini models ship faster than the hard-coded registry can track
+        # them. Unknown names route to the closest known model of the same
+        # family instead of raising, so the provider no longer returns a 500.
+        self.assertEqual(_resolve_model("gemini-3.7-flash")[0], "gemini-3.6-flash")
+        self.assertEqual(_resolve_model("gemini-3.8-flash")[0], "gemini-3.6-flash")
+        self.assertEqual(_resolve_model("gemini-3.8-pro")[0], "gemini-3.1-pro")
+        self.assertEqual(
+            _resolve_model("gemini-3.9-flash-lite")[0], "gemini-3.5-flash-lite"
+        )
 
-        message = str(context.exception)
-        self.assertIn("Unknown Gemini model: gemini-3.7-flash", message)
-        self.assertIn("Supported models:", message)
-        self.assertIn("gemini-3.6-flash", message)
-        self.assertIn("gemini-3.5-flash-lite", message)
+    def test_unknown_thinking_model_enables_expanded_thinking(self):
+        model, expanded = _resolve_model("gemini-3.8-flash-thinking")
+        self.assertEqual(model, "gemini-3.6-flash")
+        self.assertTrue(expanded)
+
+    def test_invalid_thinking_mode_still_raises(self):
+        with self.assertRaises(ValueError):
+            _resolve_model("gemini-3.6-flash@think=abc")
+        with self.assertRaises(ValueError):
+            _resolve_model("gemini-3.6-flash@think=9")
 
     def test_public_model_registry_exposes_current_models(self):
         self.assertEqual(ModelRegistry.get("gemini-auto").name, "gemini-auto")

--- a/g4f/Provider/needs_auth/Gemini.py
+++ b/g4f/Provider/needs_auth/Gemini.py
@@ -240,6 +240,18 @@ async def _iter_response_lines(
         yield buffer.decode("utf-8", errors="replace")
 
 
+def _fallback_model(requested_model: str) -> str:
+    # Google ships new Gemini models faster than the hard-coded registry can
+    # track them. Route an unknown name to the closest known model of the same
+    # family so the request keeps working until the registry is refreshed.
+    name = requested_model.lower()
+    if "pro" in name:
+        return "gemini-3.1-pro"
+    if "lite" in name:
+        return "gemini-3.5-flash-lite"
+    return "gemini-3.6-flash"
+
+
 def _resolve_model(model: str, think_override: int = None) -> tuple[str, bool]:
     requested_model = model
     think_mode = think_override
@@ -255,14 +267,20 @@ def _resolve_model(model: str, think_override: int = None) -> tuple[str, bool]:
             raise ValueError("Thinking mode must be an integer between 0 and 4")
     model = MODEL_ALIASES.get(model, model)
     if model not in models:
-        raise ValueError(
-            f"Unknown Gemini model: {model}. " f"Supported models: {', '.join(models)}"
+        fallback = _fallback_model(requested_model)
+        debug.log(
+            f"Unknown Gemini model: {model!r}. "
+            f"Falling back to {fallback!r}. "
+            f"Known models: {', '.join(models)}"
         )
-    expanded_thinking = (
-        requested_model in EXPANDED_MODEL_ALIASES
-        if think_mode is None
-        else think_mode <= 2
-    )
+        model = fallback
+    if think_mode is None:
+        expanded_thinking = (
+            requested_model in EXPANDED_MODEL_ALIASES
+            or "thinking" in requested_model.lower()
+        )
+    else:
+        expanded_thinking = think_mode <= 2
     return model, expanded_thinking
 
 


### PR DESCRIPTION
## Summary

Requesting a Gemini model that isn't in the provider's hard-coded registry (for example the newly released `gemini-3.8-flash`) made the API return HTTP 500:

```
ERROR:g4f.api:Unknown Gemini model: gemini-3.8-flash. Supported models: gemini-3.6-flash, gemini-3.5-flash-lite, gemini-3.1-pro
```

Google ships new Gemini models faster than the static `models` registry in `g4f/Provider/needs_auth/Gemini.py` can be updated, so every new model release broke the provider until the list was patched by hand. As the issue author suggests, the hard model-name check is the root cause.

## Changes

- `g4f/Provider/needs_auth/Gemini.py`
  - `_resolve_model` no longer raises `ValueError` for an unknown model. After alias resolution, an unrecognized name is routed to the closest **known** model of the same family (`pro` → `gemini-3.1-pro`, `lite` → `gemini-3.5-flash-lite`, otherwise → `gemini-3.6-flash`) and the fallback is recorded via `debug.log`.
  - Added a small `_fallback_model` helper that picks the family-appropriate known model from the requested name.
  - `expanded_thinking` now also infers `"thinking"` from the requested name, so a future `gemini-X-flash-thinking` variant still gets expanded thinking instead of silently disabling it.
  - Genuinely invalid input is still rejected: the `@think=` parsing/range validation continues to raise `ValueError` for malformed or out-of-range thinking modes.

- `etc/unittest/test_gemini.py`
  - Replaced `test_unknown_model_lists_supported_models` (which asserted the old raise-and-list behavior) with `test_unknown_model_falls_back_to_known_model`, `test_unknown_thinking_model_enables_expanded_thinking`, and `test_invalid_thinking_mode_still_raises`, covering the new fallback plus the preserved validation.

## Reviewer checklist

- `gemini-3.8-flash` (and other unknown names) now resolve to a known model of the matching family instead of raising → no more 500.
- Known models (`gemini-3.6-flash`, `gemini-3.5-flash-lite`, `gemini-3.1-pro`) and legacy aliases (`gemini-auto`, `gemini-2.5-pro`, ...) still resolve exactly as before.
- `@think=` malformed/out-of-range values still raise `ValueError`.
- `python -m unittest etc.unittest.test_gemini` passes (27 tests).

Closes #3508

_This pull request was opened by an AI agent (OpenHands)._