### PR TITLE
[#3518] [Fix] Preserve Gemini model identity without categorizing or falling back to older models

### DIFF
--- a/etc/unittest/test_gemini.py
+++ b/etc/unittest/test_gemini.py
@@ -181,21 +181,37 @@ class GeminiHelpersTest(unittest.TestCase):
                 resolved, _ = _resolve_model(legacy_name)
                 self.assertEqual(resolved, current_name)
 
-    def test_unknown_model_falls_back_to_known_model(self):
-        # New Gemini models ship faster than the hard-coded registry can track
-        # them. Unknown names route to the closest known model of the same
-        # family instead of raising, so the provider no longer returns a 500.
-        self.assertEqual(_resolve_model("gemini-3.7-flash")[0], "gemini-3.6-flash")
-        self.assertEqual(_resolve_model("gemini-3.8-flash")[0], "gemini-3.6-flash")
-        self.assertEqual(_resolve_model("gemini-3.8-pro")[0], "gemini-3.1-pro")
+    def test_unknown_model_preserves_exact_name(self):
+        # Resolving unknown model names preserves their exact identity
+        # instead of categorizing/routing them to an older model of the family (#3518).
+        self.assertEqual(_resolve_model("gemini-3.7-flash")[0], "gemini-3.7-flash")
+        self.assertEqual(_resolve_model("gemini-3.8-flash")[0], "gemini-3.8-flash")
+        self.assertEqual(_resolve_model("gemini-3.8-pro")[0], "gemini-3.8-pro")
         self.assertEqual(
-            _resolve_model("gemini-3.9-flash-lite")[0], "gemini-3.5-flash-lite"
+            _resolve_model("gemini-3.9-flash-lite")[0], "gemini-3.9-flash-lite"
         )
+        self.assertEqual(_resolve_model("gemini-4.0-flash")[0], "gemini-4.0-flash")
 
     def test_unknown_thinking_model_enables_expanded_thinking(self):
         model, expanded = _resolve_model("gemini-3.8-flash-thinking")
-        self.assertEqual(model, "gemini-3.6-flash")
+        self.assertEqual(model, "gemini-3.8-flash")
         self.assertTrue(expanded)
+
+    def test_unknown_models_dynamically_determine_request_mode(self):
+        self.assertEqual(Gemini.get_model_mode("gemini-3.7-flash"), 1)
+        self.assertEqual(Gemini.get_model_mode("gemini-3.8-flash"), 1)
+        self.assertEqual(Gemini.get_model_mode("gemini-3.8-pro"), 3)
+        self.assertEqual(Gemini.get_model_mode("gemini-3.9-flash-lite"), 6)
+        self.assertEqual(Gemini.get_model_mode("gemini-4.0-flash"), 1)
+
+        req_flash = Gemini.build_request("test", "en", "gemini-3.8-flash")
+        self.assertEqual(req_flash[79], 1)
+
+        req_pro = Gemini.build_request("test", "en", "gemini-3.8-pro")
+        self.assertEqual(req_pro[79], 3)
+
+        req_lite = Gemini.build_request("test", "en", "gemini-3.9-flash-lite")
+        self.assertEqual(req_lite[79], 6)
 
     def test_invalid_thinking_mode_still_raises(self):
         with self.assertRaises(ValueError):
@@ -319,9 +335,15 @@ class GeminiHelpersTest(unittest.TestCase):
 
         with self.assertRaises(MissingAuthError):
             ProbeGemini.validate_model_access("gemini-3.1-pro")
+        with self.assertRaises(MissingAuthError):
+            ProbeGemini.validate_model_access("gemini-3.8-pro")
         ProbeGemini.validate_model_access("gemini-3.6-flash")
         ProbeGemini.validate_model_access("gemini-3.5-flash")
+        ProbeGemini.validate_model_access("gemini-3.7-flash")
+        ProbeGemini.validate_model_access("gemini-3.8-flash")
+        ProbeGemini.validate_model_access("gemini-4.0-flash")
         ProbeGemini.validate_model_access("gemini-3.1-pro", allow_model_fallback=True)
+        ProbeGemini.validate_model_access("gemini-3.8-pro", allow_model_fallback=True)
 
     def test_dynamic_headers_only_for_available_pro(self):
         _, registry = build_account_response(ACCOUNT_STATUS_AVAILABLE)
@@ -334,8 +356,13 @@ class GeminiHelpersTest(unittest.TestCase):
             ProbeGemini.get_model_headers("gemini-3.1-pro")[MODEL_HEADER_KEY]
         )
         self.assertEqual(pro_header[4], "9d8ca3786ebdfbea")
+        pro_header_38 = json.loads(
+            ProbeGemini.get_model_headers("gemini-3.8-pro")[MODEL_HEADER_KEY]
+        )
+        self.assertEqual(pro_header_38[4], "9d8ca3786ebdfbea")
         self.assertEqual(ProbeGemini.get_model_headers("gemini-3.5-flash"), {})
         self.assertEqual(ProbeGemini.get_model_headers("gemini-3.5-flash-thinking"), {})
+        self.assertEqual(ProbeGemini.get_model_headers("gemini-3.8-flash"), {})
 
 
 class GeminiStreamTest(unittest.IsolatedAsyncioTestCase):

--- a/g4f/Provider/needs_auth/Gemini.py
+++ b/g4f/Provider/needs_auth/Gemini.py
@@ -133,6 +133,9 @@ models = {
     "gemini-3.6-flash": {"mode": 1},
     "gemini-3.5-flash-lite": {"mode": 6},
     "gemini-3.1-pro": {"mode": 3},
+    "gemini-3.7-flash": {"mode": 1},
+    "gemini-3.8-flash": {"mode": 1},
+    "gemini-3.8-pro": {"mode": 3},
 }
 MODEL_ALIASES = {
     "gemini-2.0": "gemini-3.6-flash",
@@ -240,18 +243,6 @@ async def _iter_response_lines(
         yield buffer.decode("utf-8", errors="replace")
 
 
-def _fallback_model(requested_model: str) -> str:
-    # Google ships new Gemini models faster than the hard-coded registry can
-    # track them. Route an unknown name to the closest known model of the same
-    # family so the request keeps working until the registry is refreshed.
-    name = requested_model.lower()
-    if "pro" in name:
-        return "gemini-3.1-pro"
-    if "lite" in name:
-        return "gemini-3.5-flash-lite"
-    return "gemini-3.6-flash"
-
-
 def _resolve_model(model: str, think_override: int = None) -> tuple[str, bool]:
     requested_model = model
     think_mode = think_override
@@ -265,15 +256,7 @@ def _resolve_model(model: str, think_override: int = None) -> tuple[str, bool]:
     if think_mode is not None:
         if not isinstance(think_mode, int) or not 0 <= think_mode <= 4:
             raise ValueError("Thinking mode must be an integer between 0 and 4")
-    model = MODEL_ALIASES.get(model, model)
-    if model not in models:
-        fallback = _fallback_model(requested_model)
-        debug.log(
-            f"Unknown Gemini model: {model!r}. "
-            f"Falling back to {fallback!r}. "
-            f"Known models: {', '.join(models)}"
-        )
-        model = fallback
+
     if think_mode is None:
         expanded_thinking = (
             requested_model in EXPANDED_MODEL_ALIASES
@@ -281,6 +264,16 @@ def _resolve_model(model: str, think_override: int = None) -> tuple[str, bool]:
         )
     else:
         expanded_thinking = think_mode <= 2
+
+    # Check explicit model aliases (e.g. gemini-auto -> gemini-3.6-flash)
+    if model in MODEL_ALIASES:
+        model = MODEL_ALIASES[model]
+    elif expanded_thinking and "thinking" in model.lower():
+        cleaned = re.sub(r"-thinking(-with-apps)?", "", model, flags=re.IGNORECASE)
+        cleaned = re.sub(r"-lite-thinking", "-lite", cleaned, flags=re.IGNORECASE)
+        cleaned = re.sub(r"-thinking-lite", "-lite", cleaned, flags=re.IGNORECASE)
+        model = MODEL_ALIASES.get(cleaned, cleaned)
+
     return model, expanded_thinking
 
 
@@ -481,10 +474,34 @@ class Gemini(AsyncGeneratorProvider, ProviderModelMixin):
         cls._account_models_fetched_at = time.time()
 
     @classmethod
+    def get_model_mode(cls, model: str) -> int:
+        if model in cls._account_models:
+            return cls._account_models[model]["mode"]
+        if model in models:
+            return models[model]["mode"]
+        name = model.lower()
+        if "pro" in name:
+            return 3
+        if "lite" in name:
+            return 6
+        return 1
+
+    @classmethod
+    def get_model_family(cls, model: str) -> str:
+        if model in cls._account_models:
+            return cls._account_models[model].get("family", "flash")
+        if model in MODEL_FAMILIES:
+            return MODEL_FAMILIES[model]
+        name = model.lower()
+        if "pro" in name:
+            return "pro"
+        return "flash"
+
+    @classmethod
     def get_model_headers(cls, model: str) -> dict[str, str]:
         if model in cls._account_models:
             return cls._account_models[model].get("headers", {})
-        family = MODEL_FAMILIES.get(model)
+        family = cls.get_model_family(model)
         # Request field 79 selects the model. Pro additionally needs the
         # account-specific model header or Google silently routes it to Flash.
         if family != "pro":
@@ -505,8 +522,9 @@ class Gemini(AsyncGeneratorProvider, ProviderModelMixin):
         model = MODEL_ALIASES.get(model, model)
         if allow_model_fallback or cls._account_status is None:
             return
+        family = cls.get_model_family(model)
         if cls._account_status == ACCOUNT_STATUS_UNAUTHENTICATED:
-            if model not in ANONYMOUS_MODELS:
+            if model not in ANONYMOUS_MODELS and family == "pro":
                 raise MissingAuthError(
                     f"Gemini session is unauthenticated; model {model!r} would fall back to Flash"
                 )
@@ -515,7 +533,6 @@ class Gemini(AsyncGeneratorProvider, ProviderModelMixin):
             raise ResponseError(
                 f"Gemini account is unavailable (status {cls._account_status})"
             )
-        family = MODEL_FAMILIES.get(model)
         if family != "pro" or not cls._account_models:
             return
         if not any(
@@ -1101,10 +1118,7 @@ class Gemini(AsyncGeneratorProvider, ProviderModelMixin):
         request[59] = request_uuid or str(uuid.uuid4())
         request[61] = []
         request[68] = 2
-        if model in cls._account_models:
-            request[79] = cls._account_models[model]["mode"]
-        else:
-            request[79] = models[model]["mode"]
+        request[79] = cls.get_model_mode(model)
         request[80] = 2 if expanded_thinking else 1
         request[91] = 0
         # Gemini Web marks the first turn with 1 and follow-up turns with 0.

--- a/g4f/Provider/needs_auth/gemini_utils.py
+++ b/g4f/Provider/needs_auth/gemini_utils.py
@@ -19,8 +19,16 @@ MODEL_FAMILIES = {
     "gemini-3.6-flash": "flash",
     "gemini-3.5-flash-lite": "flash",
     "gemini-3.1-pro": "pro",
+    "gemini-3.7-flash": "flash",
+    "gemini-3.8-flash": "flash",
+    "gemini-3.8-pro": "pro",
 }
-ANONYMOUS_MODELS = {"gemini-3.6-flash", "gemini-3.5-flash-lite"}
+ANONYMOUS_MODELS = {
+    "gemini-3.6-flash",
+    "gemini-3.5-flash-lite",
+    "gemini-3.7-flash",
+    "gemini-3.8-flash",
+}
 KNOWN_MODEL_IDS = {
     "fbb127bbb056c959": "flash",
     "5bf011840784117a": "thinking",

--- a/g4f/client/service.py
+++ b/g4f/client/service.py
@@ -91,6 +91,10 @@ def get_model_and_provider(
         if isinstance(model, str):
             if model in ModelUtils.convert:
                 model = ModelUtils.convert[model]
+            else:
+                dynamic_model = ModelUtils.get_model(model)
+                if dynamic_model is not None:
+                    model = dynamic_model
 
         if not model:
             if has_images:
@@ -111,6 +115,9 @@ def get_model_and_provider(
             raise ValueError(f"Unexpected type: {type(model)}")
     if not provider:
         raise ProviderNotFoundError(f"No provider found for model: {model}")
+
+    if isinstance(provider, str):
+        provider = convert_to_provider(provider)
 
     provider_name = (
         provider.__name__ if hasattr(provider, "__name__") else type(provider).__name__

--- a/g4f/models.py
+++ b/g4f/models.py
@@ -386,6 +386,18 @@ gemini_3_6_flash = Model(
     name="gemini-3.6-flash", base_provider="Google", best_provider="Gemini"
 )
 
+gemini_3_7_flash = Model(
+    name="gemini-3.7-flash", base_provider="Google", best_provider="Gemini"
+)
+
+gemini_3_8_flash = Model(
+    name="gemini-3.8-flash", base_provider="Google", best_provider="Gemini"
+)
+
+gemini_3_8_pro = Model(
+    name="gemini-3.8-pro", base_provider="Google", best_provider="Gemini"
+)
+
 gemini_3_5_flash_lite = Model(
     name="gemini-3.5-flash-lite", base_provider="Google", best_provider="Gemini"
 )
@@ -586,7 +598,15 @@ class ModelUtils:
     @classmethod
     def get_model(cls, name: str) -> Optional[Model]:
         """Get model by name or alias"""
-        return ModelRegistry.get(name)
+        model = ModelRegistry.get(name)
+        if model is None and isinstance(name, str) and name.startswith("gemini-"):
+            model = Model(
+                name=name,
+                base_provider="Google",
+                best_provider=IterListProvider(["Gemini", "GeminiPro", "GeminiCLI"]),
+            )
+            cls.refresh()
+        return model
 
     @classmethod
     def register_alias(cls, alias: str, model_name: str):


### PR DESCRIPTION
## Summary

Closes #3518.

In PR #3516 (addressing #3508), `_fallback_model` was introduced to map unknown Gemini models to a known model of the same family (e.g. `gemini-3.8-flash` -> `gemini-3.6-flash`, `gemini-3.8-pro` -> `gemini-3.1-pro`).

However, as reported in #3518, `gemini-3.8-flash` should remain `gemini-3.8-flash` and not be resolved or categorized into `gemini-3.6-flash`. Downstream callers, conversation histories, logs, and API clients expect the exact requested model identity.

In Google Gemini Web's protocol, Google does not receive the model string; it receives integer capability modes (`request[79]`), thinking modes (`request[80]`), and account Pro headers.

## Changes

1. **Exact Model Name Preservation**:
   - Removed `_fallback_model` and removed fallback model mutation from `_resolve_model`.
   - Requested models like `gemini-3.8-flash`, `gemini-3.7-flash`, `gemini-3.8-pro`, or any future Gemini models retain their exact name.
   - Suffixes like `-thinking` properly enable `expanded_thinking = True` while preserving the base model name.

2. **Decoupled Protocol Mode Selection**:
   - Added `Gemini.get_model_mode` to dynamically infer `request[79]` (`1` for Flash, `6` for Flash-Lite, `3` for Pro) without mutating the model string or raising `KeyError`.

3. **Dynamic Family & Access Validation**:
   - Added `Gemini.get_model_family` to recognize `"pro"` vs `"flash"` family for current and future models.
   - Updated `get_model_headers` to attach Pro headers whenever a Pro model is requested.
   - Updated `validate_model_access` so Flash family models (including `gemini-3.8-flash`) are allowed in anonymous sessions without triggering false `MissingAuthError` exceptions.

4. **Model Registry & Dynamic Routing**:
   - Registered `gemini-3.7-flash`, `gemini-3.8-flash`, and `gemini-3.8-pro` in `g4f/models.py`.
   - Added dynamic lookup in `ModelUtils.get_model` and `g4f/client/service.py` to route any future `gemini-*` models automatically.

5. **Tests**:
   - Updated `test_gemini.py` asserting exact model identity preservation, dynamic mode inference, and access validation.
   - All 28 tests in `test_gemini` and all 242 tests in `etc.unittest` pass.
